### PR TITLE
docs: Add DDL operation examples to README

### DIFF
--- a/specs/017-readme-ddl-examples/plan.md
+++ b/specs/017-readme-ddl-examples/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [single/web/mobile - determines source structure]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/017-readme-ddl-examples/spec.md
+++ b/specs/017-readme-ddl-examples/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: README DDL Examples
+
+**Feature Branch**: `017-readme-ddl-examples`
+**Created**: 2026-01-21
+**Status**: Complete
+**Input**: User description: "Add to the readme ddl operation examples (doc)"
+
+## Problem Statement
+
+The README documentation lacks examples of DDL (Data Definition Language) operations. Users need guidance on how to execute CREATE TABLE, ALTER TABLE, DROP TABLE, CREATE SCHEMA, and other DDL statements against SQL Server through the extension.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Add a dedicated DDL section to the README demonstrating common DDL operations
+- **FR-002**: Show examples using standard DuckDB DDL syntax for implemented operations (CREATE/DROP TABLE, CREATE/DROP SCHEMA, ALTER TABLE columns)
+- **FR-003**: Show examples using `mssql_exec()` for SQL Server-specific features (IDENTITY, constraints, indexes)
+
+## Success Criteria
+
+- **SC-001**: README contains clear DDL examples that users can copy and adapt
+- **SC-002**: Examples follow the existing README style and formatting
+- **SC-003**: Documentation accurately reflects what is implemented (spec 008) vs what requires mssql_exec()
+
+## Out of Scope
+
+- Code changes (documentation only)
+- New functionality

--- a/specs/017-readme-ddl-examples/tasks.md
+++ b/specs/017-readme-ddl-examples/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: README DDL Examples
+
+**Input**: Design documents from `/specs/017-readme-ddl-examples/`
+**Prerequisites**: spec.md (required)
+**Type**: Documentation only (no code changes)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Research (Understand What's Implemented)
+
+**Purpose**: Understand existing DDL implementation from spec 008 before writing documentation
+
+- [x] T001 Read spec 008 to understand DDL scope (what's IN vs OUT of scope) in specs/008-catalog-ddl-statistics/spec.md
+- [x] T002 [P] Review DDL translator implementation in src/catalog/mssql_ddl_translator.cpp
+- [x] T003 [P] Review existing README structure in README.md
+
+**Checkpoint**: Clear understanding of implemented vs mssql_exec-only operations
+
+---
+
+## Phase 2: User Story 1 - DDL Documentation Section (Priority: P1)
+
+**Goal**: Add comprehensive DDL examples to README that accurately reflect implemented functionality
+
+**Independent Test**: User can read README and understand how to use DuckDB DDL syntax vs mssql_exec() for various operations
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Add "DDL Operations" section introduction in README.md (line ~320)
+- [x] T005 [P] [US1] Add CREATE TABLE examples (DuckDB syntax + mssql_exec for IDENTITY/constraints) in README.md
+- [x] T006 [P] [US1] Add DROP TABLE examples in README.md
+- [x] T007 [P] [US1] Add ALTER TABLE examples (ADD/DROP/RENAME COLUMN) in README.md
+- [x] T008 [P] [US1] Add RENAME TABLE example in README.md
+- [x] T009 [P] [US1] Add CREATE/DROP SCHEMA examples in README.md
+- [x] T010 [US1] Add Indexes section (mssql_exec only, explain not implemented via DDL hooks) in README.md
+- [x] T011 [US1] Add note about mssql_refresh_cache() after mssql_exec DDL operations in README.md
+
+**Checkpoint**: README has complete DDL section with accurate examples
+
+---
+
+## Phase 3: Finalize
+
+**Purpose**: Commit and push documentation changes
+
+- [x] T012 Update spec.md status to Complete in specs/017-readme-ddl-examples/spec.md
+- [x] T013 Commit changes with descriptive message
+- [x] T014 Push branch to remote
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Research (Phase 1)**: No dependencies - understand before documenting
+- **User Story 1 (Phase 2)**: Depends on Research - write accurate docs
+- **Finalize (Phase 3)**: Depends on all documentation being complete
+
+### Parallel Opportunities
+
+- T002, T003 can run in parallel (reading different source files)
+- T005-T009 can run in parallel (different subsections, same file but non-overlapping)
+
+---
+
+## Implementation Strategy
+
+### Single Story MVP
+
+This feature has only one user story - add DDL documentation to README.
+
+1. Complete Phase 1: Research
+2. Complete Phase 2: Write documentation
+3. Complete Phase 3: Commit and push
+4. **DONE**: Create PR for review
+
+---
+
+## Completion Summary
+
+| Task | Status | Description |
+|------|--------|-------------|
+| T001-T003 | ✅ Complete | Research phase |
+| T004-T011 | ✅ Complete | Documentation written |
+| T012-T014 | ✅ Complete | Committed and pushed |
+
+**Total Tasks**: 14
+**Completed**: 14
+**Branch**: `017-readme-ddl-examples`
+**Commit**: `d07c94d` - "docs: Add DDL operation examples to README"
+
+---
+
+## Notes
+
+- This was a documentation-only feature with no code changes
+- All DDL examples accurately reflect spec 008 implementation:
+  - DuckDB DDL syntax: CREATE/DROP TABLE, CREATE/DROP SCHEMA, ALTER TABLE (columns), RENAME TABLE
+  - mssql_exec() required: Indexes, constraints, IDENTITY, IF EXISTS
+- Tasks marked [x] indicate completion (feature was implemented before task generation)


### PR DESCRIPTION
## Summary

- Add dedicated DDL Operations section to README documenting how to perform schema modifications
- Show standard DuckDB DDL syntax for implemented operations (CREATE/DROP TABLE, CREATE/DROP SCHEMA, ALTER TABLE columns, RENAME TABLE)
- Show `mssql_exec()` for SQL Server-specific features (IDENTITY, constraints, indexes)

## Changes

- **README.md**: Added DDL Operations section with comprehensive examples
- **specs/017-readme-ddl-examples/**: Feature specification and task tracking

## Documentation Coverage

| Operation | DuckDB Syntax | mssql_exec() |
|-----------|---------------|--------------|
| CREATE TABLE (basic) | ✅ | For IDENTITY, constraints |
| DROP TABLE | ✅ | For IF EXISTS |
| ALTER TABLE (columns) | ✅ | For constraints |
| RENAME TABLE | ✅ | - |
| CREATE/DROP SCHEMA | ✅ | - |
| Indexes | ❌ | ✅ Required |

## Test plan

- [x] Documentation accurately reflects spec 008 implementation
- [x] Examples follow existing README style
- [x] Clear distinction between DuckDB DDL and mssql_exec() usage

🤖 Generated with [Claude Code](https://claude.ai/code)