### PR TITLE
ci: Fix smoke test extension filename for DuckDB loading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,19 +305,25 @@ jobs:
         if: matrix.platform.os != 'windows'
         run: chmod +x cli/duckdb
 
+      - name: Rename extension for loading
+        shell: bash
+        run: |
+          # DuckDB derives extension name from filename - must be named mssql.duckdb_extension
+          VERSIONED_FILE="extension/mssql-${{ steps.version.outputs.ext_version }}-duckdb-${{ matrix.duckdb_version }}-${{ matrix.platform.id }}.duckdb_extension"
+          mv "$VERSIONED_FILE" extension/mssql.duckdb_extension
+          ls -la extension/
+
       - name: Run load-only smoke test (Unix)
         if: matrix.platform.os != 'windows'
         run: |
           chmod +x scripts/ci/smoke_test.sh
-          EXTENSION_FILE="extension/mssql-${{ steps.version.outputs.ext_version }}-duckdb-${{ matrix.duckdb_version }}-${{ matrix.platform.id }}.duckdb_extension"
-          scripts/ci/smoke_test.sh ./cli/duckdb "$EXTENSION_FILE"
+          scripts/ci/smoke_test.sh ./cli/duckdb extension/mssql.duckdb_extension
 
       - name: Run load-only smoke test (Windows)
         if: matrix.platform.os == 'windows'
         shell: bash
         run: |
-          EXTENSION_FILE="extension/mssql-${{ steps.version.outputs.ext_version }}-duckdb-${{ matrix.duckdb_version }}-${{ matrix.platform.id }}.duckdb_extension"
-          ./cli/duckdb.exe --unsigned -c "LOAD '$EXTENSION_FILE'; SELECT mssql_version();"
+          ./cli/duckdb.exe --unsigned -c "LOAD 'extension/mssql.duckdb_extension'; SELECT mssql_version();"
 
       - name: Log integration test status
         if: matrix.platform.docker_available == false
@@ -391,6 +397,13 @@ jobs:
           chmod +x cli/duckdb
           chmod +x scripts/ci/integration_test.sh
 
+      - name: Rename extension for loading
+        run: |
+          # DuckDB derives extension name from filename - must be named mssql.duckdb_extension
+          VERSIONED_FILE="extension/mssql-${{ steps.version.outputs.ext_version }}-duckdb-${{ matrix.duckdb_version }}-${{ matrix.platform.id }}.duckdb_extension"
+          mv "$VERSIONED_FILE" extension/mssql.duckdb_extension
+          ls -la extension/
+
       - name: Wait for SQL Server
         run: |
           echo "Waiting for SQL Server to be ready..."
@@ -399,8 +412,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          EXTENSION_FILE="extension/mssql-${{ steps.version.outputs.ext_version }}-duckdb-${{ matrix.duckdb_version }}-${{ matrix.platform.id }}.duckdb_extension"
-          scripts/ci/integration_test.sh ./cli/duckdb "$EXTENSION_FILE"
+          scripts/ci/integration_test.sh ./cli/duckdb extension/mssql.duckdb_extension
 
   # ============================================================================
   # Release Job - Collect artifacts and publish to GitHub Release


### PR DESCRIPTION
## Summary
- Fix release workflow smoke tests failing due to incorrect extension filename
- DuckDB derives extension name from filename - versioned names like `mssql-0.1.0-duckdb-1.4.3-platform.duckdb_extension` caused DuckDB to look for wrong entrypoint function `mssql-0_duckdb_cpp_init`
- Add rename step in smoke test and integration test jobs to use `mssql.duckdb_extension`

## Test plan
- [ ] Trigger a new release tag to verify smoke tests pass
- [ ] Verify integration tests pass on Linux platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)