### PR TITLE
ci: drop cache:pip from pr-injection-scan workflow

### DIFF
--- a/.github/workflows/pr-injection-scan.yml
+++ b/.github/workflows/pr-injection-scan.yml
@@ -54,7 +54,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: pip
+          # No `cache: pip` -- that mode requires a requirements.txt or
+          # pyproject.toml in the repo, which we don't have. The one inline
+          # `pip install llm-guard` is cheap enough to repeat on each run.
 
       - name: Install llm-guard
         run: |


### PR DESCRIPTION
## Summary

Tiny fix for a workflow bug introduced in PR #100.

\`actions/setup-python@v5\` with \`cache: pip\` requires a \`requirements.txt\` or \`pyproject.toml\` in the repo. The mssql-extension repo has neither — the only Python use is the inline \`pip install llm-guard==0.3.16\` in the very next step. Without a manifest, setup-python fails immediately at:

\`\`\`
No file in /home/runner/work/mssql-extension/mssql-extension matched to
[**/requirements.txt or **/pyproject.toml], make sure you have checked
out the target repository
\`\`\`

Surfaced when PR #98 triggered the injection-scan workflow on its updated head — the check went red without the scanner ever running. Probably affects every PR that opens / synchronizes now.

## Fix

Drop \`cache: pip\`. The one \`pip install llm-guard\` is cheap enough to repeat on each run; \`llm-guard\` pulls torch+transformers as transitive deps, so the cache would be ~600 MB anyway, which dwarfs whatever pip-install overhead we'd save.

## Test plan

- [ ] This PR's own pr-injection-scan check passes (no longer dies at setup-python)
- [ ] Re-run pr-injection-scan on PR #98 after merge — should now reach the scanner step and either pass or fail on actual scan content