### PR TITLE
feat: Implement DuckDB Surface API (spec 002)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# test output
+duckdb_unittest_tempdir/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-01-15
 
 ## Active Technologies
+- C++17 (DuckDB extension standard) + DuckDB main branch (extension API) (002-duckdb-surface-api)
+- N/A (connection metadata in memory, secrets via DuckDB's secret manager) (002-duckdb-surface-api)
 
 - C++17 (DuckDB extension standard) + DuckDB (main branch), vcpkg (manifest mode) (001-project-bootstrap)
 
@@ -22,6 +24,7 @@ tests/
 C++17 (DuckDB extension standard): Follow standard conventions
 
 ## Recent Changes
+- 002-duckdb-surface-api: Added C++17 (DuckDB extension standard) + DuckDB main branch (extension API)
 
 - 001-project-bootstrap: Added C++17 (DuckDB extension standard) + DuckDB (main branch), vcpkg (manifest mode)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ message(STATUS "Building MSSQL extension against DuckDB commit: ${DUCKDB_COMMIT_
 # Set extension sources
 set(EXTENSION_SOURCES
     src/mssql_extension.cpp
+    src/mssql_secret.cpp
+    src/mssql_storage.cpp
+    src/mssql_functions.cpp
 )
 
 # Build static extension (linked into DuckDB)

--- a/specs/002-duckdb-surface-api/checklists/requirements.md
+++ b/specs/002-duckdb-surface-api/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: DuckDB Surface API
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- The user description was comprehensive, so no clarification markers were needed
+- Assumptions documented cover DuckDB extension API availability

--- a/specs/002-duckdb-surface-api/contracts/cpp-api.md
+++ b/specs/002-duckdb-surface-api/contracts/cpp-api.md
@@ -1,0 +1,419 @@
+# C++ API Contract: MSSQL Extension
+
+**Feature**: 002-duckdb-surface-api
+**Date**: 2026-01-15
+
+This document defines the internal C++ API for the MSSQL extension components.
+
+---
+
+## 1. Header Files
+
+### mssql_secret.hpp
+
+```cpp
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/secret/secret.hpp"
+
+namespace duckdb {
+
+// Secret field names (constants)
+constexpr const char *MSSQL_SECRET_HOST = "host";
+constexpr const char *MSSQL_SECRET_PORT = "port";
+constexpr const char *MSSQL_SECRET_DATABASE = "database";
+constexpr const char *MSSQL_SECRET_USER = "user";
+constexpr const char *MSSQL_SECRET_PASSWORD = "password";
+
+// Register MSSQL secret type and creation function
+void RegisterMSSQLSecretType(ExtensionLoader &loader);
+
+// Create secret from user-provided parameters
+// Throws: InvalidInputException on validation failure
+unique_ptr<BaseSecret> CreateMSSQLSecretFromConfig(
+    ClientContext &context,
+    CreateSecretInput &input
+);
+
+// Validate secret fields
+// Returns: empty string if valid, error message if invalid
+string ValidateMSSQLSecretFields(const CreateSecretInput &input);
+
+}  // namespace duckdb
+```
+
+### mssql_storage.hpp
+
+```cpp
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/storage/storage_extension.hpp"
+
+namespace duckdb {
+
+// Connection information extracted from secret
+struct MSSQLConnectionInfo {
+    string host;
+    uint16_t port;
+    string database;
+    string user;
+    string password;
+    bool connected = false;
+
+    // Create from secret
+    static shared_ptr<MSSQLConnectionInfo> FromSecret(
+        ClientContext &context,
+        const string &secret_name
+    );
+};
+
+// Attached context state
+struct MSSQLContext {
+    string name;
+    string secret_name;
+    shared_ptr<MSSQLConnectionInfo> connection_info;
+    optional_ptr<AttachedDatabase> attached_db;
+
+    MSSQLContext(const string &name, const string &secret_name);
+};
+
+// Global context manager (singleton per DatabaseInstance)
+class MSSQLContextManager {
+public:
+    // Get singleton instance
+    static MSSQLContextManager &Get(DatabaseInstance &db);
+
+    // Context operations
+    void RegisterContext(const string &name, shared_ptr<MSSQLContext> ctx);
+    void UnregisterContext(const string &name);
+    shared_ptr<MSSQLContext> GetContext(const string &name);
+    bool HasContext(const string &name);
+    vector<string> ListContexts();
+
+private:
+    mutex lock;
+    unordered_map<string, shared_ptr<MSSQLContext>> contexts;
+};
+
+// Storage extension info (shared state)
+struct MSSQLStorageExtensionInfo : public StorageExtensionInfo {
+    // Reserved for future connection pooling, etc.
+};
+
+// Register storage extension for ATTACH TYPE mssql
+void RegisterMSSQLStorageExtension(ExtensionLoader &loader);
+
+// Attach callback
+unique_ptr<Catalog> MSSQLAttach(
+    optional_ptr<StorageExtensionInfo> storage_info,
+    ClientContext &context,
+    AttachedDatabase &db,
+    const string &name,
+    AttachInfo &info,
+    AttachOptions &options
+);
+
+// Transaction manager factory
+unique_ptr<TransactionManager> MSSQLCreateTransactionManager(
+    optional_ptr<StorageExtensionInfo> storage_info,
+    AttachedDatabase &db,
+    Catalog &catalog
+);
+
+}  // namespace duckdb
+```
+
+### mssql_functions.hpp
+
+```cpp
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+// ============================================
+// mssql_execute
+// ============================================
+
+struct MSSQLExecuteBindData : public FunctionData {
+    string context_name;
+    string sql_statement;
+
+    unique_ptr<FunctionData> Copy() const override;
+    bool Equals(const FunctionData &other) const override;
+};
+
+// Bind: validates arguments, sets return schema
+unique_ptr<FunctionData> MSSQLExecuteBind(
+    ClientContext &context,
+    TableFunctionBindInput &input,
+    vector<LogicalType> &return_types,
+    vector<string> &names
+);
+
+// Execute: produces single-row result
+void MSSQLExecuteFunction(
+    ClientContext &context,
+    TableFunctionInput &data,
+    DataChunk &output
+);
+
+// ============================================
+// mssql_scan
+// ============================================
+
+struct MSSQLScanBindData : public FunctionData {
+    string context_name;
+    string query;
+    vector<LogicalType> return_types;
+    vector<string> column_names;
+
+    unique_ptr<FunctionData> Copy() const override;
+    bool Equals(const FunctionData &other) const override;
+};
+
+struct MSSQLScanGlobalState : public GlobalTableFunctionState {
+    string context_name;
+    string query;
+    idx_t total_rows;
+    atomic<idx_t> rows_returned;
+
+    idx_t MaxThreads() const override;
+};
+
+struct MSSQLScanLocalState : public LocalTableFunctionState {
+    idx_t current_row = 0;
+};
+
+// Bind: validates arguments, determines return schema
+unique_ptr<FunctionData> MSSQLScanBind(
+    ClientContext &context,
+    TableFunctionBindInput &input,
+    vector<LogicalType> &return_types,
+    vector<string> &names
+);
+
+// Global init: sets up execution state
+unique_ptr<GlobalTableFunctionState> MSSQLScanInitGlobal(
+    ClientContext &context,
+    TableFunctionInitInput &input
+);
+
+// Local init: per-thread state
+unique_ptr<LocalTableFunctionState> MSSQLScanInitLocal(
+    ExecutionContext &context,
+    TableFunctionInitInput &input,
+    GlobalTableFunctionState *global_state
+);
+
+// Execute: produces output rows
+void MSSQLScanFunction(
+    ClientContext &context,
+    TableFunctionInput &data,
+    DataChunk &output
+);
+
+// ============================================
+// Registration
+// ============================================
+
+// Register all MSSQL table functions
+void RegisterMSSQLFunctions(ExtensionLoader &loader);
+
+}  // namespace duckdb
+```
+
+---
+
+## 2. Function Signatures
+
+### Secret Functions
+
+```cpp
+// Register secret type with DuckDB
+void RegisterMSSQLSecretType(ExtensionLoader &loader);
+
+// Signature: create_secret_function_t
+unique_ptr<BaseSecret> CreateMSSQLSecretFromConfig(
+    ClientContext &context,
+    CreateSecretInput &input
+);
+
+// Validation helper
+// Returns: Empty string if valid, error message otherwise
+string ValidateMSSQLSecretFields(const CreateSecretInput &input);
+```
+
+### Storage Extension Functions
+
+```cpp
+// Signature: attach_function_t
+unique_ptr<Catalog> MSSQLAttach(
+    optional_ptr<StorageExtensionInfo> storage_info,
+    ClientContext &context,
+    AttachedDatabase &db,
+    const string &name,
+    AttachInfo &info,
+    AttachOptions &options
+);
+
+// Signature: create_transaction_manager_t
+unique_ptr<TransactionManager> MSSQLCreateTransactionManager(
+    optional_ptr<StorageExtensionInfo> storage_info,
+    AttachedDatabase &db,
+    Catalog &catalog
+);
+```
+
+### Table Function Callbacks
+
+```cpp
+// mssql_execute
+// Signature: table_function_bind_t
+unique_ptr<FunctionData> MSSQLExecuteBind(...);
+// Signature: table_function_t
+void MSSQLExecuteFunction(...);
+
+// mssql_scan
+// Signature: table_function_bind_t
+unique_ptr<FunctionData> MSSQLScanBind(...);
+// Signature: table_function_init_global_t
+unique_ptr<GlobalTableFunctionState> MSSQLScanInitGlobal(...);
+// Signature: table_function_init_local_t
+unique_ptr<LocalTableFunctionState> MSSQLScanInitLocal(...);
+// Signature: table_function_t
+void MSSQLScanFunction(...);
+```
+
+---
+
+## 3. Error Handling
+
+### Exception Types
+
+| Scenario | Exception | Example |
+|----------|-----------|---------|
+| Invalid user input | `InvalidInputException` | Missing required field |
+| Binding failure | `BinderException` | Secret not found |
+| Internal error | `InternalException` | Unexpected null pointer |
+| Catalog error | `CatalogException` | Duplicate context name |
+
+### Error Message Format
+
+```cpp
+// Standard format
+throw InvalidInputException(
+    "MSSQL Error: %s. %s",
+    what_happened,
+    suggestion_to_fix
+);
+
+// Examples
+throw InvalidInputException(
+    "MSSQL Error: Missing required field 'host'. "
+    "Provide host parameter when creating secret."
+);
+
+throw InvalidInputException(
+    "MSSQL Error: Unknown context '%s'. "
+    "Attach a database first with: ATTACH '' AS %s TYPE mssql (SECRET ...)",
+    context_name, context_name
+);
+```
+
+---
+
+## 4. Memory Management
+
+### Ownership Rules
+
+| Type | Ownership | Lifetime |
+|------|-----------|----------|
+| MSSQLConnectionInfo | shared_ptr | Context lifetime |
+| MSSQLContext | shared_ptr | Attach to detach |
+| FunctionData subclasses | unique_ptr | Query execution |
+| GlobalTableFunctionState | unique_ptr | Query execution |
+| LocalTableFunctionState | unique_ptr | Query execution (per thread) |
+
+### Creation Patterns
+
+```cpp
+// Use make_uniq for unique ownership
+auto bind_data = make_uniq<MSSQLScanBindData>();
+
+// Use make_shared_ptr for shared ownership
+auto conn_info = make_shared_ptr<MSSQLConnectionInfo>();
+
+// Use optional_ptr for non-owning references
+optional_ptr<AttachedDatabase> db;
+```
+
+---
+
+## 5. Thread Safety
+
+### Context Manager
+
+All `MSSQLContextManager` operations are protected by internal mutex:
+
+```cpp
+void MSSQLContextManager::RegisterContext(
+    const string &name,
+    shared_ptr<MSSQLContext> ctx
+) {
+    lock_guard<mutex> guard(lock);
+    contexts[name] = std::move(ctx);
+}
+```
+
+### Table Function State
+
+- `GlobalTableFunctionState`: Shared across threads, use atomics for counters
+- `LocalTableFunctionState`: Thread-local, no synchronization needed
+- `FunctionData`: Immutable after bind, no synchronization needed
+
+---
+
+## 6. Extension Entry Point
+
+```cpp
+// mssql_extension.cpp
+
+#include "mssql_extension.hpp"
+#include "mssql_secret.hpp"
+#include "mssql_storage.hpp"
+#include "mssql_functions.hpp"
+
+namespace duckdb {
+
+static void LoadInternal(ExtensionLoader &loader) {
+    // 1. Register secrets
+    RegisterMSSQLSecretType(loader);
+
+    // 2. Register storage extension (ATTACH TYPE mssql)
+    RegisterMSSQLStorageExtension(loader);
+
+    // 3. Register table functions
+    RegisterMSSQLFunctions(loader);
+
+    // 4. Register utility functions (mssql_version)
+    auto mssql_version_func = ScalarFunction(
+        "mssql_version", {},
+        LogicalType::VARCHAR,
+        MssqlVersionFunction
+    );
+    loader.RegisterFunction(mssql_version_func);
+}
+
+}  // namespace duckdb
+
+extern "C" {
+DUCKDB_CPP_EXTENSION_ENTRY(mssql, loader) {
+    duckdb::LoadInternal(loader);
+}
+}
+```

--- a/specs/002-duckdb-surface-api/contracts/sql-interface.md
+++ b/specs/002-duckdb-surface-api/contracts/sql-interface.md
@@ -1,0 +1,384 @@
+# SQL Interface Contract: MSSQL Extension
+
+**Feature**: 002-duckdb-surface-api
+**Date**: 2026-01-15
+
+This document defines the SQL-level interface for the MSSQL extension.
+
+---
+
+## 1. Secret Management
+
+### CREATE SECRET
+
+Creates a new MSSQL secret with connection credentials.
+
+```sql
+CREATE SECRET <name> (
+    TYPE mssql,
+    host '<hostname>',
+    port <port_number>,
+    database '<database_name>',
+    user '<username>',
+    password '<password>',
+    use_ssl <boolean>  -- Optional
+);
+```
+
+**Parameters**:
+
+| Parameter | Type | Required | Constraints | Description |
+|-----------|------|----------|-------------|-------------|
+| name | identifier | Yes | Unique | Secret name for reference |
+| host | VARCHAR | Yes | Non-empty | SQL Server hostname or IP address |
+| port | INTEGER | Yes | 1-65535 | TCP port number (default: 1433) |
+| database | VARCHAR | Yes | Non-empty | Target database name |
+| user | VARCHAR | Yes | Non-empty | SQL Server username |
+| password | VARCHAR | Yes | - | SQL Server password |
+| use_ssl | BOOLEAN | No | true/false | Enable SSL/TLS encryption (default: false) |
+
+**Examples**:
+
+```sql
+-- Basic secret creation
+CREATE SECRET my_sqlserver (
+    TYPE mssql,
+    host 'db.example.com',
+    port 1433,
+    database 'production',
+    user 'app_user',
+    password 'secure_password'
+);
+
+-- Using non-standard port
+CREATE SECRET dev_server (
+    TYPE mssql,
+    host 'localhost',
+    port 14330,
+    database 'dev_db',
+    user 'sa',
+    password 'DevPassword123!'
+);
+
+-- With SSL enabled
+CREATE SECRET secure_server (
+    TYPE mssql,
+    host 'secure.example.com',
+    port 1433,
+    database 'secure_db',
+    user 'admin',
+    password 'SecurePass!',
+    use_ssl true
+);
+```
+
+**Error Conditions**:
+
+| Condition | Error Message |
+|-----------|---------------|
+| Missing host | `MSSQL Error: Missing required field 'host'. Provide host parameter when creating secret.` |
+| Missing port | `MSSQL Error: Missing required field 'port'. Provide port parameter when creating secret.` |
+| Missing database | `MSSQL Error: Missing required field 'database'. Provide database parameter when creating secret.` |
+| Missing user | `MSSQL Error: Missing required field 'user'. Provide user parameter when creating secret.` |
+| Missing password | `MSSQL Error: Missing required field 'password'. Provide password parameter when creating secret.` |
+| Invalid port | `MSSQL Error: Port must be between 1 and 65535. Got: <value>` |
+| Empty host | `MSSQL Error: Field 'host' cannot be empty.` |
+| Duplicate name | `Secret with name '<name>' already exists` |
+
+### DROP SECRET
+
+Removes an existing secret.
+
+```sql
+DROP SECRET <name>;
+```
+
+**Notes**: Standard DuckDB secret management. No MSSQL-specific behavior.
+
+### Query Secrets
+
+View registered secrets (passwords redacted).
+
+```sql
+SELECT * FROM duckdb_secrets() WHERE type = 'mssql';
+```
+
+**Output Columns**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| name | VARCHAR | Secret name |
+| type | VARCHAR | Always 'mssql' |
+| provider | VARCHAR | Always 'config' |
+| scope | VARCHAR[] | Empty for MSSQL secrets |
+| secret_string | VARCHAR | Redacted output (password hidden) |
+
+---
+
+## 2. Database Attachment
+
+### ATTACH
+
+Attaches a SQL Server database as a named context. Two methods are supported:
+
+#### Method 1: Using a Secret
+
+```sql
+ATTACH '' AS <context_name> (TYPE mssql, SECRET <secret_name>);
+```
+
+#### Method 2: Using a Connection String
+
+```sql
+ATTACH '<connection_string>' AS <context_name> (TYPE mssql);
+```
+
+**Connection String Format**:
+```
+Server=<host>[,<port>];Database=<database>;User Id=<user>;Password=<password>[;Encrypt=yes/no]
+```
+
+**Connection String Keys** (case-insensitive):
+
+| Key | Aliases | Description |
+|-----|---------|-------------|
+| Server | Data Source | Hostname, optionally with port (e.g., `host,1433`) |
+| Database | Initial Catalog | Target database name |
+| User Id | UID, User | SQL Server username |
+| Password | PWD | SQL Server password |
+| Encrypt | Use Encryption for Data | Enable SSL (yes/no, default: no) |
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| context_name | identifier | Yes | Name for the attached database |
+| secret_name | identifier | Conditional | Reference to existing MSSQL secret (if not using connection string) |
+| connection_string | VARCHAR | Conditional | Connection string (if not using secret) |
+
+**Notes**:
+- Either SECRET or connection string must be provided, not both
+- When using SECRET, the path (first parameter) must be empty string `''`
+- Connection is established lazily (on first data access)
+- Context name must be unique among all attached databases
+- Default port is 1433 if not specified in connection string
+
+**Examples**:
+
+```sql
+-- Attach using a secret
+ATTACH '' AS sqlserver (TYPE mssql, SECRET my_sqlserver);
+
+-- Attach with different context name
+ATTACH '' AS production_db (TYPE mssql, SECRET prod_secret);
+
+-- Attach using connection string
+ATTACH 'Server=localhost,1433;Database=mydb;User Id=sa;Password=pass' AS conn_db (TYPE mssql);
+
+-- Connection string with default port
+ATTACH 'Server=db.example.com;Database=prod;User Id=admin;Password=secret' AS prod_db (TYPE mssql);
+
+-- Connection string with SSL enabled
+ATTACH 'Server=secure.example.com;Database=db;User Id=user;Password=pass;Encrypt=yes' AS secure_db (TYPE mssql);
+
+-- Connection string with alternative key names
+ATTACH 'Data Source=localhost;Initial Catalog=testdb;UID=testuser;PWD=testpass' AS alt_db (TYPE mssql);
+```
+
+**Error Conditions**:
+
+| Condition | Error Message |
+|-----------|---------------|
+| Neither secret nor connection string | `MSSQL Error: Either SECRET or connection string is required for ATTACH.` |
+| Secret not found | `Secret '<name>' not found` |
+| Invalid secret type | `Secret '<name>' is not of type 'mssql'` |
+| Duplicate context | `Database '<name>' already exists` |
+| Missing Server in connection string | `MSSQL Error: Missing 'Server' in connection string.` |
+| Missing Database in connection string | `MSSQL Error: Missing 'Database' in connection string.` |
+| Missing User Id in connection string | `MSSQL Error: Missing 'User Id' in connection string.` |
+| Missing Password in connection string | `MSSQL Error: Missing 'Password' in connection string.` |
+| Invalid port in connection string | `MSSQL Error: Port must be between 1 and 65535. Got: <value>` |
+
+### DETACH
+
+Removes an attached SQL Server database.
+
+```sql
+DETACH <context_name>;
+```
+
+**Behavior**:
+- Immediately aborts any in-progress queries on the context
+- Closes any open network connections
+- Removes the context from the registry
+- Cleans up all associated metadata
+
+**Examples**:
+
+```sql
+-- Detach a database
+DETACH sqlserver;
+```
+
+**Error Conditions**:
+
+| Condition | Error Message |
+|-----------|---------------|
+| Context not found | `Database '<name>' not found` |
+
+---
+
+## 3. Table Functions
+
+### mssql_execute
+
+Executes a raw SQL statement against SQL Server.
+
+```sql
+SELECT * FROM mssql_execute('<context_name>', '<sql_statement>');
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| context_name | VARCHAR | Name of attached MSSQL database |
+| sql_statement | VARCHAR | SQL statement to execute |
+
+**Return Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| success | BOOLEAN | `true` if execution succeeded |
+| affected_rows | BIGINT | Number of rows affected, or -1 if not applicable |
+| message | VARCHAR | Status message or error description |
+
+**Examples**:
+
+```sql
+-- Execute an UPDATE statement
+SELECT * FROM mssql_execute('sqlserver', 'UPDATE users SET active = 1 WHERE id = 5');
+
+-- Execute a DDL statement
+SELECT * FROM mssql_execute('sqlserver', 'CREATE INDEX idx_name ON users(name)');
+
+-- Check result
+SELECT success, affected_rows, message
+FROM mssql_execute('sqlserver', 'DELETE FROM logs WHERE created_at < ''2024-01-01''');
+```
+
+**Return Values**:
+
+| Scenario | success | affected_rows | message |
+|----------|---------|---------------|---------|
+| Successful DML | true | N (rows affected) | "Query executed successfully" |
+| Successful DDL | true | -1 | "Query executed successfully" |
+| SQL Error | false | -1 | Error message from SQL Server |
+| Stub mode | true | 1 | "Query executed successfully (stub)" |
+
+**Error Conditions**:
+
+| Condition | Error Message |
+|-----------|---------------|
+| Context not found | `MSSQL Error: Unknown context '<name>'. Attach a database first with: ATTACH '' AS <name> TYPE mssql (SECRET ...)` |
+
+### mssql_scan
+
+Executes a SELECT query and returns results as a relation.
+
+```sql
+SELECT * FROM mssql_scan('<context_name>', '<select_query>');
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| context_name | VARCHAR | Name of attached MSSQL database |
+| select_query | VARCHAR | SELECT statement to execute |
+
+**Return Schema** (stub implementation):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Sample row identifier |
+| name | VARCHAR | Sample name value |
+
+**Notes**:
+- In stub mode, returns 3 hardcoded sample rows regardless of query
+- Future implementation will return actual query results with dynamic schema
+
+**Examples**:
+
+```sql
+-- Basic scan
+SELECT * FROM mssql_scan('sqlserver', 'SELECT id, name FROM users');
+
+-- With filtering (applied after scan in stub mode)
+SELECT * FROM mssql_scan('sqlserver', 'SELECT * FROM products')
+WHERE id > 1;
+
+-- Join with local data
+SELECT s.id, s.name, l.extra
+FROM mssql_scan('sqlserver', 'SELECT id, name FROM users') s
+JOIN local_table l ON s.id = l.user_id;
+```
+
+**Stub Return Data**:
+
+| id | name |
+|----|------|
+| 1 | Name 1 |
+| 2 | Name 2 |
+| 3 | Name 3 |
+
+**Error Conditions**:
+
+| Condition | Error Message |
+|-----------|---------------|
+| Context not found | `MSSQL Error: Unknown context '<name>'. Attach a database first with: ATTACH '' AS <name> TYPE mssql (SECRET ...)` |
+
+---
+
+## 4. Information Functions
+
+### mssql_version
+
+Returns the extension version string.
+
+```sql
+SELECT mssql_version();
+```
+
+**Return Type**: VARCHAR
+
+**Example Output**: `"a1b2c3d"` (DuckDB commit hash)
+
+---
+
+## 5. Complete Usage Example
+
+```sql
+-- 1. Create a secret with connection credentials
+CREATE SECRET prod_db (
+    TYPE mssql,
+    host 'sql.example.com',
+    port 1433,
+    database 'production',
+    user 'readonly_user',
+    password 'SecurePass123!'
+);
+
+-- 2. Attach the database
+ATTACH '' AS prod TYPE mssql (SECRET prod_db);
+
+-- 3. Query data (stub returns sample data)
+SELECT * FROM mssql_scan('prod', 'SELECT id, name FROM customers');
+
+-- 4. Execute a statement (stub returns success)
+SELECT * FROM mssql_execute('prod', 'UPDATE metrics SET last_access = GETDATE()');
+
+-- 5. Clean up
+DETACH prod;
+DROP SECRET prod_db;
+```

--- a/specs/002-duckdb-surface-api/data-model.md
+++ b/specs/002-duckdb-surface-api/data-model.md
@@ -1,0 +1,221 @@
+# Data Model: DuckDB Surface API
+
+**Feature**: 002-duckdb-surface-api
+**Date**: 2026-01-15
+
+## Overview
+
+This document defines the internal data structures for the MSSQL extension's public interface. These are C++ classes and structures, not database tables.
+
+---
+
+## Entities
+
+### 1. MSSQLSecret (via KeyValueSecret)
+
+Stores SQL Server connection credentials using DuckDB's built-in secret storage.
+
+**Storage**: DuckDB SecretManager (KeyValueSecret)
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| host | VARCHAR | Required, non-empty | SQL Server hostname or IP |
+| port | INTEGER | Required, 1-65535 | TCP port number |
+| database | VARCHAR | Required, non-empty | Target database name |
+| user | VARCHAR | Required, non-empty | Authentication username |
+| password | VARCHAR | Required, redacted | Authentication password |
+
+**Lifecycle**:
+- Created via `CREATE SECRET name (TYPE mssql, ...)`
+- Immutable after creation (DuckDB enforced)
+- Deleted via `DROP SECRET name`
+- Password redacted in `duckdb_secrets()` output
+
+**Validation Rules**:
+- All fields must be provided at creation time
+- Port must be valid TCP port (1-65535)
+- No field may be empty string
+- Name must be unique across all secrets
+
+---
+
+### 2. MSSQLConnectionInfo
+
+Internal representation of connection parameters extracted from a secret.
+
+**Storage**: In-memory (MSSQLContextManager)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| host | string | Resolved from secret |
+| port | uint16_t | Resolved from secret |
+| database | string | Resolved from secret |
+| user | string | Resolved from secret |
+| password | string | Resolved from secret (sensitive) |
+| connected | bool | Whether network connection is established |
+
+**Lifecycle**:
+- Created during ATTACH (extracted from referenced secret)
+- Updated when lazy connection is established
+- Destroyed during DETACH
+
+**Notes**:
+- Password stored in memory per constitution (delegated to DuckDB)
+- `connected` flag tracks lazy initialization state
+
+---
+
+### 3. MSSQLContext
+
+Represents an attached MSSQL database context.
+
+**Storage**: MSSQLContextManager (keyed by context name)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Context name (from ATTACH ... AS name) |
+| secret_name | string | Name of associated secret |
+| connection_info | shared_ptr<MSSQLConnectionInfo> | Resolved connection parameters |
+| attached_db | optional_ptr<AttachedDatabase> | Reference to DuckDB attached database |
+
+**Lifecycle**:
+- Created during `ATTACH '' AS {name} TYPE mssql (SECRET {secret})`
+- Registered in MSSQLContextManager
+- Unregistered and destroyed during `DETACH {name}`
+
+**State Transitions**:
+```
+[Created] --> [Attached] --> [Connected] --> [Detached]
+                  |                              ^
+                  +------------------------------+
+                  (detach before any query)
+```
+
+---
+
+### 4. ExecuteResult
+
+Return value structure for `mssql_execute` function.
+
+**Storage**: Transient (query result)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| success | bool | Whether execution succeeded |
+| affected_rows | int64_t | Number of rows affected (or -1 if N/A) |
+| message | string | Status message or error description |
+
+**Usage**:
+- Single row returned per `mssql_execute` call
+- `success=false` includes error message from SQL Server
+- `affected_rows=-1` for statements without row count (e.g., DDL)
+
+---
+
+### 5. ScanBindData
+
+Bind-time data for `mssql_scan` table function.
+
+**Storage**: FunctionData (query execution lifetime)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| context_name | string | Target MSSQL context |
+| query | string | SQL query to execute |
+| return_types | vector<LogicalType> | Output column types |
+| column_names | vector<string> | Output column names |
+
+**Lifecycle**:
+- Created during query binding
+- Immutable during execution
+- Destroyed after query completes
+
+---
+
+### 6. ScanGlobalState
+
+Global execution state for `mssql_scan` (shared across threads).
+
+**Storage**: GlobalTableFunctionState (query execution lifetime)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| context_name | string | Target context (copied from bind) |
+| query | string | SQL query (copied from bind) |
+| total_rows | idx_t | Total rows to return (stub: 3) |
+| rows_returned | atomic<idx_t> | Rows already returned |
+
+**Thread Safety**: `rows_returned` is atomic for potential future parallel execution.
+
+---
+
+### 7. ScanLocalState
+
+Per-thread execution state for `mssql_scan`.
+
+**Storage**: LocalTableFunctionState (query execution lifetime)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| current_row | idx_t | Next row index to produce |
+
+**Notes**: For stub implementation, single-threaded execution only.
+
+---
+
+## Relationships
+
+```
+┌─────────────────┐     references     ┌──────────────────┐
+│  MSSQLContext   │───────────────────▶│   MSSQLSecret    │
+│                 │                    │  (KeyValueSecret) │
+└────────┬────────┘                    └──────────────────┘
+         │
+         │ contains
+         ▼
+┌─────────────────────┐
+│ MSSQLConnectionInfo │
+└─────────────────────┘
+
+┌─────────────────┐     lookup     ┌─────────────────┐
+│  mssql_scan     │───────────────▶│  MSSQLContext   │
+│  mssql_execute  │                │                 │
+└─────────────────┘                └─────────────────┘
+```
+
+---
+
+## Context Manager
+
+Central registry for attached MSSQL databases.
+
+```cpp
+class MSSQLContextManager {
+    // Singleton per DatabaseInstance
+    static MSSQLContextManager& Get(DatabaseInstance &db);
+
+    // Context operations
+    void RegisterContext(const string &name, shared_ptr<MSSQLContext> ctx);
+    void UnregisterContext(const string &name);
+    shared_ptr<MSSQLContext> GetContext(const string &name);
+    bool HasContext(const string &name);
+    vector<string> ListContexts();
+
+private:
+    mutex lock;
+    unordered_map<string, shared_ptr<MSSQLContext>> contexts;
+};
+```
+
+**Thread Safety**: All operations protected by mutex.
+
+---
+
+## Validation Summary
+
+| Entity | Validation Point | Rules |
+|--------|------------------|-------|
+| MSSQLSecret | Creation | All fields required, port 1-65535, no empty strings |
+| MSSQLContext | Attach | Secret must exist, name must be unique |
+| mssql_execute | Bind | Context must exist |
+| mssql_scan | Bind | Context must exist |

--- a/specs/002-duckdb-surface-api/plan.md
+++ b/specs/002-duckdb-surface-api/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: DuckDB Surface API
+
+**Branch**: `002-duckdb-surface-api` | **Date**: 2026-01-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-duckdb-surface-api/spec.md`
+
+## Summary
+
+Define and implement the public DuckDB interface for the MSSQL extension including:
+- SECRET TYPE `mssql` with host, port, database, user, password fields
+- ATTACH/DETACH handlers for connection context management
+- `mssql_execute` and `mssql_scan` table functions
+
+This phase creates stub implementations (no real network traffic) to stabilize the API surface before protocol implementation.
+
+## Technical Context
+
+**Language/Version**: C++17 (DuckDB extension standard)
+**Primary Dependencies**: DuckDB main branch (extension API)
+**Storage**: N/A (connection metadata in memory, secrets via DuckDB's secret manager)
+**Testing**: DuckDB SQL test framework (`.test` files in `test/sql/`)
+**Target Platform**: Linux (x64, arm64), macOS (arm64), Windows (x64)
+**Project Type**: Single (DuckDB extension)
+**Performance Goals**: N/A for stub phase
+**Constraints**: No external dependencies (native TDS per constitution)
+**Scale/Scope**: API surface definition only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Native and Open | PASS | No external dependencies; stub implementation |
+| II. Streaming First | N/A | No data streaming in this phase (stubs only) |
+| III. Correctness over Convenience | PASS | Explicit errors for invalid input |
+| IV. Explicit State Machines | DEFERRED | Connection state machine designed but not implemented |
+| V. DuckDB-Native UX | PASS | Uses standard DuckDB patterns (secrets, attach, table functions) |
+| VI. Incremental Delivery | PASS | Read-first approach; stub before real implementation |
+
+**Pre-Design Gate Status**: PASS
+
+### Post-Design Check (Phase 1 Complete)
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Native and Open | PASS | Only DuckDB APIs used; KeyValueSecret, StorageExtension, TableFunction |
+| II. Streaming First | PASS | mssql_scan uses TableFunction with chunked output pattern |
+| III. Correctness over Convenience | PASS | All validation errors explicit with actionable messages |
+| IV. Explicit State Machines | PASS | MSSQLContext tracks state (Created→Attached→Connected→Detached) |
+| V. DuckDB-Native UX | PASS | Standard CREATE SECRET, ATTACH, DETACH, table function syntax |
+| VI. Incremental Delivery | PASS | Stub phase delivers testable API before protocol implementation |
+
+**Post-Design Gate Status**: PASS - Design fully compliant with constitution.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-duckdb-surface-api/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (API specifications)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── include/
+│   ├── mssql_extension.hpp      # Extension class declaration
+│   ├── mssql_secret.hpp         # Secret type registration (NEW)
+│   ├── mssql_storage.hpp        # Storage extension / attach handler (NEW)
+│   └── mssql_functions.hpp      # Table functions (NEW)
+├── mssql_extension.cpp          # Extension entry point (MODIFY)
+├── mssql_secret.cpp             # Secret implementation (NEW)
+├── mssql_storage.cpp            # Attach/detach implementation (NEW)
+└── mssql_functions.cpp          # mssql_scan, mssql_execute (NEW)
+
+test/sql/
+├── mssql_version.test           # Existing
+├── mssql_secret.test            # Secret creation/validation (NEW)
+├── mssql_attach.test            # Attach/detach tests (NEW)
+├── mssql_execute.test           # mssql_execute tests (NEW)
+└── mssql_scan.test              # mssql_scan tests (NEW)
+```
+
+**Structure Decision**: Single project structure. Extension code in `src/`, tests in `test/sql/`. New files follow existing patterns from `mssql_extension.cpp`.
+
+## Complexity Tracking
+
+> No violations requiring justification.

--- a/specs/002-duckdb-surface-api/quickstart.md
+++ b/specs/002-duckdb-surface-api/quickstart.md
@@ -1,0 +1,232 @@
+# Quickstart: DuckDB Surface API Implementation
+
+**Feature**: 002-duckdb-surface-api
+**Date**: 2026-01-15
+
+This guide provides step-by-step instructions for implementing the MSSQL extension's public interface.
+
+---
+
+## Prerequisites
+
+- DuckDB source (main branch) cloned as submodule
+- C++17 compiler (GCC 11+, Clang 14+, MSVC 2019+)
+- CMake 3.21+
+- Existing extension skeleton from `001-project-bootstrap`
+
+---
+
+## Implementation Order
+
+### Phase 1: Secret Type (FR-001 to FR-006)
+
+**Goal**: Enable `CREATE SECRET ... TYPE mssql`
+
+1. Create `src/include/mssql_secret.hpp`
+2. Create `src/mssql_secret.cpp`
+3. Add to CMakeLists.txt
+4. Create `test/sql/mssql_secret.test`
+
+**Verification**:
+```sql
+CREATE SECRET test_secret (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'test',
+    user 'sa',
+    password 'test'
+);
+
+SELECT * FROM duckdb_secrets() WHERE type = 'mssql';
+-- Should show secret with password redacted
+```
+
+### Phase 2: Storage Extension (FR-007 to FR-012a)
+
+**Goal**: Enable `ATTACH ... TYPE mssql` and `DETACH`
+
+1. Create `src/include/mssql_storage.hpp`
+2. Create `src/mssql_storage.cpp`
+3. Add to CMakeLists.txt
+4. Create `test/sql/mssql_attach.test`
+
+**Verification**:
+```sql
+CREATE SECRET my_secret (TYPE mssql, host 'localhost', port 1433,
+                         database 'test', user 'sa', password 'test');
+ATTACH '' AS mydb (TYPE mssql, SECRET my_secret);
+-- Should succeed without network connection
+
+DETACH mydb;
+-- Should succeed
+```
+
+### Phase 3: Table Functions (FR-013 to FR-018)
+
+**Goal**: Enable `mssql_execute` and `mssql_scan`
+
+1. Create `src/include/mssql_functions.hpp`
+2. Create `src/mssql_functions.cpp`
+3. Add to CMakeLists.txt
+4. Create `test/sql/mssql_execute.test`
+5. Create `test/sql/mssql_scan.test`
+
+**Verification**:
+```sql
+-- Setup
+CREATE SECRET my_secret (TYPE mssql, host 'localhost', port 1433,
+                         database 'test', user 'sa', password 'test');
+ATTACH '' AS mydb (TYPE mssql, SECRET my_secret);
+
+-- Test mssql_execute
+SELECT * FROM mssql_execute('mydb', 'SELECT 1');
+-- Should return: success=true, affected_rows=1, message='Query executed...'
+
+-- Test mssql_scan
+SELECT * FROM mssql_scan('mydb', 'SELECT id, name FROM users');
+-- Should return 3 sample rows
+
+DETACH mydb;
+```
+
+---
+
+## File Structure After Implementation
+
+```
+src/
+├── include/
+│   ├── mssql_extension.hpp    # Existing
+│   ├── mssql_secret.hpp       # NEW: Secret type definitions
+│   ├── mssql_storage.hpp      # NEW: Storage extension, context manager
+│   └── mssql_functions.hpp    # NEW: Table function definitions
+├── mssql_extension.cpp        # MODIFIED: Add registrations
+├── mssql_secret.cpp           # NEW: Secret implementation
+├── mssql_storage.cpp          # NEW: Attach/detach implementation
+└── mssql_functions.cpp        # NEW: mssql_scan, mssql_execute
+
+test/sql/
+├── mssql_version.test         # Existing
+├── mssql_secret.test          # NEW
+├── mssql_attach.test          # NEW
+├── mssql_execute.test         # NEW
+└── mssql_scan.test            # NEW
+```
+
+---
+
+## CMakeLists.txt Updates
+
+```cmake
+set(EXTENSION_SOURCES
+    src/mssql_extension.cpp
+    src/mssql_secret.cpp        # ADD
+    src/mssql_storage.cpp       # ADD
+    src/mssql_functions.cpp     # ADD
+)
+```
+
+---
+
+## Key Implementation Patterns
+
+### 1. Secret Registration
+
+```cpp
+// In RegisterMSSQLSecretType():
+SecretType mssql_type;
+mssql_type.name = "mssql";
+mssql_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+mssql_type.default_provider = "config";
+loader.RegisterSecretType(mssql_type);
+
+CreateSecretFunction create_func;
+create_func.secret_type = "mssql";
+create_func.provider = "config";
+create_func.function = CreateMSSQLSecretFromConfig;
+create_func.named_parameters["host"] = LogicalType::VARCHAR;
+// ... other parameters
+loader.RegisterFunction(std::move(create_func));
+```
+
+### 2. Storage Extension Registration
+
+```cpp
+// In RegisterMSSQLStorageExtension():
+auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+auto storage_ext = make_uniq<StorageExtension>();
+storage_ext->attach = MSSQLAttach;
+storage_ext->create_transaction_manager = MSSQLCreateTransactionManager;
+config.storage_extensions["mssql"] = std::move(storage_ext);
+```
+
+### 3. Table Function Registration
+
+```cpp
+// In RegisterMSSQLFunctions():
+TableFunction mssql_scan(
+    "mssql_scan",
+    {LogicalType::VARCHAR, LogicalType::VARCHAR},
+    MSSQLScanFunction,
+    MSSQLScanBind,
+    MSSQLScanInitGlobal,
+    MSSQLScanInitLocal
+);
+loader.RegisterFunction(mssql_scan);
+```
+
+---
+
+## Testing Commands
+
+```bash
+# Build extension
+make -j$(nproc)
+
+# Run all tests
+make test
+
+# Run specific test
+./build/release/test/unittest "test/sql/mssql_secret.test"
+
+# Run SQL tests interactively
+./build/release/duckdb
+```
+
+---
+
+## Common Issues
+
+### Issue: Secret type not recognized
+
+**Symptom**: `Unknown secret type: mssql`
+
+**Solution**: Ensure `RegisterMSSQLSecretType()` is called in `LoadInternal()` before any secret operations.
+
+### Issue: Attach type not recognized
+
+**Symptom**: `Unknown storage type: mssql`
+
+**Solution**: Ensure `RegisterMSSQLStorageExtension()` registers in `config.storage_extensions["mssql"]`.
+
+### Issue: Context not found in table function
+
+**Symptom**: `Unknown context 'mydb'`
+
+**Solution**: Verify `MSSQLContextManager::RegisterContext()` is called during attach and the manager is accessible via `MSSQLContextManager::Get(context.db)`.
+
+---
+
+## Acceptance Checklist
+
+- [ ] `CREATE SECRET ... TYPE mssql` works with all 5 required fields
+- [ ] Missing/invalid fields produce clear error messages
+- [ ] Secrets appear in `duckdb_secrets()` with password redacted
+- [ ] `ATTACH '' AS name TYPE mssql (SECRET secret_name)` creates context
+- [ ] Attach does not open network connection (lazy)
+- [ ] `DETACH name` removes context cleanly
+- [ ] `mssql_execute` returns (success, affected_rows, message)
+- [ ] `mssql_scan` returns 3 sample rows
+- [ ] Invalid context name produces clear error in both functions
+- [ ] All SQL tests pass

--- a/specs/002-duckdb-surface-api/research.md
+++ b/specs/002-duckdb-surface-api/research.md
@@ -1,0 +1,288 @@
+# Research: DuckDB Surface API
+
+**Feature**: 002-duckdb-surface-api
+**Date**: 2026-01-15
+
+## Overview
+
+This document consolidates research on DuckDB extension APIs required for implementing the MSSQL extension's public interface.
+
+---
+
+## 1. Secret System
+
+### Decision
+Use DuckDB's `KeyValueSecret` with custom `SecretType` registration.
+
+### Rationale
+- DuckDB provides a built-in secret management system designed for extensions
+- `KeyValueSecret` handles all storage, serialization, and redaction automatically
+- Follows established patterns from other database extensions (PostgreSQL, MySQL)
+- No custom encryption needed—constitution delegates security to DuckDB's secret manager
+
+### Alternatives Considered
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Custom BaseSecret subclass | Unnecessary complexity; KeyValueSecret handles all requirements |
+| External credential store | Violates "Native and Open" principle; adds dependency |
+| In-memory only | Would not persist across sessions |
+
+### API Pattern
+
+```cpp
+// Register secret type
+SecretType mssql_type;
+mssql_type.name = "mssql";
+mssql_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+mssql_type.default_provider = "config";
+loader.RegisterSecretType(mssql_type);
+
+// Register creation function with named parameters
+CreateSecretFunction create_func;
+create_func.secret_type = "mssql";
+create_func.provider = "config";
+create_func.function = CreateMSSQLSecretFromConfig;
+create_func.named_parameters["host"] = LogicalType::VARCHAR;
+create_func.named_parameters["port"] = LogicalType::INTEGER;
+create_func.named_parameters["database"] = LogicalType::VARCHAR;
+create_func.named_parameters["user"] = LogicalType::VARCHAR;
+create_func.named_parameters["password"] = LogicalType::VARCHAR;
+loader.RegisterFunction(std::move(create_func));
+```
+
+### Key Classes
+- `SecretType` (duckdb/main/secret/secret.hpp)
+- `CreateSecretFunction` - defines parameters and creation callback
+- `KeyValueSecret` - stores key-value pairs with redaction support
+- `CreateSecretInput` - receives user-provided values
+
+---
+
+## 2. Storage Extension (Attach/Detach)
+
+### Decision
+Implement `StorageExtension` with custom attach function returning a minimal `Catalog`.
+
+### Rationale
+- DuckDB's `ATTACH ... TYPE xxx` dispatches to registered storage extensions
+- Allows lazy connection pattern (connect only when data accessed)
+- Provides standard transaction manager integration
+- Catalog can be empty for stub phase; populated later for schema browsing
+
+### Alternatives Considered
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Virtual table per connection | Doesn't integrate with ATTACH/DETACH syntax |
+| Custom database manager | Reinvents DuckDB infrastructure; harder to maintain |
+| Attached database without catalog | Still requires StorageExtension registration |
+
+### API Pattern
+
+```cpp
+// Define attach function
+static unique_ptr<Catalog> MSSQLAttach(
+    optional_ptr<StorageExtensionInfo> storage_info,
+    ClientContext &context,
+    AttachedDatabase &db,
+    const string &name,
+    AttachInfo &info,
+    AttachOptions &options
+) {
+    // Extract SECRET parameter from options
+    // Store connection context (lazy - don't connect yet)
+    // Return empty catalog for stub
+    return make_uniq<Catalog>(db);
+}
+
+// Register storage extension
+auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+auto storage_ext = make_uniq<StorageExtension>();
+storage_ext->attach = MSSQLAttach;
+storage_ext->create_transaction_manager = MSSQLCreateTransactionManager;
+config.storage_extensions["mssql"] = std::move(storage_ext);
+```
+
+### Key Classes
+- `StorageExtension` (duckdb/storage/storage_extension.hpp)
+- `AttachedDatabase` - represents an attached database instance
+- `AttachInfo` - contains path, name, and user options
+- `AttachOptions` - contains access mode, db_type, secret reference
+
+### Connection Context Management
+- Store connection metadata in `StorageExtensionInfo` subclass
+- Track attached contexts by name for function lookups
+- Implement detach cleanup via `AttachedDatabase::OnDetach()`
+
+---
+
+## 3. Table Functions
+
+### Decision
+Use `TableFunction` with bind/init/execute pattern for both `mssql_scan` and `mssql_execute`.
+
+### Rationale
+- Standard DuckDB pattern for functions returning tabular data
+- Supports streaming results (important for future phases)
+- Integrates with query optimizer and parallel execution
+- Well-documented with many extension examples
+
+### Alternatives Considered
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Scalar function returning JSON | Cannot return proper relations; poor UX |
+| Custom operator | Overkill for table-valued functions |
+| Direct catalog integration | Better suited for schema browsing, not ad-hoc queries |
+
+### API Pattern
+
+```cpp
+// Bind function - determines output schema
+static unique_ptr<FunctionData> MSSQLScanBind(
+    ClientContext &context,
+    TableFunctionBindInput &input,
+    vector<LogicalType> &return_types,
+    vector<string> &names
+) {
+    // Validate arguments (context_name, query)
+    // For stub: return fixed schema
+    return_types.push_back(LogicalType::INTEGER);
+    return_types.push_back(LogicalType::VARCHAR);
+    names.push_back("id");
+    names.push_back("name");
+    return bind_data;
+}
+
+// Main function - produces output rows
+static void MSSQLScanFunction(
+    ClientContext &context,
+    TableFunctionInput &data,
+    DataChunk &output
+) {
+    // For stub: return 3 hardcoded rows
+    output.SetCardinality(3);
+    // Fill columns...
+}
+
+// Registration
+TableFunction mssql_scan("mssql_scan",
+    {LogicalType::VARCHAR, LogicalType::VARCHAR},
+    MSSQLScanFunction,
+    MSSQLScanBind,
+    MSSQLScanInitGlobal,
+    MSSQLScanInitLocal
+);
+loader.RegisterFunction(mssql_scan);
+```
+
+### mssql_execute Return Schema
+| Column | Type | Description |
+|--------|------|-------------|
+| success | BOOLEAN | Whether execution succeeded |
+| affected_rows | BIGINT | Number of rows affected |
+| message | VARCHAR | Status or error message |
+
+### mssql_scan Stub Return Schema
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Sample row ID |
+| name | VARCHAR | Sample name value |
+
+---
+
+## 4. Context Lookup Pattern
+
+### Decision
+Maintain a global map of attached MSSQL contexts accessible to table functions.
+
+### Rationale
+- Table functions receive context_name as string argument
+- Need to resolve to connection metadata for query execution
+- Must validate context exists before executing queries
+
+### Implementation Approach
+
+```cpp
+// In mssql_storage.hpp
+class MSSQLContextManager {
+public:
+    static MSSQLContextManager& Get(DatabaseInstance &db);
+
+    void RegisterContext(const string &name, shared_ptr<MSSQLConnectionInfo> info);
+    void UnregisterContext(const string &name);
+    optional_ptr<MSSQLConnectionInfo> GetContext(const string &name);
+    bool HasContext(const string &name);
+};
+
+// In mssql_functions.cpp
+void MSSQLScanFunction(...) {
+    auto &manager = MSSQLContextManager::Get(context.db);
+    auto conn_info = manager.GetContext(context_name);
+    if (!conn_info) {
+        throw InvalidInputException("Unknown MSSQL context: " + context_name);
+    }
+    // Execute query using conn_info...
+}
+```
+
+---
+
+## 5. Error Handling Strategy
+
+### Decision
+Use DuckDB exception types with clear, actionable messages.
+
+### Exception Types
+| Scenario | Exception Type |
+|----------|---------------|
+| Missing required secret field | `InvalidInputException` |
+| Invalid port number | `InvalidInputException` |
+| Unknown context name | `InvalidInputException` |
+| Secret not found | `BinderException` |
+| Internal error | `InternalException` |
+
+### Message Format
+```
+"MSSQL Error: {what happened}. {suggestion to fix}"
+
+Examples:
+- "MSSQL Error: Missing required field 'host'. Provide host parameter when creating secret."
+- "MSSQL Error: Port must be between 1 and 65535. Got: -1"
+- "MSSQL Error: Unknown context 'mydb'. Attach a database first with: ATTACH '' AS mydb TYPE mssql (SECRET ...)"
+```
+
+---
+
+## 6. File Organization
+
+### Decision
+Separate concerns into dedicated source files with shared headers.
+
+### Files
+| File | Responsibility |
+|------|---------------|
+| `mssql_secret.hpp/cpp` | Secret type and creation function |
+| `mssql_storage.hpp/cpp` | StorageExtension, attach/detach, context manager |
+| `mssql_functions.hpp/cpp` | mssql_scan, mssql_execute table functions |
+| `mssql_extension.cpp` | Entry point, registration coordination |
+
+### Rationale
+- Clear separation of concerns
+- Easier to maintain and test independently
+- Follows patterns from other DuckDB extensions
+- Headers in `src/include/`, implementation in `src/`
+
+---
+
+## Summary
+
+All NEEDS CLARIFICATION items from Technical Context have been resolved:
+
+| Item | Resolution |
+|------|------------|
+| Secret storage mechanism | KeyValueSecret via DuckDB's secret manager |
+| Attach handler pattern | StorageExtension with custom attach function |
+| Table function pattern | Bind/Init/Execute with FunctionData state |
+| Context management | Global manager with name-based lookup |
+| Error handling | DuckDB exception types with actionable messages |
+
+The implementation can proceed to Phase 1 design artifacts.

--- a/specs/002-duckdb-surface-api/spec.md
+++ b/specs/002-duckdb-surface-api/spec.md
@@ -1,0 +1,183 @@
+# Feature Specification: DuckDB Surface API
+
+**Feature Branch**: `002-duckdb-surface-api`
+**Created**: 2026-01-15
+**Status**: Draft
+**Input**: Define and stabilize the public DuckDB interface of the extension before implementing protocol and execution logic. Includes secrets, attach/detach, and user-facing functions.
+
+## Clarifications
+
+### Session 2026-01-15
+
+- Q: What security posture should be used for credential/password handling at runtime? → A: Defer to DuckDB's secret manager (use whatever it provides)
+- Q: What should mssql_scan return as stub behavior (no real network traffic)? → A: Return hardcoded sample rows (e.g., 3 rows with dummy values)
+- Q: What happens when DETACH is called while a query is in progress? → A: Immediately abort query and detach
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Secret Creation (Priority: P1)
+
+As a DuckDB user, I want to securely store SQL Server connection credentials so that I can connect to remote databases without exposing sensitive information in queries.
+
+**Why this priority**: Secrets are the foundation for all other functionality. Without secure credential storage, users cannot establish any connection to SQL Server databases.
+
+**Independent Test**: Can be fully tested by creating a secret with all required fields and verifying it persists across sessions and cannot be modified after creation.
+
+**Acceptance Scenarios**:
+
+1. **Given** DuckDB is running with the mssql extension loaded, **When** I create a secret with `CREATE SECRET my_secret (TYPE mssql, host 'server.example.com', port 1433, database 'mydb', user 'admin', password 'secret')`, **Then** the secret is stored and accessible by name.
+2. **Given** an mssql secret already exists, **When** I attempt to modify any of its fields, **Then** the operation fails with an error indicating secrets are immutable.
+3. **Given** I am creating an mssql secret, **When** I omit any required field (host, port, database, user, or password), **Then** the creation fails with a clear error message indicating which field is missing.
+
+---
+
+### User Story 2 - Attach SQL Server Database (Priority: P1)
+
+As a DuckDB user, I want to attach a SQL Server database as a named connection context so that I can query it using familiar DuckDB syntax.
+
+**Why this priority**: Attach is the primary mechanism for establishing a connection context. Without it, users cannot access SQL Server data through DuckDB.
+
+**Independent Test**: Can be fully tested by attaching a database with a secret, verifying the named context is created, and confirming no network connection is opened until data is actually accessed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an mssql secret named `my_secret` exists, **When** I execute `ATTACH '' AS mydb TYPE mssql (SECRET my_secret)`, **Then** a named connection context `mydb` is created.
+2. **Given** an attached database context exists, **When** no queries have been executed against it, **Then** no actual network connection to SQL Server has been opened (lazy connection).
+3. **Given** I attempt to attach without a valid secret, **When** the attach command executes, **Then** it fails with a clear error message.
+
+---
+
+### User Story 3 - Detach SQL Server Database (Priority: P2)
+
+As a DuckDB user, I want to detach a previously attached SQL Server database so that resources are properly released and the connection context is removed.
+
+**Why this priority**: Detach completes the connection lifecycle. While not needed for initial functionality, proper cleanup is essential for production use.
+
+**Independent Test**: Can be fully tested by detaching an attached database and verifying the context is removed and any open connections are closed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an attached database context `mydb` exists, **When** I execute `DETACH mydb`, **Then** the connection context is removed.
+2. **Given** an attached database had an active network connection, **When** I detach it, **Then** the network connection is properly closed.
+3. **Given** I attempt to detach a non-existent context, **When** the detach command executes, **Then** it fails with a clear error message.
+
+---
+
+### User Story 4 - Execute Raw SQL (Priority: P2)
+
+As a DuckDB user, I want to execute arbitrary SQL statements against SQL Server so that I can perform operations that may not be supported through DuckDB's native syntax.
+
+**Why this priority**: Provides an escape hatch for advanced users and operations not covered by standard query translation. Important for real-world usability but not blocking for MVP.
+
+**Independent Test**: Can be fully tested by executing a raw SQL statement and verifying the return includes success status, affected row count, and result message.
+
+**Acceptance Scenarios**:
+
+1. **Given** an attached database context `mydb` exists, **When** I execute `SELECT * FROM mssql_execute('mydb', 'UPDATE users SET active = 1 WHERE id = 5')`, **Then** I receive a result with success flag, affected row count, and message.
+2. **Given** I execute a statement that fails on SQL Server, **When** `mssql_execute` runs, **Then** the result includes success=false and an error message from SQL Server.
+3. **Given** I reference a non-existent database context, **When** `mssql_execute` runs, **Then** it fails with a clear error indicating the context does not exist.
+
+---
+
+### User Story 5 - Scan SQL Server Data (Priority: P2)
+
+As a DuckDB user, I want to execute SELECT queries against SQL Server and receive results as a DuckDB relation so that I can analyze remote data using DuckDB's query engine.
+
+**Why this priority**: Core query functionality for reading data. Equally important as execute but focused on data retrieval rather than mutations.
+
+**Independent Test**: Can be fully tested by executing a SELECT query and verifying a relation is returned with appropriate schema and data.
+
+**Acceptance Scenarios**:
+
+1. **Given** an attached database context `mydb` exists, **When** I execute `SELECT * FROM mssql_scan('mydb', 'SELECT id, name FROM users')`, **Then** I receive a relation with the query results.
+2. **Given** a scan query returns no rows, **When** `mssql_scan` executes, **Then** an empty relation with the correct schema is returned.
+3. **Given** I reference a non-existent database context, **When** `mssql_scan` runs, **Then** it fails with a clear error indicating the context does not exist.
+
+---
+
+### Edge Cases
+
+- What happens when a secret is created with an invalid port number (e.g., negative, zero, or > 65535)?
+- How does the system handle attach with an empty database name in the secret?
+- What happens when detach is called while a query is in progress? → Immediately abort the query and proceed with detach.
+- How does mssql_execute handle very large affected row counts that may exceed integer limits?
+- What happens when mssql_scan receives a query that is not a SELECT statement?
+- How does the system handle special characters in passwords (quotes, backslashes)?
+- What happens when attempting to create a secret with the same name as an existing one?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Secrets
+
+- **FR-001**: System MUST support a `SECRET TYPE mssql` for storing SQL Server connection credentials.
+- **FR-002**: Mssql secrets MUST require all of the following fields: host, port, database, user, password.
+- **FR-003**: Mssql secrets MUST be immutable after creation; any attempt to modify fields MUST fail.
+- **FR-004**: System MUST validate port is a valid TCP port number (1-65535) during secret creation.
+- **FR-005**: System MUST validate that all required fields are non-empty during secret creation.
+- **FR-006**: System MUST prevent creation of a secret with a name that already exists.
+
+#### Attach/Detach
+
+- **FR-007**: System MUST support `ATTACH ... TYPE mssql` syntax for creating named connection contexts.
+- **FR-008**: Attach MUST require a valid mssql secret to be specified.
+- **FR-009**: Network connections MUST be opened lazily (only when data is actually accessed).
+- **FR-010**: `DETACH` MUST remove the named connection context.
+- **FR-011**: `DETACH` MUST close any open network connections associated with the context.
+- **FR-012**: `DETACH` MUST clean up all internal metadata associated with the connection context.
+- **FR-012a**: `DETACH` MUST immediately abort any in-progress query on the context before proceeding with cleanup.
+
+#### Functions
+
+- **FR-013**: System MUST provide `mssql_execute(context_name, sql_statement)` function for executing raw SQL.
+- **FR-014**: `mssql_execute` MUST return a result containing: success flag (boolean), affected row count (integer), and message (string).
+- **FR-015**: System MUST provide `mssql_scan(context_name, select_query)` function for executing SELECT queries.
+- **FR-016**: `mssql_scan` MUST return a DuckDB relation containing the query results.
+- **FR-017**: Both functions MUST validate that the specified context name exists before execution.
+- **FR-018**: Both functions MUST propagate meaningful error messages from SQL Server when queries fail.
+
+### Key Entities
+
+- **MssqlSecret**: Stores connection credentials for SQL Server. Contains host (string), port (integer), database (string), user (string), password (string). Immutable after creation.
+- **ConnectionContext**: Named reference to an attached SQL Server database. Links to an MssqlSecret. Manages lazy network connection lifecycle.
+- **ExecuteResult**: Result of mssql_execute. Contains success (boolean), affected_rows (integer), message (string).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can create an mssql secret and attach a database in under 10 seconds with no prior knowledge beyond reading documentation.
+- **SC-002**: All five required secret fields are validated at creation time with clear error messages identifying any missing or invalid fields.
+- **SC-003**: Detaching a database releases all associated resources within 1 second.
+- **SC-004**: Error messages from invalid operations clearly identify the problem and suggest corrective action.
+- **SC-005**: The public API (secret type, attach/detach, functions) remains stable and backward-compatible for future releases.
+- **SC-006**: All functions handle edge cases gracefully without crashes or undefined behavior.
+
+## Scope Boundaries
+
+### In Scope
+
+- SECRET TYPE mssql definition and validation
+- ATTACH/DETACH mechanics for connection context management
+- mssql_execute function signature and return structure
+- mssql_scan function signature and return type
+- Error handling and validation for all public interfaces
+
+### Out of Scope (Non-Goals)
+
+- Actual network traffic to SQL Server
+- TDS protocol implementation
+- Catalog integration (schema discovery, table listing)
+- Query translation from DuckDB SQL to T-SQL
+- Connection pooling
+- Transaction management
+
+## Assumptions
+
+- DuckDB's existing secret management infrastructure is available and follows standard patterns.
+- Password/credential security (storage, memory handling) is delegated entirely to DuckDB's secret manager; no custom encryption layer is implemented.
+- The extension can register custom secret types through DuckDB's extension API.
+- Lazy connection opening is achievable through DuckDB's attach mechanism.
+- During this phase (no real network), mssql_scan returns hardcoded sample rows (e.g., 3 rows with dummy values) to validate the data flow through DuckDB.
+- The DuckDB main branch API for extensions is stable enough for this implementation.

--- a/specs/002-duckdb-surface-api/tasks.md
+++ b/specs/002-duckdb-surface-api/tasks.md
@@ -1,0 +1,283 @@
+# Tasks: DuckDB Surface API
+
+**Input**: Design documents from `/specs/002-duckdb-surface-api/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/`, `test/sql/` at repository root
+- Headers in `src/include/`, implementation in `src/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project structure and build configuration updates
+
+- [X] T001 Update CMakeLists.txt to add new source files (mssql_secret.cpp, mssql_storage.cpp, mssql_functions.cpp) in CMakeLists.txt
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: User Story 2 (Attach) depends on User Story 1 (Secrets). User Stories 3-5 depend on User Story 2.
+
+- [X] T002 [P] Create MSSQLContextManager singleton class in src/include/mssql_storage.hpp and src/mssql_storage.cpp
+- [X] T003 [P] Create MSSQLConnectionInfo struct in src/include/mssql_storage.hpp
+- [X] T004 [P] Create MSSQLContext struct in src/include/mssql_storage.hpp
+- [X] T005 Update mssql_extension.cpp to include new headers and call registration functions in src/mssql_extension.cpp
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Secret Creation (Priority: P1) 🎯 MVP
+
+**Goal**: Enable `CREATE SECRET ... TYPE mssql` with required fields (host, port, database, user, password)
+
+**Independent Test**: Create a secret with all required fields, verify it appears in `duckdb_secrets()` with password redacted, verify missing/invalid fields produce clear errors
+
+### Implementation for User Story 1
+
+- [X] T006 [P] [US1] Create mssql_secret.hpp header with constants and function declarations in src/include/mssql_secret.hpp
+- [X] T007 [US1] Implement ValidateMSSQLSecretFields() function to validate all required fields in src/mssql_secret.cpp
+- [X] T008 [US1] Implement CreateMSSQLSecretFromConfig() function using KeyValueSecret in src/mssql_secret.cpp
+- [X] T009 [US1] Implement RegisterMSSQLSecretType() to register SecretType and CreateSecretFunction in src/mssql_secret.cpp
+- [X] T010 [US1] Create SQL test for secret creation with valid parameters in test/sql/mssql_secret.test
+- [X] T011 [US1] Add SQL test cases for missing required fields (host, port, database, user, password) in test/sql/mssql_secret.test
+- [X] T012 [US1] Add SQL test case for invalid port number (0, -1, 65536) in test/sql/mssql_secret.test
+- [X] T013 [US1] Add SQL test case for password redaction in duckdb_secrets() output in test/sql/mssql_secret.test
+
+**Checkpoint**: User Story 1 complete - secrets can be created and validated independently
+
+---
+
+## Phase 4: User Story 2 - Attach SQL Server Database (Priority: P1) 🎯 MVP
+
+**Goal**: Enable `ATTACH '' AS name TYPE mssql (SECRET secret_name)` to create named connection context
+
+**Independent Test**: Attach a database with a valid secret, verify context is created, verify lazy connection (no network until data access)
+
+**Dependency**: Requires User Story 1 (Secrets) to be complete
+
+### Implementation for User Story 2
+
+- [X] T014 [US2] Implement MSSQLConnectionInfo::FromSecret() to extract connection params from secret in src/mssql_storage.cpp
+- [X] T015 [US2] Implement MSSQLStorageExtensionInfo struct in src/mssql_storage.cpp
+- [X] T016 [US2] Implement MSSQLAttach() callback function for storage extension in src/mssql_storage.cpp
+- [X] T017 [US2] Implement MSSQLCreateTransactionManager() callback function in src/mssql_storage.cpp
+- [X] T018 [US2] Implement RegisterMSSQLStorageExtension() to register storage extension type in src/mssql_storage.cpp
+- [X] T019 [US2] Create SQL test for successful attach with valid secret in test/sql/mssql_attach.test
+- [X] T020 [US2] Add SQL test case for attach without secret (should fail) in test/sql/mssql_attach.test
+- [X] T021 [US2] Add SQL test case for attach with non-existent secret (should fail) in test/sql/mssql_attach.test
+
+**Checkpoint**: User Story 2 complete - databases can be attached with secrets
+
+---
+
+## Phase 5: User Story 3 - Detach SQL Server Database (Priority: P2)
+
+**Goal**: Enable `DETACH name` to remove connection context and clean up resources
+
+**Independent Test**: Detach an attached database, verify context is removed, verify detaching non-existent context produces error
+
+**Dependency**: Requires User Story 2 (Attach) to be complete
+
+### Implementation for User Story 3
+
+- [X] T022 [US3] Implement OnDetach handling in MSSQLContextManager::UnregisterContext() in src/mssql_storage.cpp
+- [X] T023 [US3] Add connection cleanup logic (abort in-progress queries) in detach handler in src/mssql_storage.cpp
+- [X] T024 [US3] Create SQL test for successful detach in test/sql/mssql_attach.test
+- [X] T025 [US3] Add SQL test case for detach non-existent context (should fail) in test/sql/mssql_attach.test
+
+**Checkpoint**: User Story 3 complete - full attach/detach lifecycle works
+
+---
+
+## Phase 6: User Story 4 - Execute Raw SQL (Priority: P2)
+
+**Goal**: Enable `mssql_execute(context, sql)` table function returning (success, affected_rows, message)
+
+**Independent Test**: Execute a SQL statement via mssql_execute, verify return schema, verify invalid context produces error
+
+**Dependency**: Requires User Story 2 (Attach) to be complete
+
+### Implementation for User Story 4
+
+- [X] T026 [P] [US4] Create mssql_functions.hpp header with MSSQLExecuteBindData struct in src/include/mssql_functions.hpp
+- [X] T027 [US4] Implement MSSQLExecuteBindData::Copy() and Equals() methods in src/mssql_functions.cpp
+- [X] T028 [US4] Implement MSSQLExecuteBind() to validate context and set return schema in src/mssql_functions.cpp
+- [X] T029 [US4] Implement MSSQLExecuteFunction() returning stub result (success=true, affected_rows=1) in src/mssql_functions.cpp
+- [X] T030 [US4] Add mssql_execute registration in RegisterMSSQLFunctions() in src/mssql_functions.cpp
+- [X] T031 [US4] Create SQL test for mssql_execute with valid context in test/sql/mssql_execute.test
+- [X] T032 [US4] Add SQL test case for mssql_execute with invalid context (should fail) in test/sql/mssql_execute.test
+- [X] T033 [US4] Add SQL test to verify return schema (success BOOLEAN, affected_rows BIGINT, message VARCHAR) in test/sql/mssql_execute.test
+
+**Checkpoint**: User Story 4 complete - raw SQL execution works (stub)
+
+---
+
+## Phase 7: User Story 5 - Scan SQL Server Data (Priority: P2)
+
+**Goal**: Enable `mssql_scan(context, query)` table function returning relation with stub data (3 sample rows)
+
+**Independent Test**: Execute mssql_scan, verify returns relation with correct schema, verify 3 rows returned, verify invalid context produces error
+
+**Dependency**: Requires User Story 2 (Attach) to be complete
+
+### Implementation for User Story 5
+
+- [X] T034 [US5] Add MSSQLScanBindData, MSSQLScanGlobalState, MSSQLScanLocalState structs to header in src/include/mssql_functions.hpp
+- [X] T035 [US5] Implement MSSQLScanBindData::Copy() and Equals() methods in src/mssql_functions.cpp
+- [X] T036 [US5] Implement MSSQLScanBind() to validate context and set return schema (id INTEGER, name VARCHAR) in src/mssql_functions.cpp
+- [X] T037 [US5] Implement MSSQLScanInitGlobal() setting total_rows=3 for stub in src/mssql_functions.cpp
+- [X] T038 [US5] Implement MSSQLScanInitLocal() initializing current_row=0 in src/mssql_functions.cpp
+- [X] T039 [US5] Implement MSSQLScanFunction() producing 3 hardcoded rows in src/mssql_functions.cpp
+- [X] T040 [US5] Add mssql_scan registration in RegisterMSSQLFunctions() in src/mssql_functions.cpp
+- [X] T041 [US5] Create SQL test for mssql_scan with valid context in test/sql/mssql_scan.test
+- [X] T042 [US5] Add SQL test case for mssql_scan with invalid context (should fail) in test/sql/mssql_scan.test
+- [X] T043 [US5] Add SQL test to verify exactly 3 rows returned with correct schema in test/sql/mssql_scan.test
+
+**Checkpoint**: User Story 5 complete - data scanning works (stub)
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [X] T044 Verify all error messages follow format "MSSQL Error: {what}. {suggestion}" across all source files
+- [X] T045 Run full test suite and fix any failures via make test
+- [X] T046 Verify quickstart.md acceptance checklist passes manually
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - shared infrastructure
+- **User Story 1 (Phase 3)**: Depends on Foundational - enables secret creation
+- **User Story 2 (Phase 4)**: Depends on US1 - attach requires secrets
+- **User Story 3 (Phase 5)**: Depends on US2 - detach requires attach
+- **User Story 4 (Phase 6)**: Depends on US2 - execute requires attached context
+- **User Story 5 (Phase 7)**: Depends on US2 - scan requires attached context
+- **Polish (Phase 8)**: Depends on all user stories
+
+### User Story Dependencies
+
+```
+US1 (Secrets) ─────────────┬──> US2 (Attach) ──┬──> US3 (Detach)
+                           │                   │
+                           │                   ├──> US4 (Execute)
+                           │                   │
+                           │                   └──> US5 (Scan)
+```
+
+- **US1**: Independent (first to implement)
+- **US2**: Depends on US1 (needs secrets to attach)
+- **US3, US4, US5**: All depend on US2 (need attach), can run in parallel after US2
+
+### Within Each User Story
+
+- Headers before implementation
+- Core functions before registration
+- Implementation before tests
+- Verify tests pass before moving to next story
+
+### Parallel Opportunities
+
+**Phase 2 (Foundational):**
+```
+T002 (ContextManager) || T003 (ConnectionInfo) || T004 (Context)
+```
+
+**Phase 3 (US1):**
+```
+T006 (header) can start immediately
+```
+
+**After US2 Complete (Phases 5-7):**
+```
+US3 (Detach) || US4 (Execute) || US5 (Scan)
+```
+
+---
+
+## Parallel Example: After User Story 2
+
+```bash
+# Once US2 (Attach) is complete, launch US3, US4, US5 in parallel:
+
+# Developer A - User Story 3 (Detach):
+Task: "Implement OnDetach handling in src/mssql_storage.cpp"
+
+# Developer B - User Story 4 (Execute):
+Task: "Create mssql_functions.hpp header in src/include/mssql_functions.hpp"
+
+# Developer C - User Story 5 (Scan):
+Task: "Add MSSQLScanBindData struct to header in src/include/mssql_functions.hpp"
+# Note: US4 and US5 share mssql_functions.hpp - coordinate on header changes
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1 (Secrets)
+4. Complete Phase 4: User Story 2 (Attach)
+5. **STOP and VALIDATE**: Test CREATE SECRET and ATTACH independently
+6. Deploy/demo if ready - users can now configure connections
+
+### Incremental Delivery
+
+1. Setup + Foundational → Infrastructure ready
+2. Add US1 (Secrets) → Users can store credentials
+3. Add US2 (Attach) → Users can attach databases (MVP!)
+4. Add US3 (Detach) → Full connection lifecycle
+5. Add US4 (Execute) → Raw SQL execution
+6. Add US5 (Scan) → Data retrieval
+7. Each story adds value without breaking previous stories
+
+### Sequential Team Strategy
+
+With single developer:
+1. Complete phases sequentially (Phase 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8)
+2. Test after each user story checkpoint
+3. Commit after each phase
+
+### Parallel Team Strategy
+
+With multiple developers:
+1. Team completes Setup + Foundational + US1 + US2 together (dependencies)
+2. Once US2 is done:
+   - Developer A: User Story 3 (Detach)
+   - Developer B: User Story 4 (Execute)
+   - Developer C: User Story 5 (Scan)
+3. Coordinate on shared files (mssql_functions.hpp)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable after dependencies met
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Stub implementations return hardcoded data (no real SQL Server connection)

--- a/src/include/mssql_functions.hpp
+++ b/src/include/mssql_functions.hpp
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// mssql_functions.hpp
+//
+// Table functions: mssql_execute and mssql_scan
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/function/table_function.hpp"
+
+#include <atomic>
+
+namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// mssql_execute - Execute raw SQL statement
+//===----------------------------------------------------------------------===//
+
+struct MSSQLExecuteBindData : public FunctionData {
+	string context_name;
+	string sql_statement;
+
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other) const override;
+};
+
+struct MSSQLExecuteGlobalState : public GlobalTableFunctionState {
+	bool done = false;
+
+	idx_t MaxThreads() const override {
+		return 1;
+	}
+};
+
+// Bind: validates arguments, sets return schema
+unique_ptr<FunctionData> MSSQLExecuteBind(ClientContext &context, TableFunctionBindInput &input,
+                                          vector<LogicalType> &return_types, vector<string> &names);
+
+// Global init: sets up execution state
+unique_ptr<GlobalTableFunctionState> MSSQLExecuteInitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+// Execute: produces single-row result
+void MSSQLExecuteFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output);
+
+//===----------------------------------------------------------------------===//
+// mssql_scan - Scan SQL Server data
+//===----------------------------------------------------------------------===//
+
+struct MSSQLScanBindData : public FunctionData {
+	string context_name;
+	string query;
+	vector<LogicalType> return_types;
+	vector<string> column_names;
+
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other) const override;
+};
+
+struct MSSQLScanGlobalState : public GlobalTableFunctionState {
+	string context_name;
+	string query;
+	idx_t total_rows;
+	atomic<idx_t> rows_returned;
+
+	MSSQLScanGlobalState() : total_rows(3), rows_returned(0) {
+	}
+
+	idx_t MaxThreads() const override;
+};
+
+struct MSSQLScanLocalState : public LocalTableFunctionState {
+	idx_t current_row = 0;
+};
+
+// Bind: validates arguments, determines return schema
+unique_ptr<FunctionData> MSSQLScanBind(ClientContext &context, TableFunctionBindInput &input,
+                                       vector<LogicalType> &return_types, vector<string> &names);
+
+// Global init: sets up execution state
+unique_ptr<GlobalTableFunctionState> MSSQLScanInitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+// Local init: per-thread state
+unique_ptr<LocalTableFunctionState> MSSQLScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                       GlobalTableFunctionState *global_state);
+
+// Execute: produces output rows
+void MSSQLScanFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output);
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+// Register all MSSQL table functions
+void RegisterMSSQLFunctions(ExtensionLoader &loader);
+
+}  // namespace duckdb

--- a/src/include/mssql_secret.hpp
+++ b/src/include/mssql_secret.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// mssql_secret.hpp
+//
+// Secret type registration for MSSQL credentials
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/secret/secret.hpp"
+
+namespace duckdb {
+
+// Secret field names (constants)
+constexpr const char *MSSQL_SECRET_HOST = "host";
+constexpr const char *MSSQL_SECRET_PORT = "port";
+constexpr const char *MSSQL_SECRET_DATABASE = "database";
+constexpr const char *MSSQL_SECRET_USER = "user";
+constexpr const char *MSSQL_SECRET_PASSWORD = "password";
+constexpr const char *MSSQL_SECRET_USE_SSL = "use_ssl";  // Optional, defaults to false
+
+// Register MSSQL secret type and creation function
+void RegisterMSSQLSecretType(ExtensionLoader &loader);
+
+// Create secret from user-provided parameters
+// Throws: InvalidInputException on validation failure
+unique_ptr<BaseSecret> CreateMSSQLSecretFromConfig(ClientContext &context, CreateSecretInput &input);
+
+// Validate secret fields
+// Returns: empty string if valid, error message if invalid
+string ValidateMSSQLSecretFields(const CreateSecretInput &input);
+
+}  // namespace duckdb

--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// mssql_storage.hpp
+//
+// Storage extension for ATTACH/DETACH and context management
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/transaction/transaction_manager.hpp"
+
+#include <atomic>
+#include <mutex>
+
+namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// MSSQLConnectionInfo - Connection parameters extracted from secret or connection string
+//===----------------------------------------------------------------------===//
+struct MSSQLConnectionInfo {
+	string host;
+	uint16_t port;
+	string database;
+	string user;
+	string password;
+	bool use_ssl = false;
+	bool connected = false;
+
+	// Create from secret
+	static shared_ptr<MSSQLConnectionInfo> FromSecret(ClientContext &context, const string &secret_name);
+
+	// Create from connection string
+	// Format: "Server=host,port;Database=db;User Id=user;Password=pass;Encrypt=yes/no"
+	static shared_ptr<MSSQLConnectionInfo> FromConnectionString(const string &connection_string);
+
+	// Validate connection string format
+	// Returns: empty string if valid, error message if invalid
+	static string ValidateConnectionString(const string &connection_string);
+};
+
+//===----------------------------------------------------------------------===//
+// MSSQLContext - Attached context state
+//===----------------------------------------------------------------------===//
+struct MSSQLContext {
+	string name;
+	string secret_name;
+	shared_ptr<MSSQLConnectionInfo> connection_info;
+	optional_ptr<AttachedDatabase> attached_db;
+
+	MSSQLContext(const string &name, const string &secret_name);
+};
+
+//===----------------------------------------------------------------------===//
+// MSSQLContextManager - Global context manager (singleton per DatabaseInstance)
+//===----------------------------------------------------------------------===//
+class MSSQLContextManager {
+public:
+	// Get singleton instance for a DatabaseInstance
+	static MSSQLContextManager &Get(DatabaseInstance &db);
+
+	// Context operations
+	void RegisterContext(const string &name, shared_ptr<MSSQLContext> ctx);
+	void UnregisterContext(const string &name);
+	shared_ptr<MSSQLContext> GetContext(const string &name);
+	bool HasContext(const string &name);
+	vector<string> ListContexts();
+
+private:
+	mutex lock;
+	case_insensitive_map_t<shared_ptr<MSSQLContext>> contexts;
+};
+
+//===----------------------------------------------------------------------===//
+// MSSQLStorageExtensionInfo - Shared state for storage extension
+//===----------------------------------------------------------------------===//
+struct MSSQLStorageExtensionInfo : public StorageExtensionInfo {
+	// Reserved for future connection pooling, etc.
+};
+
+//===----------------------------------------------------------------------===//
+// MSSQLCatalog - Custom catalog that cleans up context on detach
+//===----------------------------------------------------------------------===//
+class MSSQLCatalog : public DuckCatalog {
+public:
+	MSSQLCatalog(AttachedDatabase &db, const string &context_name);
+
+	void OnDetach(ClientContext &context) override;
+
+private:
+	string context_name;
+};
+
+//===----------------------------------------------------------------------===//
+// Registration and callbacks
+//===----------------------------------------------------------------------===//
+
+// Register storage extension for ATTACH TYPE mssql
+void RegisterMSSQLStorageExtension(ExtensionLoader &loader);
+
+// Attach callback
+unique_ptr<Catalog> MSSQLAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
+                                AttachedDatabase &db, const string &name, AttachInfo &info, AttachOptions &options);
+
+// Transaction manager factory
+unique_ptr<TransactionManager> MSSQLCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
+                                                             AttachedDatabase &db, Catalog &catalog);
+
+}  // namespace duckdb

--- a/src/mssql_extension.cpp
+++ b/src/mssql_extension.cpp
@@ -1,4 +1,7 @@
 #include "mssql_extension.hpp"
+#include "mssql_functions.hpp"
+#include "mssql_secret.hpp"
+#include "mssql_storage.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -24,9 +27,18 @@ static void MssqlVersionFunction(DataChunk &args, ExpressionState &state, Vector
 
 // Internal function to register extension functionality
 static void LoadInternal(ExtensionLoader &loader) {
-	// Register mssql_version() scalar function for load verification
+	// 1. Register secrets
+	RegisterMSSQLSecretType(loader);
+
+	// 2. Register storage extension (ATTACH TYPE mssql)
+	RegisterMSSQLStorageExtension(loader);
+
+	// 3. Register table functions
+	RegisterMSSQLFunctions(loader);
+
+	// 4. Register utility functions (mssql_version)
 	auto mssql_version_func = ScalarFunction("mssql_version", {},  // No arguments
-											 LogicalType::VARCHAR, MssqlVersionFunction);
+	                                         LogicalType::VARCHAR, MssqlVersionFunction);
 	loader.RegisterFunction(mssql_version_func);
 }
 

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -1,0 +1,203 @@
+#include "mssql_functions.hpp"
+#include "mssql_storage.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// mssql_execute implementation
+//===----------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> MSSQLExecuteBindData::Copy() const {
+	auto result = make_uniq<MSSQLExecuteBindData>();
+	result->context_name = context_name;
+	result->sql_statement = sql_statement;
+	return std::move(result);
+}
+
+bool MSSQLExecuteBindData::Equals(const FunctionData &other) const {
+	auto &other_data = other.Cast<MSSQLExecuteBindData>();
+	return context_name == other_data.context_name && sql_statement == other_data.sql_statement;
+}
+
+unique_ptr<FunctionData> MSSQLExecuteBind(ClientContext &context, TableFunctionBindInput &input,
+                                          vector<LogicalType> &return_types, vector<string> &names) {
+	// Extract arguments
+	if (input.inputs.size() != 2) {
+		throw InvalidInputException("MSSQL Error: mssql_execute requires 2 arguments: context_name and sql_statement");
+	}
+
+	auto bind_data = make_uniq<MSSQLExecuteBindData>();
+	bind_data->context_name = input.inputs[0].GetValue<string>();
+	bind_data->sql_statement = input.inputs[1].GetValue<string>();
+
+	// Validate context exists
+	auto &manager = MSSQLContextManager::Get(*context.db);
+	if (!manager.HasContext(bind_data->context_name)) {
+		throw InvalidInputException(
+		    "MSSQL Error: Unknown context '%s'. Attach a database first with: ATTACH '' AS %s TYPE mssql (SECRET ...)",
+		    bind_data->context_name, bind_data->context_name);
+	}
+
+	// Set return schema
+	return_types.push_back(LogicalType::BOOLEAN);
+	names.push_back("success");
+	return_types.push_back(LogicalType::BIGINT);
+	names.push_back("affected_rows");
+	return_types.push_back(LogicalType::VARCHAR);
+	names.push_back("message");
+
+	return std::move(bind_data);
+}
+
+unique_ptr<GlobalTableFunctionState> MSSQLExecuteInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<MSSQLExecuteGlobalState>();
+}
+
+void MSSQLExecuteFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+	auto &global_state = data.global_state->Cast<MSSQLExecuteGlobalState>();
+
+	if (global_state.done) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	// For stub implementation, return success with 1 affected row
+	output.SetCardinality(1);
+
+	// success = true
+	auto &success_vec = output.data[0];
+	FlatVector::GetData<bool>(success_vec)[0] = true;
+
+	// affected_rows = 1
+	auto &rows_vec = output.data[1];
+	FlatVector::GetData<int64_t>(rows_vec)[0] = 1;
+
+	// message
+	auto &message_vec = output.data[2];
+	FlatVector::GetData<string_t>(message_vec)[0] = StringVector::AddString(message_vec, "Query executed successfully (stub)");
+
+	global_state.done = true;
+}
+
+//===----------------------------------------------------------------------===//
+// mssql_scan implementation
+//===----------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> MSSQLScanBindData::Copy() const {
+	auto result = make_uniq<MSSQLScanBindData>();
+	result->context_name = context_name;
+	result->query = query;
+	result->return_types = return_types;
+	result->column_names = column_names;
+	return std::move(result);
+}
+
+bool MSSQLScanBindData::Equals(const FunctionData &other) const {
+	auto &other_data = other.Cast<MSSQLScanBindData>();
+	return context_name == other_data.context_name && query == other_data.query;
+}
+
+idx_t MSSQLScanGlobalState::MaxThreads() const {
+	// Single-threaded for stub implementation
+	return 1;
+}
+
+unique_ptr<FunctionData> MSSQLScanBind(ClientContext &context, TableFunctionBindInput &input,
+                                       vector<LogicalType> &return_types, vector<string> &names) {
+	// Extract arguments
+	if (input.inputs.size() != 2) {
+		throw InvalidInputException("MSSQL Error: mssql_scan requires 2 arguments: context_name and query");
+	}
+
+	auto bind_data = make_uniq<MSSQLScanBindData>();
+	bind_data->context_name = input.inputs[0].GetValue<string>();
+	bind_data->query = input.inputs[1].GetValue<string>();
+
+	// Validate context exists
+	auto &manager = MSSQLContextManager::Get(*context.db);
+	if (!manager.HasContext(bind_data->context_name)) {
+		throw InvalidInputException(
+		    "MSSQL Error: Unknown context '%s'. Attach a database first with: ATTACH '' AS %s TYPE mssql (SECRET ...)",
+		    bind_data->context_name, bind_data->context_name);
+	}
+
+	// For stub implementation, return fixed schema: id INTEGER, name VARCHAR
+	return_types.push_back(LogicalType::INTEGER);
+	names.push_back("id");
+	return_types.push_back(LogicalType::VARCHAR);
+	names.push_back("name");
+
+	bind_data->return_types = return_types;
+	bind_data->column_names = names;
+
+	return std::move(bind_data);
+}
+
+unique_ptr<GlobalTableFunctionState> MSSQLScanInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<MSSQLScanGlobalState>();
+	result->total_rows = 3;  // Stub returns 3 rows
+	result->rows_returned = 0;
+	return std::move(result);
+}
+
+unique_ptr<LocalTableFunctionState> MSSQLScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                       GlobalTableFunctionState *global_state) {
+	auto result = make_uniq<MSSQLScanLocalState>();
+	result->current_row = 0;
+	return std::move(result);
+}
+
+void MSSQLScanFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+	auto &global_state = data.global_state->Cast<MSSQLScanGlobalState>();
+	auto &local_state = data.local_state->Cast<MSSQLScanLocalState>();
+
+	// Check if we're done
+	idx_t remaining = global_state.total_rows - local_state.current_row;
+	if (remaining == 0) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	// Output all remaining rows (up to STANDARD_VECTOR_SIZE)
+	idx_t to_output = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+	output.SetCardinality(to_output);
+
+	auto &id_vec = output.data[0];
+	auto &name_vec = output.data[1];
+
+	for (idx_t i = 0; i < to_output; i++) {
+		idx_t row_idx = local_state.current_row + i + 1;  // 1-based
+
+		// id column
+		FlatVector::GetData<int32_t>(id_vec)[i] = static_cast<int32_t>(row_idx);
+
+		// name column
+		string name_val = StringUtil::Format("Name %llu", row_idx);
+		FlatVector::GetData<string_t>(name_vec)[i] = StringVector::AddString(name_vec, name_val);
+	}
+
+	local_state.current_row += to_output;
+	global_state.rows_returned += to_output;
+}
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+void RegisterMSSQLFunctions(ExtensionLoader &loader) {
+	// mssql_execute(context_name VARCHAR, sql_statement VARCHAR)
+	// -> (success BOOLEAN, affected_rows BIGINT, message VARCHAR)
+	TableFunction mssql_execute("mssql_execute", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MSSQLExecuteFunction,
+	                            MSSQLExecuteBind, MSSQLExecuteInitGlobal);
+	loader.RegisterFunction(mssql_execute);
+
+	// mssql_scan(context_name VARCHAR, query VARCHAR)
+	// -> (id INTEGER, name VARCHAR) for stub
+	TableFunction mssql_scan("mssql_scan", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MSSQLScanFunction,
+	                         MSSQLScanBind, MSSQLScanInitGlobal, MSSQLScanInitLocal);
+	loader.RegisterFunction(mssql_scan);
+}
+
+}  // namespace duckdb

--- a/src/mssql_secret.cpp
+++ b/src/mssql_secret.cpp
@@ -1,0 +1,114 @@
+#include "mssql_secret.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/secret/secret.hpp"
+
+namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// Validation
+//===----------------------------------------------------------------------===//
+
+string ValidateMSSQLSecretFields(const CreateSecretInput &input) {
+	// Check required string fields
+	const char *required_string_fields[] = {MSSQL_SECRET_HOST, MSSQL_SECRET_DATABASE, MSSQL_SECRET_USER,
+	                                        MSSQL_SECRET_PASSWORD};
+
+	for (auto field : required_string_fields) {
+		auto it = input.options.find(field);
+		if (it == input.options.end()) {
+			return StringUtil::Format("Missing required field '%s'. Provide %s parameter when creating secret.", field,
+			                          field);
+		}
+		auto str_val = it->second.ToString();
+		if (str_val.empty()) {
+			return StringUtil::Format("Field '%s' cannot be empty.", field);
+		}
+	}
+
+	// Check port field
+	auto port_it = input.options.find(MSSQL_SECRET_PORT);
+	if (port_it == input.options.end()) {
+		return "Missing required field 'port'. Provide port parameter when creating secret.";
+	}
+
+	// Validate port range
+	int64_t port_value;
+	try {
+		port_value = port_it->second.GetValue<int64_t>();
+	} catch (...) {
+		return StringUtil::Format("Port must be a valid integer. Got: %s", port_it->second.ToString());
+	}
+
+	if (port_value < 1 || port_value > 65535) {
+		return StringUtil::Format("Port must be between 1 and 65535. Got: %lld", port_value);
+	}
+
+	return "";  // Valid
+}
+
+//===----------------------------------------------------------------------===//
+// Secret creation
+//===----------------------------------------------------------------------===//
+
+unique_ptr<BaseSecret> CreateMSSQLSecretFromConfig(ClientContext &context, CreateSecretInput &input) {
+	// Validate all fields
+	string error = ValidateMSSQLSecretFields(input);
+	if (!error.empty()) {
+		throw InvalidInputException("MSSQL Error: %s", error);
+	}
+
+	// Create KeyValueSecret with all fields
+	auto scope = input.scope;
+	auto result = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
+
+	// Copy all values to the secret (TrySetValue looks up the key from input.options)
+	result->TrySetValue(MSSQL_SECRET_HOST, input);
+	result->TrySetValue(MSSQL_SECRET_PORT, input);
+	result->TrySetValue(MSSQL_SECRET_DATABASE, input);
+	result->TrySetValue(MSSQL_SECRET_USER, input);
+	result->TrySetValue(MSSQL_SECRET_PASSWORD, input);
+
+	// Handle optional use_ssl parameter (defaults to false if not provided)
+	auto use_ssl_it = input.options.find(MSSQL_SECRET_USE_SSL);
+	if (use_ssl_it != input.options.end()) {
+		result->TrySetValue(MSSQL_SECRET_USE_SSL, input);
+	} else {
+		// Set default value of false
+		result->secret_map[MSSQL_SECRET_USE_SSL] = Value::BOOLEAN(false);
+	}
+
+	// Mark password as redacted (hidden in duckdb_secrets() output)
+	result->redact_keys.insert(MSSQL_SECRET_PASSWORD);
+
+	return std::move(result);
+}
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+void RegisterMSSQLSecretType(ExtensionLoader &loader) {
+	// Register secret type
+	SecretType mssql_type;
+	mssql_type.name = "mssql";
+	mssql_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+	mssql_type.default_provider = "config";
+
+	loader.RegisterSecretType(mssql_type);
+
+	// Register creation function with named parameters
+	CreateSecretFunction create_func;
+	create_func.secret_type = "mssql";
+	create_func.provider = "config";
+	create_func.function = CreateMSSQLSecretFromConfig;
+	create_func.named_parameters[MSSQL_SECRET_HOST] = LogicalType::VARCHAR;
+	create_func.named_parameters[MSSQL_SECRET_PORT] = LogicalType::INTEGER;
+	create_func.named_parameters[MSSQL_SECRET_DATABASE] = LogicalType::VARCHAR;
+	create_func.named_parameters[MSSQL_SECRET_USER] = LogicalType::VARCHAR;
+	create_func.named_parameters[MSSQL_SECRET_PASSWORD] = LogicalType::VARCHAR;
+	create_func.named_parameters[MSSQL_SECRET_USE_SSL] = LogicalType::BOOLEAN;  // Optional
+
+	loader.RegisterFunction(std::move(create_func));
+}
+
+}  // namespace duckdb

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1,0 +1,340 @@
+#include "mssql_storage.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/transaction/transaction_manager.hpp"
+
+namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// MSSQLConnectionInfo implementation
+//===----------------------------------------------------------------------===//
+
+shared_ptr<MSSQLConnectionInfo> MSSQLConnectionInfo::FromSecret(ClientContext &context, const string &secret_name) {
+	auto &secret_manager = SecretManager::Get(context);
+
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name);
+	if (!secret_entry) {
+		throw BinderException("MSSQL Error: Secret '%s' not found. Create it first with: CREATE SECRET %s (TYPE "
+		                      "mssql, host '...', port ..., database '...', user '...', password '...')",
+		                      secret_name, secret_name);
+	}
+
+	auto &secret = secret_entry->secret;
+	if (secret->GetType() != "mssql") {
+		throw BinderException("MSSQL Error: Secret '%s' is not of type 'mssql'. Got type: '%s'", secret_name,
+		                      secret->GetType());
+	}
+
+	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret);
+
+	auto result = make_shared_ptr<MSSQLConnectionInfo>();
+	result->host = kv_secret.TryGetValue("host").ToString();
+	result->port = static_cast<uint16_t>(kv_secret.TryGetValue("port").GetValue<int32_t>());
+	result->database = kv_secret.TryGetValue("database").ToString();
+	result->user = kv_secret.TryGetValue("user").ToString();
+	result->password = kv_secret.TryGetValue("password").ToString();
+
+	// Read optional use_ssl (defaults to false)
+	auto use_ssl_val = kv_secret.TryGetValue("use_ssl");
+	if (!use_ssl_val.IsNull()) {
+		result->use_ssl = use_ssl_val.GetValue<bool>();
+	} else {
+		result->use_ssl = false;
+	}
+
+	result->connected = false;
+	return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Connection String Parsing
+//===----------------------------------------------------------------------===//
+
+// Parse key=value pairs from connection string
+// Format: "Server=host,port;Database=db;User Id=user;Password=pass;Encrypt=yes/no"
+static case_insensitive_map_t<string> ParseConnectionString(const string &connection_string) {
+	case_insensitive_map_t<string> result;
+
+	// Split by semicolon
+	auto parts = StringUtil::Split(connection_string, ';');
+	for (auto &part : parts) {
+		// Trim whitespace (Trim modifies in place)
+		string trimmed = part;
+		StringUtil::Trim(trimmed);
+		if (trimmed.empty()) {
+			continue;
+		}
+
+		// Split by first '='
+		auto eq_pos = trimmed.find('=');
+		if (eq_pos == string::npos) {
+			continue;  // Skip invalid parts
+		}
+
+		string key = trimmed.substr(0, eq_pos);
+		string value = trimmed.substr(eq_pos + 1);
+		StringUtil::Trim(key);
+		StringUtil::Trim(value);
+
+		// Normalize key names
+		auto lower_key = StringUtil::Lower(key);
+		if (lower_key == "server" || lower_key == "data source") {
+			result["server"] = value;
+		} else if (lower_key == "database" || lower_key == "initial catalog") {
+			result["database"] = value;
+		} else if (lower_key == "user id" || lower_key == "uid" || lower_key == "user") {
+			result["user"] = value;
+		} else if (lower_key == "password" || lower_key == "pwd") {
+			result["password"] = value;
+		} else if (lower_key == "encrypt" || lower_key == "use encryption for data") {
+			result["encrypt"] = value;
+		} else {
+			result[key] = value;
+		}
+	}
+
+	return result;
+}
+
+string MSSQLConnectionInfo::ValidateConnectionString(const string &connection_string) {
+	if (connection_string.empty()) {
+		return "Connection string cannot be empty.";
+	}
+
+	auto params = ParseConnectionString(connection_string);
+
+	// Check required fields
+	if (params.find("server") == params.end()) {
+		return "Missing 'Server' in connection string. Format: Server=host,port;Database=...;User Id=...;Password=...";
+	}
+	if (params.find("database") == params.end()) {
+		return "Missing 'Database' in connection string.";
+	}
+	if (params.find("user") == params.end()) {
+		return "Missing 'User Id' in connection string.";
+	}
+	if (params.find("password") == params.end()) {
+		return "Missing 'Password' in connection string.";
+	}
+
+	// Validate server format (host or host,port)
+	auto server = params["server"];
+	auto comma_pos = server.find(',');
+	if (comma_pos != string::npos) {
+		auto port_str = server.substr(comma_pos + 1);
+		try {
+			int port = std::stoi(port_str);
+			if (port < 1 || port > 65535) {
+				return StringUtil::Format("Port must be between 1 and 65535. Got: %d", port);
+			}
+		} catch (...) {
+			return StringUtil::Format("Invalid port in Server parameter: '%s'", port_str);
+		}
+	}
+
+	return "";  // Valid
+}
+
+shared_ptr<MSSQLConnectionInfo> MSSQLConnectionInfo::FromConnectionString(const string &connection_string) {
+	// Validate first
+	string error = ValidateConnectionString(connection_string);
+	if (!error.empty()) {
+		throw InvalidInputException("MSSQL Error: %s", error);
+	}
+
+	auto params = ParseConnectionString(connection_string);
+	auto result = make_shared_ptr<MSSQLConnectionInfo>();
+
+	// Parse server (host,port or just host)
+	auto server = params["server"];
+	auto comma_pos = server.find(',');
+	if (comma_pos != string::npos) {
+		result->host = server.substr(0, comma_pos);
+		result->port = static_cast<uint16_t>(std::stoi(server.substr(comma_pos + 1)));
+	} else {
+		result->host = server;
+		result->port = 1433;  // Default MSSQL port
+	}
+
+	result->database = params["database"];
+	result->user = params["user"];
+	result->password = params["password"];
+
+	// Parse optional encrypt/use_ssl
+	if (params.find("encrypt") != params.end()) {
+		auto encrypt_val = StringUtil::Lower(params["encrypt"]);
+		result->use_ssl = (encrypt_val == "yes" || encrypt_val == "true" || encrypt_val == "1");
+	} else {
+		result->use_ssl = false;
+	}
+
+	result->connected = false;
+	return result;
+}
+
+//===----------------------------------------------------------------------===//
+// MSSQLContext implementation
+//===----------------------------------------------------------------------===//
+
+MSSQLContext::MSSQLContext(const string &name, const string &secret_name) : name(name), secret_name(secret_name) {
+}
+
+//===----------------------------------------------------------------------===//
+// MSSQLContextManager implementation
+//===----------------------------------------------------------------------===//
+
+// Static storage for context managers - keyed by DatabaseInstance pointer
+static case_insensitive_map_t<unique_ptr<MSSQLContextManager>> g_context_managers;
+static mutex g_context_managers_lock;
+
+MSSQLContextManager &MSSQLContextManager::Get(DatabaseInstance &db) {
+	lock_guard<mutex> guard(g_context_managers_lock);
+
+	// Use pointer address as unique key - cast to size_t for formatting
+	string db_key = StringUtil::Format("%llu", (unsigned long long)(uintptr_t)&db);
+
+	auto it = g_context_managers.find(db_key);
+	if (it == g_context_managers.end()) {
+		auto manager = make_uniq<MSSQLContextManager>();
+		auto &manager_ref = *manager;
+		g_context_managers[db_key] = std::move(manager);
+		return manager_ref;
+	}
+	return *it->second;
+}
+
+void MSSQLContextManager::RegisterContext(const string &name, shared_ptr<MSSQLContext> ctx) {
+	lock_guard<mutex> guard(lock);
+	if (contexts.find(name) != contexts.end()) {
+		throw CatalogException("MSSQL Error: Context '%s' already exists. Use a different name or DETACH first.", name);
+	}
+	contexts[name] = std::move(ctx);
+}
+
+void MSSQLContextManager::UnregisterContext(const string &name) {
+	lock_guard<mutex> guard(lock);
+	auto it = contexts.find(name);
+	if (it != contexts.end()) {
+		// Clean up: abort any in-progress queries, close connection
+		// For stub implementation, just remove from map
+		contexts.erase(it);
+	}
+}
+
+shared_ptr<MSSQLContext> MSSQLContextManager::GetContext(const string &name) {
+	lock_guard<mutex> guard(lock);
+	auto it = contexts.find(name);
+	if (it == contexts.end()) {
+		return nullptr;
+	}
+	return it->second;
+}
+
+bool MSSQLContextManager::HasContext(const string &name) {
+	lock_guard<mutex> guard(lock);
+	return contexts.find(name) != contexts.end();
+}
+
+vector<string> MSSQLContextManager::ListContexts() {
+	lock_guard<mutex> guard(lock);
+	vector<string> result;
+	for (auto &entry : contexts) {
+		result.push_back(entry.first);
+	}
+	return result;
+}
+
+//===----------------------------------------------------------------------===//
+// MSSQLCatalog implementation
+//===----------------------------------------------------------------------===//
+
+MSSQLCatalog::MSSQLCatalog(AttachedDatabase &db, const string &context_name)
+    : DuckCatalog(db), context_name(context_name) {
+}
+
+void MSSQLCatalog::OnDetach(ClientContext &context) {
+	// Unregister context from the manager
+	auto &manager = MSSQLContextManager::Get(*context.db);
+	manager.UnregisterContext(context_name);
+
+	// Call parent implementation
+	DuckCatalog::OnDetach(context);
+}
+
+//===----------------------------------------------------------------------===//
+// Storage Extension callbacks
+//===----------------------------------------------------------------------===//
+
+unique_ptr<Catalog> MSSQLAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
+                                AttachedDatabase &db, const string &name, AttachInfo &info, AttachOptions &options) {
+	// Extract SECRET parameter (optional if connection string is provided)
+	string secret_name;
+	for (auto &entry : options.options) {
+		auto lower_name = StringUtil::Lower(entry.first);
+		if (lower_name == "secret") {
+			secret_name = entry.second.ToString();
+		}
+	}
+
+	// Get connection string from info.path (the first argument to ATTACH)
+	string connection_string = info.path;
+
+	// Create context based on whether SECRET or connection string is provided
+	auto ctx = make_shared_ptr<MSSQLContext>(name, secret_name);
+	ctx->attached_db = &db;
+
+	if (!secret_name.empty()) {
+		// SECRET provided - use secret-based connection
+		ctx->connection_info = MSSQLConnectionInfo::FromSecret(context, secret_name);
+	} else if (!connection_string.empty()) {
+		// Connection string provided - parse it
+		ctx->connection_info = MSSQLConnectionInfo::FromConnectionString(connection_string);
+	} else {
+		// Neither SECRET nor connection string provided
+		throw InvalidInputException(
+		    "MSSQL Error: Either SECRET or connection string is required for ATTACH.\n"
+		    "With secret: ATTACH '' AS %s (TYPE mssql, SECRET <secret_name>)\n"
+		    "With connection string: ATTACH 'Server=host;Database=db;User Id=user;Password=pass' AS %s (TYPE mssql)",
+		    name, name);
+	}
+
+	// Register context
+	auto &manager = MSSQLContextManager::Get(*context.db);
+	manager.RegisterContext(name, ctx);
+
+	// Create MSSQLCatalog that will clean up the context on detach
+	auto catalog = make_uniq<MSSQLCatalog>(db, name);
+	catalog->Initialize(false);
+
+	return std::move(catalog);
+}
+
+unique_ptr<TransactionManager> MSSQLCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
+                                                             AttachedDatabase &db, Catalog &catalog) {
+	// Use DuckDB's standard transaction manager
+	return make_uniq<DuckTransactionManager>(db);
+}
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+void RegisterMSSQLStorageExtension(ExtensionLoader &loader) {
+	auto &db = loader.GetDatabaseInstance();
+	auto &config = DBConfig::GetConfig(db);
+
+	auto storage_ext = make_uniq<StorageExtension>();
+	storage_ext->attach = MSSQLAttach;
+	storage_ext->create_transaction_manager = MSSQLCreateTransactionManager;
+
+	config.storage_extensions["mssql"] = std::move(storage_ext);
+}
+
+}  // namespace duckdb

--- a/test/sql/mssql_attach.test
+++ b/test/sql/mssql_attach.test
@@ -1,0 +1,112 @@
+# name: test/sql/mssql_attach.test
+# description: Test MSSQL database attach and detach
+# group: [mssql]
+
+require mssql
+
+# First create a secret that we'll use for attachment
+statement ok
+CREATE SECRET attach_test_secret (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+# T019: Test successful attach with valid secret
+statement ok
+ATTACH '' AS mydb (TYPE mssql, SECRET attach_test_secret);
+
+# T024: Test successful detach
+statement ok
+DETACH mydb;
+
+# T020: Test attach without secret or connection string (should fail)
+statement error
+ATTACH '' AS no_secret_db (TYPE mssql);
+----
+Either SECRET or connection string is required
+
+# T021: Test attach with non-existent secret (should fail)
+statement error
+ATTACH '' AS bad_secret_db (TYPE mssql, SECRET nonexistent_secret);
+----
+not found
+
+# T025: Test detach non-existent context (should fail)
+# Note: DuckDB handles this error internally
+statement error
+DETACH nonexistent_db;
+----
+not found
+
+# Test re-attach after detach
+statement ok
+ATTACH '' AS mydb (TYPE mssql, SECRET attach_test_secret);
+
+statement ok
+DETACH mydb;
+
+# Clean up
+statement ok
+DROP SECRET attach_test_secret;
+
+# Test attach with connection string (no secret)
+statement ok
+ATTACH 'Server=localhost,1433;Database=testdb;User Id=testuser;Password=testpass' AS conn_str_db (TYPE mssql);
+
+statement ok
+DETACH conn_str_db;
+
+# Test attach with connection string (default port)
+statement ok
+ATTACH 'Server=localhost;Database=testdb;User Id=testuser;Password=testpass' AS conn_str_default_port (TYPE mssql);
+
+statement ok
+DETACH conn_str_default_port;
+
+# Test attach with connection string using alternative key names
+statement ok
+ATTACH 'Data Source=localhost;Initial Catalog=testdb;UID=testuser;PWD=testpass' AS conn_str_alt_keys (TYPE mssql);
+
+statement ok
+DETACH conn_str_alt_keys;
+
+# Test attach with connection string with SSL enabled
+statement ok
+ATTACH 'Server=localhost;Database=testdb;User Id=testuser;Password=testpass;Encrypt=yes' AS conn_str_ssl (TYPE mssql);
+
+statement ok
+DETACH conn_str_ssl;
+
+# Test attach with invalid connection string - missing Server
+statement error
+ATTACH 'Database=testdb;User Id=testuser;Password=testpass' AS invalid_conn_str (TYPE mssql);
+----
+Missing 'Server' in connection string
+
+# Test attach with invalid connection string - missing Database
+statement error
+ATTACH 'Server=localhost;User Id=testuser;Password=testpass' AS invalid_conn_str2 (TYPE mssql);
+----
+Missing 'Database' in connection string
+
+# Test attach with invalid connection string - missing User Id
+statement error
+ATTACH 'Server=localhost;Database=testdb;Password=testpass' AS invalid_conn_str3 (TYPE mssql);
+----
+Missing 'User Id' in connection string
+
+# Test attach with invalid connection string - missing Password
+statement error
+ATTACH 'Server=localhost;Database=testdb;User Id=testuser' AS invalid_conn_str4 (TYPE mssql);
+----
+Missing 'Password' in connection string
+
+# Test attach with invalid port in connection string
+statement error
+ATTACH 'Server=localhost,99999;Database=testdb;User Id=testuser;Password=testpass' AS invalid_port_conn (TYPE mssql);
+----
+Port must be between 1 and 65535

--- a/test/sql/mssql_execute.test
+++ b/test/sql/mssql_execute.test
@@ -1,0 +1,69 @@
+# name: test/sql/mssql_execute.test
+# description: Test mssql_execute table function
+# group: [mssql]
+
+require mssql
+
+# Setup: create secret and attach database
+statement ok
+CREATE SECRET exec_test_secret (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+statement ok
+ATTACH '' AS execdb (TYPE mssql, SECRET exec_test_secret);
+
+# T031: Test mssql_execute with valid context
+query III
+SELECT * FROM mssql_execute('execdb', 'SELECT 1');
+----
+true	1	Query executed successfully (stub)
+
+# T032: Test mssql_execute with invalid context (should fail)
+statement error
+SELECT * FROM mssql_execute('nonexistent_context', 'SELECT 1');
+----
+Unknown context 'nonexistent_context'
+
+# T033: Test return schema (success BOOLEAN, affected_rows BIGINT, message VARCHAR)
+query III
+SELECT typeof(success), typeof(affected_rows), typeof(message)
+FROM mssql_execute('execdb', 'UPDATE table SET x = 1');
+----
+BOOLEAN	BIGINT	VARCHAR
+
+# Test that result has exactly 1 row
+query I
+SELECT COUNT(*) FROM mssql_execute('execdb', 'DELETE FROM table');
+----
+1
+
+# Test success value is true in stub mode
+query I
+SELECT success FROM mssql_execute('execdb', 'CREATE TABLE test (id INT)');
+----
+true
+
+# Test affected_rows is 1 in stub mode
+query I
+SELECT affected_rows FROM mssql_execute('execdb', 'INSERT INTO table VALUES (1)');
+----
+1
+
+# Test message content
+query I
+SELECT message LIKE '%stub%' FROM mssql_execute('execdb', 'TRUNCATE TABLE test');
+----
+true
+
+# Cleanup
+statement ok
+DETACH execdb;
+
+statement ok
+DROP SECRET exec_test_secret;

--- a/test/sql/mssql_scan.test
+++ b/test/sql/mssql_scan.test
@@ -1,0 +1,91 @@
+# name: test/sql/mssql_scan.test
+# description: Test mssql_scan table function
+# group: [mssql]
+
+require mssql
+
+# Setup: create secret and attach database
+statement ok
+CREATE SECRET scan_test_secret (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+statement ok
+ATTACH '' AS scandb (TYPE mssql, SECRET scan_test_secret);
+
+# T041: Test mssql_scan with valid context
+query II
+SELECT * FROM mssql_scan('scandb', 'SELECT id, name FROM users');
+----
+1	Name 1
+2	Name 2
+3	Name 3
+
+# T042: Test mssql_scan with invalid context (should fail)
+statement error
+SELECT * FROM mssql_scan('nonexistent_context', 'SELECT * FROM users');
+----
+Unknown context 'nonexistent_context'
+
+# T043: Test exactly 3 rows returned with correct schema
+query I
+SELECT COUNT(*) FROM mssql_scan('scandb', 'SELECT * FROM any_table');
+----
+3
+
+# Verify column types (id INTEGER, name VARCHAR)
+query II
+SELECT typeof(id), typeof(name) FROM mssql_scan('scandb', 'SELECT id, name FROM test');
+----
+INTEGER	VARCHAR
+INTEGER	VARCHAR
+INTEGER	VARCHAR
+
+# Verify column names
+query II
+SELECT id, name FROM mssql_scan('scandb', 'SELECT * FROM test') WHERE id = 1;
+----
+1	Name 1
+
+# Test filtering works on stub data
+query II
+SELECT * FROM mssql_scan('scandb', 'SELECT * FROM test') WHERE id > 1;
+----
+2	Name 2
+3	Name 3
+
+# Test ordering works on stub data
+query II
+SELECT * FROM mssql_scan('scandb', 'SELECT * FROM test') ORDER BY id DESC;
+----
+3	Name 3
+2	Name 2
+1	Name 1
+
+# Test joining with local data
+statement ok
+CREATE TABLE local_data AS SELECT 1 AS user_id, 'extra' AS info UNION SELECT 2, 'more';
+
+query III
+SELECT s.id, s.name, l.info
+FROM mssql_scan('scandb', 'SELECT id, name FROM users') s
+JOIN local_data l ON s.id = l.user_id
+ORDER BY s.id;
+----
+1	Name 1	extra
+2	Name 2	more
+
+statement ok
+DROP TABLE local_data;
+
+# Cleanup
+statement ok
+DETACH scandb;
+
+statement ok
+DROP SECRET scan_test_secret;

--- a/test/sql/mssql_secret.test
+++ b/test/sql/mssql_secret.test
@@ -1,0 +1,223 @@
+# name: test/sql/mssql_secret.test
+# description: Test MSSQL secret creation and validation
+# group: [mssql]
+
+require mssql
+
+# T010: Test secret creation with valid parameters
+statement ok
+CREATE SECRET test_secret (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+# Verify secret exists
+query I
+SELECT COUNT(*) FROM duckdb_secrets() WHERE type = 'mssql' AND name = 'test_secret';
+----
+1
+
+# Clean up
+statement ok
+DROP SECRET test_secret;
+
+# T011: Test missing required field - host
+statement error
+CREATE SECRET missing_host (
+    TYPE mssql,
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+----
+Missing required field 'host'
+
+# T011: Test missing required field - port
+statement error
+CREATE SECRET missing_port (
+    TYPE mssql,
+    host 'localhost',
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+----
+Missing required field 'port'
+
+# T011: Test missing required field - database
+statement error
+CREATE SECRET missing_database (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    user 'testuser',
+    password 'testpass'
+);
+----
+Missing required field 'database'
+
+# T011: Test missing required field - user
+statement error
+CREATE SECRET missing_user (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    password 'testpass'
+);
+----
+Missing required field 'user'
+
+# T011: Test missing required field - password
+statement error
+CREATE SECRET missing_password (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser'
+);
+----
+Missing required field 'password'
+
+# T012: Test invalid port number - 0
+statement error
+CREATE SECRET invalid_port_zero (
+    TYPE mssql,
+    host 'localhost',
+    port 0,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+----
+Port must be between 1 and 65535
+
+# T012: Test invalid port number - negative
+statement error
+CREATE SECRET invalid_port_negative (
+    TYPE mssql,
+    host 'localhost',
+    port -1,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+----
+Port must be between 1 and 65535
+
+# T012: Test invalid port number - too large
+statement error
+CREATE SECRET invalid_port_large (
+    TYPE mssql,
+    host 'localhost',
+    port 65536,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+----
+Port must be between 1 and 65535
+
+# T013: Test password redaction in duckdb_secrets() output
+statement ok
+CREATE SECRET redacted_test (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'supersecret'
+);
+
+# Verify password is redacted (should not contain 'supersecret')
+query I
+SELECT secret_string NOT LIKE '%supersecret%' FROM duckdb_secrets() WHERE name = 'redacted_test';
+----
+true
+
+# Clean up
+statement ok
+DROP SECRET redacted_test;
+
+# Test valid port boundaries
+statement ok
+CREATE SECRET port_min (
+    TYPE mssql,
+    host 'localhost',
+    port 1,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+statement ok
+DROP SECRET port_min;
+
+statement ok
+CREATE SECRET port_max (
+    TYPE mssql,
+    host 'localhost',
+    port 65535,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+statement ok
+DROP SECRET port_max;
+
+# Test use_ssl parameter (optional)
+statement ok
+CREATE SECRET ssl_enabled (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass',
+    use_ssl true
+);
+
+# Verify secret exists with SSL enabled
+query I
+SELECT COUNT(*) FROM duckdb_secrets() WHERE type = 'mssql' AND name = 'ssl_enabled';
+----
+1
+
+statement ok
+DROP SECRET ssl_enabled;
+
+# Test use_ssl set to false explicitly
+statement ok
+CREATE SECRET ssl_disabled (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass',
+    use_ssl false
+);
+
+statement ok
+DROP SECRET ssl_disabled;
+
+# Test without use_ssl (should default to false)
+statement ok
+CREATE SECRET ssl_default (
+    TYPE mssql,
+    host 'localhost',
+    port 1433,
+    database 'testdb',
+    user 'testuser',
+    password 'testpass'
+);
+
+statement ok
+DROP SECRET ssl_default;


### PR DESCRIPTION
## Summary

- Add complete MSSQL extension public interface with stub implementations
- Implement secret management with `CREATE SECRET TYPE mssql` (host, port, database, user, password, use_ssl)
- Add database attachment via `ATTACH ... (TYPE mssql, SECRET ...)` or connection string
- Implement `mssql_execute` and `mssql_scan` table functions
- Add proper context cleanup on DETACH via custom MSSQLCatalog

## Features

### Secret Management
- All 5 required fields validated (host, port, database, user, password)
- Optional `use_ssl` parameter for SSL/TLS connections
- Password redaction in `duckdb_secrets()` output
- Port validation (1-65535)

### Database Attachment
- Attach with SECRET reference: `ATTACH '' AS db (TYPE mssql, SECRET secret_name)`
- Attach with connection string: `ATTACH 'Server=...;Database=...;User Id=...;Password=...' AS db (TYPE mssql)`
- Connection string key aliases supported (Data Source, Initial Catalog, UID, PWD, Encrypt)
- Lazy connection establishment (no network until data access)

### Table Functions
- `mssql_execute(context, sql)` → returns (success BOOLEAN, affected_rows BIGINT, message VARCHAR)
- `mssql_scan(context, query)` → returns relation with stub data (3 sample rows)

## Test plan

- [x] All 103 SQL test assertions pass
- [x] Full test suite passes (948,695 assertions)
- [x] Manual verification of all features
- [x] Acceptance checklist from quickstart.md verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)