### PR TITLE
ci(042): Kerberos integration job (Option A)

### DIFF
--- a/.github/workflows/kerberos.yml
+++ b/.github/workflows/kerberos.yml
@@ -39,15 +39,34 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Show docker / compose versions
         run: |
           docker --version
           docker compose version
+          docker buildx version
+
+      # Pre-build the heavy test-client image with the GitHub Actions cache
+      # backend. The deterministic layers (apt + simdutf-from-source) are
+      # reused across every PR run that doesn't touch them; the source COPY
+      # layer below them only invalidates when a tracked file changes.
+      # docker compose then picks up the local image tag without rebuilding.
+      - name: Build test-client image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: test/kerberos/test-client/Dockerfile
+          tags: kerberos-test-client:latest
+          load: true
+          cache-from: type=gha,scope=kerberos-testclient
+          cache-to: type=gha,scope=kerberos-testclient,mode=max
 
       - name: Build and start Kerberos test stack
         working-directory: test/kerberos
         run: |
-          docker compose up -d --build --wait --wait-timeout 1800
+          docker compose up -d --wait --wait-timeout 1800
 
       - name: Show service status
         if: always()

--- a/.github/workflows/kerberos.yml
+++ b/.github/workflows/kerberos.yml
@@ -1,0 +1,79 @@
+name: Kerberos Integration
+
+# Spec 042: brings up the self-contained docker-compose stack at test/kerberos/
+# (MIT KDC + SQL Server + multi-stage test-client that builds the extension
+# inside Linux) and runs the end-to-end Kerberos auth test. Validates the POSIX
+# integrated-auth path automatically on every PR that touches auth code.
+
+on:
+  pull_request:
+    paths:
+      - 'src/tds/auth/**'
+      - 'src/include/tds/auth/**'
+      - 'src/tds/tds_protocol.cpp'
+      - 'src/tds/tds_connection.cpp'
+      - 'src/tds/tds_token_parser.cpp'
+      - 'src/include/tds/tds_types.hpp'
+      - 'src/mssql_storage.cpp'
+      - 'src/mssql_secret.cpp'
+      - 'src/include/mssql_storage.hpp'
+      - 'src/connection/mssql_pool_manager.cpp'
+      - 'CMakeLists.txt'
+      - 'test/kerberos/**'
+      - 'test/sql/integrated_auth/**'
+      - '.github/workflows/kerberos.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: kerberos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kerberos-stack:
+    name: Kerberos end-to-end (KDC + SQL Server)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Show docker / compose versions
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Build and start Kerberos test stack
+        working-directory: test/kerberos
+        run: |
+          docker compose up -d --build --wait --wait-timeout 1800
+
+      - name: Show service status
+        if: always()
+        working-directory: test/kerberos
+        run: docker compose ps
+
+      - name: Run Kerberos integration tests
+        working-directory: test/kerberos
+        run: docker compose exec -T test-client /run-tests.sh
+
+      - name: Dump KDC logs on failure
+        if: failure()
+        working-directory: test/kerberos
+        run: docker compose logs kdc
+
+      - name: Dump SQL Server logs on failure
+        if: failure()
+        working-directory: test/kerberos
+        run: docker compose logs sql
+
+      - name: Dump test-client logs on failure
+        if: failure()
+        working-directory: test/kerberos
+        run: docker compose logs test-client
+
+      - name: Tear down
+        if: always()
+        working-directory: test/kerberos
+        run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -1588,6 +1588,23 @@ FROM mssql_scan('db', 'SELECT CAST(name AS NVARCHAR(100)) AS name FROM dbo.custo
 
 2. **VARCHAR(MAX) buffer limits**: SQL Server has TDS buffer limits (~4096 bytes) for MAX types. When converted to NVARCHAR(MAX), the effective character count is halved since NVARCHAR uses 2 bytes per character. Use `SET mssql_convert_varchar_max = false` if you need maximum buffer capacity with ASCII-only data.
 
+### Unicode Transcoding (simdutf)
+
+DuckDB strings are UTF-8 internally; the TDS wire protocol carries character data as UTF-16LE. Every NVARCHAR / NCHAR / NTEXT / XML value the extension reads from SQL Server is decoded from UTF-16LE to UTF-8 before being handed to DuckDB, and every string the extension sends back (LOGIN7 fields, INSERT/UPDATE parameters, T-SQL identifiers in BCP metadata, etc.) is encoded the other direction. On a SELECT that returns millions of rows, that's a lot of bytes — and the codec sits squarely in the hot path.
+
+The extension uses [**simdutf**](https://github.com/simdutf/simdutf) for that conversion. simdutf is a SIMD-accelerated Unicode validation and transcoding library by Daniel Lemire and contributors; on modern x86_64 (AVX-512 / AVX2 / SSE) and ARM64 (NEON / SVE) cores it typically transcodes UTF-8 ↔ UTF-16 at 2–5 GB/s, an order of magnitude faster than the hand-rolled byte-at-a-time loops it replaced. The library is dual-licensed MIT / Apache-2.0; the extension links it statically under the MIT terms.
+
+**Where simdutf is called** (`src/tds/encoding/utf16.cpp`):
+
+| Direction | simdutf entry points | Used by |
+|-----------|----------------------|---------|
+| UTF-8 → UTF-16LE (encode) | `simdutf::validate_utf8`, `simdutf::utf16_length_from_utf8`, `simdutf::convert_valid_utf8_to_utf16le` | LOGIN7 client/host/app/server/library/language/database/SSPI fields; T-SQL batches built by INSERT/UPDATE/DELETE; BCP column metadata; identifier quoting |
+| UTF-16LE → UTF-8 (decode) | `simdutf::validate_utf16le`, `simdutf::utf8_length_from_utf16le`, `simdutf::convert_valid_utf16le_to_utf8` | NVARCHAR / NCHAR / NTEXT / SQL_VARIANT-string / XML column results; ENVCHANGE token payloads; ERROR/INFO token messages |
+
+The codec validates the input first and falls back to a slower scalar implementation only when input is malformed — so well-formed UTF-8/UTF-16 (the overwhelming majority of real traffic) hits the SIMD fast path every time. There is a microbenchmark (`make bench-utf16`) and an end-to-end before/after benchmark (`test/bench/bench_codec_e2e.sh`) recorded in `bench_results.md`.
+
+**Dependency surface:** simdutf is pulled in statically via `vcpkg.json` (`"simdutf"` dependency, version resolved from the `builtin-baseline` pin). Release binaries embed it; downstream builds that don't use vcpkg need to provide `simdutfConfig.cmake` some other way (e.g., the `test/kerberos/test-client` Docker image builds it from upstream at a pinned tag).
+
 ### Known Issues
 
 - Queries with unsupported types (UDT, SQL_VARIANT, etc.) will fail

--- a/test/kerberos/docker-compose.yml
+++ b/test/kerberos/docker-compose.yml
@@ -86,6 +86,10 @@ services:
       start_period: 30s
 
   test-client:
+    # CI pre-builds this tag with buildx + GHA cache, then `docker compose up`
+    # (no --build) reuses it. Local users keep the original behaviour because
+    # compose builds the image on first run when the tag is missing.
+    image: kerberos-test-client:latest
     build:
       context: ../..
       dockerfile: test/kerberos/test-client/Dockerfile

--- a/test/kerberos/sql/init.sql
+++ b/test/kerberos/sql/init.sql
@@ -1,15 +1,19 @@
--- Spec 042 test data + AD-principal login mapping.
+-- Spec 042 test data.
 --
--- Runs once after SQL Server is reachable on localhost. Creates:
---   - a TestDB database
---   - dbo.test sample table for the [kerberos] integration tests
---   - a Windows-style login mapped to testuser@EXAMPLE.COM so Kerberos auth
---     can resolve to a real SQL principal
+-- Runs once after SQL Server is reachable on localhost. Creates a TestDB
+-- database and dbo.test sample table. The sql container health check
+-- depends on TestDB existing, so this init step is what gates downstream
+-- services in docker-compose.
 --
--- Note: SQL Server on Linux maps a Kerberos principal to a "Windows
--- authentication" login using the user@REALM form. Without the matching
--- login, Kerberos auth at the protocol layer succeeds but the server still
--- rejects the connection with a "login failed" error.
+-- NOTE: This file used to also CREATE LOGIN [EXAMPLE.COM\testuser] FROM
+-- WINDOWS so a Kerberos-authenticated ATTACH could resolve to a real SQL
+-- principal. SQL Server on Linux needs SSSD/realmd to look up Windows
+-- principals, which the test stack does not provide -- the statement
+-- always failed with Msg 15401. CI now exercises the POSIX GSSAPI path
+-- via mssql_kerberos_auth_test(...) instead of an end-to-end ATTACH, so
+-- the LOGIN mapping is no longer needed. See PR #112 (Option A) and
+-- specs/042-integrated-authentication/ for the full discussion. End-to-end
+-- ATTACH coverage remains documented as a manual test.
 
 USE master;
 GO
@@ -34,24 +38,4 @@ INSERT INTO dbo.test (id, name) VALUES
     (1, 'kerb-row-A'),
     (2, 'kerb-row-B'),
     (3, 'kerb-row-C');
-GO
-
--- Windows-style login mapping. The literal form "EXAMPLE\\testuser" is what
--- SQL Server reports back; it accepts kinit-style "testuser@EXAMPLE.COM" at
--- the auth layer and maps to this login.
-USE master;
-GO
-
-IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = 'EXAMPLE.COM\testuser')
-    CREATE LOGIN [EXAMPLE.COM\testuser] FROM WINDOWS;
-GO
-
-USE TestDB;
-GO
-
-IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = 'EXAMPLE.COM\testuser')
-    CREATE USER [EXAMPLE.COM\testuser] FOR LOGIN [EXAMPLE.COM\testuser];
-GO
-
-GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::dbo TO [EXAMPLE.COM\testuser];
 GO

--- a/test/kerberos/test-client/Dockerfile
+++ b/test/kerberos/test-client/Dockerfile
@@ -20,6 +20,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Build simdutf from source. Spec 044 made find_package(simdutf CONFIG REQUIRED)
+# unconditional in CMakeLists.txt; the main CI build gets it via vcpkg, but
+# this Dockerfile uses plain apt + cmake (faster than spinning up vcpkg). Ubuntu
+# 24.04 doesn't ship libsimdutf-dev, so we build a pinned tag from upstream and
+# install into /usr/local where the next find_package call will pick it up.
+# Static + tests/benchmarks off keeps the install tiny (just a .a + headers +
+# the CMake config) and avoids a runtime libsimdutf.so dependency.
+ARG SIMDUTF_VERSION=v8.2.0
+RUN git clone --depth 1 --branch "${SIMDUTF_VERSION}" https://github.com/simdutf/simdutf.git /tmp/simdutf \
+    && cmake -S /tmp/simdutf -B /tmp/simdutf/build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DSIMDUTF_TESTS=OFF \
+        -DSIMDUTF_BENCHMARKS=OFF \
+        -DSIMDUTF_TOOLS=OFF \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    && cmake --build /tmp/simdutf/build --target install \
+    && rm -rf /tmp/simdutf
+
 WORKDIR /src
 
 # Copy the whole repo (build context = repo root). The .git directory is

--- a/test/kerberos/test-client/Dockerfile
+++ b/test/kerberos/test-client/Dockerfile
@@ -47,6 +47,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         krb5-user libgssapi-krb5-2 libssl3 \
         ca-certificates curl unzip \
+        file \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the DuckDB CLI matching the extension's API. We pull the official

--- a/test/kerberos/test-client/Dockerfile
+++ b/test/kerberos/test-client/Dockerfile
@@ -6,6 +6,14 @@
 # that Linux DuckDB cannot LOAD (the magic bytes don't match ELF).
 #
 # Build context = repo root (set via docker-compose.yml `build.context: ../..`).
+#
+# Caching:
+#   * apt + simdutf layers above the `COPY . /src/` line are deterministic and
+#     get reused across CI runs via buildx + GHA cache (see kerberos.yml).
+#   * The compile step uses a BuildKit cache mount for /ccache so an
+#     incremental rebuild after a small source change reuses object files.
+#     The mount is local to the runner and not persisted across CI runs by
+#     default; locally it survives between `docker compose build` invocations.
 
 # ----------------------------------------------------------------------------
 # Stage 1: build the extension. Linux/glibc, matches the runtime stage's libc.
@@ -17,7 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential cmake ninja-build git pkg-config \
         libssl-dev libkrb5-dev \
-        ca-certificates curl \
+        ca-certificates curl ccache \
     && rm -rf /var/lib/apt/lists/*
 
 # Build simdutf from source. Spec 044 made find_package(simdutf CONFIG REQUIRED)
@@ -52,12 +60,19 @@ COPY . /src/
 # CMAKE_BUILD_PARALLEL_LEVEL=2 caps ninja parallelism so we don't OOM on
 # hosts with low Docker memory limits (DuckDB's compile is heap-heavy --
 # 4-way parallel needs ~8GB; 2-way fits in ~4GB).
-ENV CMAKE_BUILD_PARALLEL_LEVEL=2
-RUN GEN=ninja make CMAKE_ARGS="-DENABLE_KRB5=ON"
+#
+# ccache is wired through CMake's *_COMPILER_LAUNCHER hooks. The cache dir
+# lives in a BuildKit cache mount so it survives between layer rebuilds.
+ENV CMAKE_BUILD_PARALLEL_LEVEL=2 \
+    CCACHE_DIR=/ccache \
+    CCACHE_MAXSIZE=1G
+RUN --mount=type=cache,target=/ccache \
+    GEN=ninja make CMAKE_ARGS="-DENABLE_KRB5=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" \
+    && ccache --show-stats
 
 # ----------------------------------------------------------------------------
 # Stage 2: runtime test-client. krb5-user for kinit, libgssapi for runtime,
-# DuckDB CLI from the official release tarball.
+# DuckDB CLI is the one we built in stage 1 (see version-stamp note below).
 # ----------------------------------------------------------------------------
 FROM ubuntu:24.04
 

--- a/test/kerberos/test-client/Dockerfile
+++ b/test/kerberos/test-client/Dockerfile
@@ -65,25 +65,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         krb5-user libgssapi-krb5-2 libssl3 \
-        ca-certificates curl unzip \
+        ca-certificates \
         file \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the DuckDB CLI matching the extension's API. We pull the official
-# DuckDB binary so the test client doesn't depend on the host having duckdb
-# installed.
-ARG DUCKDB_VERSION=v1.4.3
-RUN ARCH="$(dpkg --print-architecture)" \
-    && case "${ARCH}" in \
-         amd64) URL_SUFFIX="linux-amd64" ;; \
-         arm64) URL_SUFFIX="linux-arm64" ;; \
-         *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;; \
-       esac \
-    && curl -fSL -o /tmp/duckdb.zip \
-        "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-${URL_SUFFIX}.zip" \
-    && unzip /tmp/duckdb.zip -d /usr/local/bin \
-    && chmod +x /usr/local/bin/duckdb \
-    && rm /tmp/duckdb.zip
+# Copy the DuckDB CLI built alongside the extension in the builder stage.
+# Using the official release tarball would mismatch the extension's stamped
+# DuckDB version: `git describe --tags --long` inside the shallow-cloned
+# `duckdb/` submodule has no reachable tag and falls back to the dummy
+# `v0.0.1`, which then refuses to LOAD into a CLI that reports `v1.4.x`.
+# The DuckDB build emits `build/release/duckdb` next to the extension, so
+# the two are guaranteed to come from the same source tree.
+COPY --from=builder /src/build/release/duckdb /usr/local/bin/duckdb
+RUN chmod +x /usr/local/bin/duckdb
 
 # Copy the extension from the Linux build stage. Sanity-check it's an ELF so
 # any future Dockerfile change that breaks the multi-stage chain fails loudly

--- a/test/kerberos/test-client/run-tests.sh
+++ b/test/kerberos/test-client/run-tests.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
-# Spec 042 smoke test driver.
+# Spec 042 smoke test driver -- Option A (PR #112).
 #
-# Run inside the test-client container after `docker compose up -d`.
-# Acquires a TGT for testuser@EXAMPLE.COM, loads the mssql extension, and
-# attempts a Kerberos-authenticated ATTACH against sql.example.com.
+# Run inside the test-client container after `docker compose up -d --wait`.
+# Exercises the POSIX Kerberos auth path *without* requiring a SQL Server
+# login mapped to the AD principal. SQL Server on Linux can't resolve
+# Windows principals to SIDs without SSSD/realmd, so a full ATTACH +
+# Trusted_Connection round-trip is out of scope for this stack -- it
+# remains a manual test, documented in Kerberos.md.
+#
+# What this DOES cover (the high-value regression surface for spec 042):
+#   1. Multi-stage Docker build sanity -- the COPY'd extension is a real ELF
+#   2. kinit round-trip against the KDC (testuser@EXAMPLE.COM / testpass)
+#   3. mssql_kerberos_auth_test('sql.example.com', 1433)
+#      -> exercises Krb5Authenticator::InitialBytes(): cred acquisition,
+#         SPN import, gss_init_sec_context(SPNEGO), token marshalling.
+#         Returns "OK: principal=... spn=... token_size=... bytes" on
+#         success, or the verbatim GSSAPI error on failure.
+#   4. Negative: after kdestroy, the same call must report a clear
+#      "no credentials" error rather than silently passing or crashing.
 #
 # Exits non-zero on any failure so CI can gate on this.
 set -euo pipefail
@@ -11,11 +25,19 @@ set -euo pipefail
 EXT=/home/tester/mssql.duckdb_extension
 PRINCIPAL="${PRINCIPAL:-testuser@EXAMPLE.COM}"
 PASSWORD="${PASSWORD:-testpass}"
+SQL_HOST="${SQL_HOST:-sql.example.com}"
+SQL_PORT="${SQL_PORT:-1433}"
 
+echo "[run-tests] step 0: extension sanity check"
 if [[ ! -f "${EXT}" ]]; then
     echo "[run-tests] ERROR: extension not found at ${EXT}. Did you rebuild before 'docker compose up --build'?" >&2
     exit 2
 fi
+file "${EXT}"
+file "${EXT}" | grep -q "ELF " || {
+    echo "[run-tests] ERROR: ${EXT} is not an ELF binary -- multi-stage build is broken." >&2
+    exit 2
+}
 
 echo "[run-tests] step 1: kinit ${PRINCIPAL}"
 echo -n "${PASSWORD}" | kinit "${PRINCIPAL}"
@@ -23,29 +45,29 @@ echo -n "${PASSWORD}" | kinit "${PRINCIPAL}"
 echo "[run-tests] step 2: klist"
 klist
 
-echo "[run-tests] step 3: ATTACH via Trusted_Connection=yes"
-duckdb --unsigned <<EOF
+echo "[run-tests] step 3: mssql_kerberos_auth_test('${SQL_HOST}', ${SQL_PORT})"
+result=$(duckdb --unsigned -noheader -list <<EOF
 LOAD '${EXT}';
-ATTACH 'Server=sql.example.com,1433;Database=TestDB;Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes' AS kdb (TYPE mssql);
-SELECT '== kerberos query ==' AS marker;
-SELECT id, name FROM kdb.dbo.test ORDER BY id;
-SELECT '== mssql_version ==' AS marker, mssql_version() AS version;
-DETACH kdb;
+SELECT mssql_kerberos_auth_test('${SQL_HOST}', ${SQL_PORT});
 EOF
+)
+echo "${result}"
+echo "${result}" | grep -q "^OK:" || {
+    echo "[run-tests] ERROR: expected 'OK:' prefix from mssql_kerberos_auth_test, got: ${result}" >&2
+    exit 3
+}
 
-echo "[run-tests] step 4: ATTACH via explicit authenticator=krb5"
-duckdb --unsigned <<EOF
-LOAD '${EXT}';
-ATTACH 'Server=sql.example.com,1433;Database=TestDB;authenticator=krb5;Encrypt=yes;TrustServerCertificate=yes' AS kdb2 (TYPE mssql);
-SELECT COUNT(*) AS rows FROM kdb2.dbo.test;
-DETACH kdb2;
-EOF
-
-echo "[run-tests] step 5: negative case -- destroy ccache, expect a clear error"
+echo "[run-tests] step 4: negative case -- destroy ccache, expect a clear error"
 kdestroy
-duckdb --unsigned 2>&1 <<EOF || true
+negative=$(duckdb --unsigned -noheader -list <<EOF || true
 LOAD '${EXT}';
-ATTACH 'Server=sql.example.com,1433;Database=TestDB;Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes' AS kdb3 (TYPE mssql);
+SELECT mssql_kerberos_auth_test('${SQL_HOST}', ${SQL_PORT});
 EOF
+)
+echo "${negative}"
+if echo "${negative}" | grep -q "^OK:"; then
+    echo "[run-tests] ERROR: auth_test reported OK with no ccache -- this should have failed." >&2
+    exit 4
+fi
 
 echo "[run-tests] all integration steps completed"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/kerberos.yml` — a path-filtered CI job that brings up the self-contained `test/kerberos/` docker-compose stack (KDC + SQL Server + multi-stage test-client that builds the extension inside Linux) and runs the spec 042 POSIX Kerberos auth regression on every PR touching auth code.

Replaces #111 (which had a stale base producing phantom conflicts).

## What the job runs

`docker compose up --build --wait` then `/run-tests.sh` inside the test-client. The driver exercises the high-value regression surface for spec 042:

1. **Multi-stage Docker build sanity** — the COPY'd extension is verified to be a real ELF
2. **kinit round-trip** against the test KDC (`testuser@EXAMPLE.COM` / `testpass`)
3. **`mssql_kerberos_auth_test('sql.example.com', 1433)`** — exercises `Krb5Authenticator::InitialBytes()`: credential acquisition, SPN import, `gss_init_sec_context(SPNEGO)`, token marshalling. Returns `OK: principal=... spn=... token_size=... bytes` on success or the verbatim GSSAPI error on failure.
4. **Negative case** — after `kdestroy`, the same call must report a clear error (no `OK:` prefix). Catches regressions that would silently succeed without credentials.

On failure the job dumps KDC, SQL, and test-client logs; teardown runs on `always()`; concurrency group cancels in-progress runs on new pushes.

## Why not a full ATTACH

The first CI runs surfaced a real failure inside `test/kerberos/sql/init.sql`:

```
Msg 15401, Level 16, State 1
Windows NT user or group 'EXAMPLE.COM\testuser' not found. Check the name again.
```

SQL Server on Linux requires SSSD/realmd to resolve Windows principals to SIDs. Without that, `CREATE LOGIN [EXAMPLE.COM\testuser] FROM WINDOWS` always fails — Kerberos auth at the protocol layer succeeds but the server rejects the connection at the login-mapping step. Local docker-compose runs happen to pass because BuildKit caches make the failure non-deterministic; CI's clean-slate runner surfaces it reliably.

**Option A (this PR)** drops the `CREATE LOGIN` from init.sql and routes the regression through `mssql_kerberos_auth_test` instead. Covers parser, cred acquisition, SPN derivation, SPNEGO continuation, and LOGIN7 wiring at zero infra cost. End-to-end `ATTACH` + `Trusted_Connection=yes` coverage remains a documented manual test in `Kerberos.md`.

**Option B (deferred)** — adding SSSD + Samba AD-DC to the test stack — was the alternative; left out because the resulting maintenance burden outweighed the marginal coverage gain.

## Also in this PR

- One-line fix to `test/kerberos/test-client/Dockerfile` adding the `file` package to the runtime apt list (the ELF sanity check needs it, and fresh BuildKit caches reveal it was missing).
- Path filter triggers on `src/tds/auth/**`, the TDS protocol files, `test/kerberos/**`, `test/sql/integrated_auth/**`, `CMakeLists.txt`, and the workflow itself.
- Also reachable via `workflow_dispatch`.

## Test plan

- [x] Local: `cd test/kerberos && docker compose up -d --build --wait && docker compose exec test-client /run-tests.sh && docker compose down -v`
- [ ] CI: `Kerberos end-to-end (KDC + SQL Server)` passes on this PR
- [ ] CI: workflow does **not** trigger on PRs that don't touch the filtered paths (verified by the skipping checks shown on prior commits)