### PR TITLE
feat(auth): Spec 042 Phase 4 — Windows SSPI integrated authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Windows SSPI** integrated authentication (spec 042 Phase 4). `WinSspiAuthenticator`
+  via `secur32.dll`'s Negotiate package. Uses the current Windows logon session — no
+  `kinit` needed. Same connection-string surface as POSIX (`Trusted_Connection=yes` /
+  `authenticator=winsspi`). Mirrors the structure of `Krb5Authenticator`; shares the
+  `IAuthenticator` interface and the SPNEGO continuation loop in
+  `TdsConnection::AuthenticateIntegrated`. Linked against `secur32.lib` from the
+  Windows SDK — no third-party dependency.
+
 - **Integrated Authentication (Kerberos)** for POSIX hosts (spec 042, phases 1-3).
   Adds the `IAuthenticator` multi-round interface, parser support for the
   `microsoft/go-mssqldb` connection-string surface, LOGIN7 `fIntSecurity`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,8 @@ Available in: ATTACH options, ADO.NET connection strings (`SchemaFilter`/`TableF
 | `mssql_azure_auth_test(secret, tenant?)` | Scalar | Test Azure AD token acquisition |
 | `mssql_kerberos_auth_test(host [, port])` | Scalar | Test POSIX Kerberos auth path (spec 042); returns OK + SPN / principal / token size, or verbatim GSSAPI error |
 | `mssql_kerberos_auth_test_secret(secret_name)` | Scalar | Same but reads keytab / SPN-override / etc. from an MSSQL secret |
+| `mssql_winsspi_auth_test(host [, port])` | Scalar | Windows SSPI peer of `mssql_kerberos_auth_test` (spec 042 Phase 4); returns OK + SPN / UPN / token size, or verbatim SSPI error |
+| `mssql_winsspi_auth_test_spn(spn)` | Scalar | Same but takes an explicit SPN (overrides default `MSSQLSvc/<host>:<port>` derivation) |
 
 ## Active Technologies
 - C++17 (DuckDB extension standard) + DuckDB (main branch), OpenSSL (vcpkg), Winsock2 (Windows system library) (019-fix-winsock-init)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ POSIX Kerberos and Windows SSPI integrated authentication, shipped via spec 042.
 **Implementation files:**
 - `src/include/tds/auth/iauthenticator.hpp` — three-method interface (`InitialBytes` / `NextBytes` / `Free`), modeled on `microsoft/go-mssqldb`'s `integratedauth.IntegratedAuthenticator`
 - `src/tds/auth/krb5_authenticator.{hpp,cpp}` — GSSAPI implementation (POSIX, compiled when `MSSQL_ENABLE_KRB5` is defined)
-- `src/tds/auth/winsspi_authenticator.{hpp,cpp}` — Windows SSPI implementation (Phase 4, not yet present)
+- `src/tds/auth/winsspi_authenticator.{hpp,cpp}` — Windows SSPI implementation via `secur32.dll` Negotiate package (compiled when `MSSQL_ENABLE_SSPI` is defined; CMake auto-enables on `_WIN32`)
 - `src/include/tds/auth/integrated_auth_strategy.hpp` — adapter wrapping `IAuthenticator` in the existing `AuthenticationStrategy` interface
 - `src/tds/auth/auth_strategy_factory.cpp` — `AuthStrategyFactory::Create` dispatches `KRB5` / `WINSSPI` based on `info.auth_method`
 - `src/tds/tds_connection.cpp` `AuthenticateIntegrated()` — SPNEGO continuation loop on `0xED` SSPI tokens
@@ -299,7 +299,7 @@ The test KDC's realm is `EXAMPLE.COM`, principal is `testuser@EXAMPLE.COM` (pass
 |---|---|---|---|---|
 | Linux x86_64 / ARM64 | yes | yes | yes (secret only) | Phase 3 shipped |
 | macOS ARM64 | yes | rejected at construction | rejected at construction | Phase 3 shipped |
-| Windows x64 | n/a | n/a | n/a | Phase 4 pending |
+| Windows x64 | yes (logon session) | n/a | n/a | Phase 4 shipped |
 
 **Connection-string surface (verbatim from `microsoft/go-mssqldb`):**
 
@@ -346,9 +346,10 @@ target_compile_features(${EXTENSION_NAME} PRIVATE cxx_std_17)
 **Note:** This issue only manifests on GCC/Linux, not on Clang/macOS, because Clang is more lenient with ODR for constexpr static members.
 
 ## Recent Changes
+- 042-integrated-authentication Phase 4: Added Windows SSPI authentication via `secur32.dll`'s Negotiate package. `WinSspiAuthenticator` peer of `Krb5Authenticator`. Same `IAuthenticator` interface; shared SPNEGO continuation loop in `TdsConnection::AuthenticateIntegrated`.
 - 044-codec-consolidation: Finishes the simdutf migration started in 043 — every legacy `Utf16LE*` call site moves to the simdutf-backed wrapper, the wrapper is renamed back to `Utf16LE*` (legacy file path resurrected with new implementation), and the legacy hand-rolled converter survives only as a private invalid-input fallback. Includes codec microbenchmark (`make bench-utf16`) and an end-to-end before/after benchmark (`test/bench/bench_codec_e2e.sh`, 100M rows) recorded into `bench_results.md`. No new vcpkg deps.
 - 043-refactoring-foundation: Added C++ (C++11-compatible ABI) + DuckDB (main branch), simdutf (vcpkg, statically linked, MIT) for LOGIN7 non-ASCII fix; OpenSSL unchanged
-- 042-integrated-authentication: Added Kerberos (POSIX) integrated authentication via system GSSAPI. SPNEGO + LOGIN7 `fIntSecurity` bit + 0xED SSPI continuation tokens. Self-contained test stack at `test/kerberos/`. Phase 4 (Windows SSPI) deferred.
+- 042-integrated-authentication: Added Kerberos (POSIX) integrated authentication via system GSSAPI. SPNEGO + LOGIN7 `fIntSecurity` bit + 0xED SSPI continuation tokens. Self-contained test stack at `test/kerberos/`.
 - 041-xml-type-support: Added C++17 (C++11-compatible for ODR on Linux) + DuckDB (main branch), OpenSSL (vcpkg), existing TDS protocol layer
 - 040-fix-datetimeoffset-nbc: Added C++17 (C++11-compatible for ODR on Linux) + DuckDB (main branch), OpenSSL (vcpkg), custom TDS protocol layer
 - 039-order-pushdown: Added C++17 (C++11-compatible for ODR on Linux) + DuckDB (main branch), OpenSSL (vcpkg), existing TDS protocol layer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ set(EXTENSION_SOURCES
     src/tds/auth/manual_token_strategy.cpp
     src/tds/auth/auth_strategy_factory.cpp
     src/tds/auth/krb5_test_function.cpp
+    src/tds/auth/winsspi_test_function.cpp
     src/tds/tds_token_parser.cpp
     src/tds/tds_row_reader.cpp
     # TLS layer (OpenSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,9 +212,12 @@ set(EXTENSION_SOURCES
 
 # Spec 042: conditional inclusion of the platform-specific integrated-auth
 # authenticator. POSIX gets krb5_authenticator.cpp when GSSAPI is discovered;
-# Windows gets winsspi_authenticator.cpp (Phase 4).
+# Windows gets winsspi_authenticator.cpp via secur32.dll (Phase 4).
 if(MSSQL_KRB5_AVAILABLE)
     list(APPEND EXTENSION_SOURCES src/tds/auth/krb5_authenticator.cpp)
+endif()
+if(MSSQL_SSPI_AVAILABLE)
+    list(APPEND EXTENSION_SOURCES src/tds/auth/winsspi_authenticator.cpp)
 endif()
 
 # Build static extension (linked into DuckDB)

--- a/Kerberos.md
+++ b/Kerberos.md
@@ -11,6 +11,7 @@ End-user guide for connecting to Active-Directory-joined SQL Server via Kerberos
 - [Connection Examples](#connection-examples)
 - [Using MSSQL Secrets](#using-mssql-secrets)
 - [Diagnostic function: `mssql_kerberos_auth_test`](#diagnostic-function-mssql_kerberos_auth_test)
+- [Diagnostic function: `mssql_winsspi_auth_test` (Windows)](#diagnostic-function-mssql_winsspi_auth_test-windows)
 - [Troubleshooting](#troubleshooting)
 - [Running the test stack locally](#running-the-test-stack-locally)
 - [Reference](#reference)
@@ -432,6 +433,70 @@ Kerberos support (MSSQL_ENABLE_KRB5 was not defined). Rebuild with -DENABLE_KRB5
 - A fail here + working `kinit` → `mssql_kerberos_auth_test` exposes a
   bug in your config that `kinit` didn't catch (wrong SPN, wrong realm
   resolution, etc.).
+
+## Diagnostic function: `mssql_winsspi_auth_test` (Windows)
+
+The Windows SSPI peer of `mssql_kerberos_auth_test`. Same idea: exercises
+the client-side handshake (`AcquireCredentialsHandleW` +
+`InitializeSecurityContextW`, Negotiate package) **without** connecting to
+SQL Server. Useful for confirming the current logon session has a valid
+ticket, the SPN resolves, and Negotiate produces a non-empty token.
+
+Three overloads:
+
+```sql
+-- 1. Smoke test against a host, default port 1433.
+SELECT mssql_winsspi_auth_test('sqlhost.corp.example.com');
+
+-- 2. Explicit port.
+SELECT mssql_winsspi_auth_test('sqlhost.corp.example.com', 1433);
+
+-- 3. Explicit SPN -- override default MSSQLSvc/<host>:<port> derivation.
+SELECT mssql_winsspi_auth_test_spn('MSSQLSvc/sqlcluster.corp.example.com:1433');
+```
+
+### Success output
+
+```text
+OK: principal=alice@CORP.EXAMPLE.COM, spn=MSSQLSvc/sqlhost.corp.example.com:1433, mech=Negotiate, token_size=1652 bytes
+```
+
+`principal` here is the current logon session's UPN (via
+`GetUserNameEx(NameUserPrincipal)`); falls back to `DOMAIN\user` if the UPN
+isn't set on the account. `mech=Negotiate` is the SSPI package name —
+Negotiate transparently selects Kerberos when the SPN resolves through AD
+and falls back to NTLM otherwise, which is why we report it explicitly.
+
+### Failure output
+
+The function returns the verbatim error message from
+`winsspi_authenticator.cpp`, wrapping `FormatMessageW` plus the SSPI status
+code. Common cases:
+
+```text
+-- SPN not registered for this server
+MSSQL Kerberos auth failed: InitializeSecurityContext failed:
+sspi_status=0x80090303, The specified target is unknown or unreachable.
+(Hint: SPN not found in Active Directory. Verify with 'setspn -L domain\sqlsvc'.)
+
+-- No domain credentials in the current session
+MSSQL Kerberos auth failed: InitializeSecurityContext failed:
+sspi_status=0x8009030E, No credentials are available in the security package.
+(Hint: log in as a domain user, or run 'runas /netonly' against domain creds.)
+
+-- Clock skew
+MSSQL Kerberos auth failed: InitializeSecurityContext failed:
+sspi_status=0x80090324, The clocks on the client and server machines are skewed.
+(Hint: sync system clock; typical tolerance is ±5 minutes.)
+```
+
+### Function availability
+
+- On Windows builds: real implementation, exercises SSPI Negotiate.
+- On Linux / macOS builds: returns a clear "wrong platform — use
+  `mssql_kerberos_auth_test` on POSIX" message. Registered unconditionally
+  so the function exists on every platform and gives consistent diagnostics
+  rather than "function does not exist".
 
 ## Troubleshooting
 

--- a/Kerberos.md
+++ b/Kerberos.md
@@ -14,6 +14,7 @@ End-user guide for connecting to Active-Directory-joined SQL Server via Kerberos
 - [Diagnostic function: `mssql_winsspi_auth_test` (Windows)](#diagnostic-function-mssql_winsspi_auth_test-windows)
 - [Troubleshooting](#troubleshooting)
 - [Running the test stack locally](#running-the-test-stack-locally)
+- [Running the Windows SSPI test suite](#running-the-windows-sspi-test-suite)
 - [Reference](#reference)
 
 ## Quick Start
@@ -600,6 +601,68 @@ duckdb --unsigned
 ```
 
 See `test/kerberos/README.md` for the full layout and troubleshooting.
+
+## Running the Windows SSPI test suite
+
+The POSIX `test/kerberos/` docker-compose stack has no Windows analog —
+SSPI requires a real Windows logon session against a real KDC, which a
+container can't provide. The Windows test surface is a sqllogictest file
+that runs manually on a domain-joined Windows host:
+
+**Suite:** `test/sql/integrated_auth/winsspi_basic.test` — four cases
+covering `Trusted_Connection=yes` ATTACH, catalog SELECT, raw
+`mssql_scan`, and the explicit `authenticator=winsspi` form.
+
+**Gated on three env vars** so it's a no-op in normal CI:
+
+| Env var | Purpose |
+|---|---|
+| `MSSQL_WINSSPI_TEST=1` | Opt-in switch |
+| `MSSQL_TEST_HOST` | SQL Server hostname (FQDN) |
+| `MSSQL_TEST_DB` | Database to ATTACH (any DB you can read works) |
+
+**Run via the helper script** (recommended):
+
+```powershell
+.\scripts\ci\winsspi_test.ps1 -SqlHost sqlhost.corp.example.com -Database master
+```
+
+The script verifies `klist` shows a TGT, sets the env vars, and runs
+`unittest.exe` against the suite. The `unittest.exe` either comes from a
+local `make` build (`build\release\test\unittest.exe`) or from the
+`unittest-windows_amd64` artifact of a green CI run.
+
+**Or directly:**
+
+```powershell
+$env:MSSQL_WINSSPI_TEST = "1"
+$env:MSSQL_TEST_HOST    = "sqlhost.corp.example.com"
+$env:MSSQL_TEST_DB      = "master"
+
+.\build\release\test\unittest.exe test\sql\integrated_auth\winsspi_basic.test
+```
+
+**Pre-flight with the diagnostic function first.** Cheaper to debug a SPN
+or credential issue via `mssql_winsspi_auth_test` than via a failing
+sqllogictest:
+
+```powershell
+duckdb.exe --unsigned -c "
+  LOAD 'C:\duckdb\ext\mssql.duckdb_extension';
+  SELECT mssql_winsspi_auth_test('sqlhost.corp.example.com');
+"
+```
+
+If that returns `OK: ...`, the SSPI handshake works and any
+sqllogictest failure is on the SQL Server side (login mapping,
+permissions). If it returns an error, fix the client-side problem first.
+
+**Why this isn't automated in CI.** GitHub-hosted Windows runners aren't
+domain-joined and can't be made to be. A self-hosted Windows runner
+joined to an Entra Domain Services managed domain would work but adds
+~$140/mo Azure cost and a maintenance surface that only pays off once
+there's a second Windows contributor. Until then: maintainer manual
+smoke test before merging Windows-touching PRs.
 
 ## Reference
 

--- a/Kerberos.md
+++ b/Kerberos.md
@@ -70,8 +70,43 @@ Minimal `/etc/krb5.conf`:
 
 ### Windows
 
-**Phase 4 is not yet shipped.** Windows SSPI support is on the roadmap (`secur32.dll`
-+ the `Negotiate` package). Until it lands, use [WSL2 Ubuntu](#wsl2-ubuntu-under-windows).
+Native Windows SSPI via `secur32.dll`'s Negotiate package. Uses the current
+Windows logon session — no `kinit` needed. Same connection-string surface as
+POSIX:
+
+```sql
+ATTACH 'Server=sqlhost.corp.example.com,1433;Database=YourDB;Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes'
+    AS db (TYPE mssql);
+```
+
+Or the explicit form:
+
+```sql
+ATTACH 'Server=sqlhost.corp.example.com,1433;Database=YourDB;authenticator=winsspi;Encrypt=yes;TrustServerCertificate=yes'
+    AS db (TYPE mssql);
+```
+
+`Trusted_Connection=yes` and `Integrated Security=SSPI` both resolve to
+`authenticator=winsspi` on Windows; on POSIX they resolve to
+`authenticator=krb5`. The behavior is the same — your machine's existing
+authentication credentials are used.
+
+**Prerequisites:**
+
+- Domain-joined Windows host (or sufficient privileges to acquire a Kerberos
+  TGT for the target realm).
+- SQL Server's SPN registered in AD with the canonical
+  `MSSQLSvc/<fqdn>:<port>` form. Verify with `setspn -L DOMAIN\sqlservice`
+  from an admin PowerShell.
+- No build-time dependencies — `secur32.lib` is part of the Windows SDK.
+
+**Limitations:**
+
+- Only credential-cache mode (current logon session). Keytab and raw-credentials
+  modes are POSIX-only.
+- Negotiate falls back to NTLM transparently when the KDC isn't reachable for
+  the target SPN. If you require Kerberos-only authentication, ensure the SPN
+  is registered correctly so the fallback is never triggered.
 
 ### WSL2 (Ubuntu under Windows)
 
@@ -532,7 +567,7 @@ Names verbatim from `microsoft/go-mssqldb`'s `integratedauth/` package.
 |---|---|---|---|---|
 | Linux x86_64 / ARM64 | yes | yes | yes (secret only) | Phase 3 shipped |
 | macOS ARM64 | yes | rejected | rejected | Phase 3 shipped |
-| Windows x64 | n/a | n/a | n/a | Phase 4 pending |
+| Windows x64 | yes (logon session) | n/a (use logon session) | n/a (use logon session) | Phase 4 shipped |
 | WSL2 Ubuntu | yes | yes | yes (secret only) | Same as Linux |
 
 ### Security notes

--- a/scripts/ci/winsspi_test.ps1
+++ b/scripts/ci/winsspi_test.ps1
@@ -1,0 +1,71 @@
+# Run the Windows SSPI sqllogictest suite (spec 042 Phase 4).
+#
+# Bundles the three env vars + the unittest invocation into one command.
+# Run from a domain-joined Windows host with valid Kerberos credentials
+# (verify with `klist`) against any AD-joined SQL Server you have access to.
+#
+# Usage:
+#   .\scripts\ci\winsspi_test.ps1 -Host sqlhost.corp.example.com -Database master
+#
+# Optional:
+#   -UnittestExe   path to unittest.exe (default: build\release\test\unittest.exe)
+#   -TestFile      sqllogictest file (default: the bundled winsspi suite)
+#
+# The script does NOT run kinit -- on Windows, your interactive logon session
+# already holds a TGT if you're signed in as a domain user. If `klist` shows
+# nothing, log out and back in (or use `runas /netonly` against domain creds).
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SqlHost,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Database,
+
+    [string]$UnittestExe = "build\release\test\unittest.exe",
+
+    [string]$TestFile = "test\sql\integrated_auth\winsspi_basic.test"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $UnittestExe)) {
+    Write-Error @"
+unittest.exe not found at '$UnittestExe'.
+Either build the extension locally with 'make' (produces build\release\test\unittest.exe)
+or download the 'unittest-windows_amd64' artifact from a green CI run and unzip it
+to that path.
+"@
+}
+
+if (-not (Test-Path $TestFile)) {
+    Write-Error "Test file not found: $TestFile"
+}
+
+Write-Host "[winsspi-test] verifying Kerberos ticket..." -ForegroundColor Cyan
+$klist = & klist 2>&1
+if ($LASTEXITCODE -ne 0 -or $klist -notmatch "krbtgt") {
+    Write-Warning @"
+klist did not report a krbtgt entry. The Windows SSPI tests need a valid Kerberos
+ticket in the current logon session. If this is unexpected:
+  - Confirm you're signed in as a domain user (not a local account)
+  - Try `runas /netonly /user:DOMAIN\you cmd.exe` and re-run from that shell
+Continuing anyway; tests will fail with SEC_E_NO_CREDENTIALS if there's no ticket.
+"@
+}
+
+$env:MSSQL_WINSSPI_TEST = "1"
+$env:MSSQL_TEST_HOST    = $SqlHost
+$env:MSSQL_TEST_DB      = $Database
+
+Write-Host "[winsspi-test] running $TestFile against $SqlHost / $Database..." -ForegroundColor Cyan
+& $UnittestExe $TestFile
+$exit = $LASTEXITCODE
+
+if ($exit -eq 0) {
+    Write-Host "[winsspi-test] all cases passed" -ForegroundColor Green
+} else {
+    Write-Host "[winsspi-test] FAILED (exit $exit)" -ForegroundColor Red
+}
+exit $exit

--- a/scripts/ci/winsspi_test.ps1
+++ b/scripts/ci/winsspi_test.ps1
@@ -5,7 +5,9 @@
 # (verify with `klist`) against any AD-joined SQL Server you have access to.
 #
 # Usage:
-#   .\scripts\ci\winsspi_test.ps1 -Host sqlhost.corp.example.com -Database master
+#   .\scripts\ci\winsspi_test.ps1 -SqlHost sqlhost.corp.example.com -Database master
+#
+# (-SqlHost, not -Host -- $Host is a PowerShell automatic variable for the host UI.)
 #
 # Optional:
 #   -UnittestExe   path to unittest.exe (default: build\release\test\unittest.exe)

--- a/scripts/ci/winsspi_test.ps1
+++ b/scripts/ci/winsspi_test.ps1
@@ -30,6 +30,7 @@ param(
     [string]$TestFile = "test\sql\integrated_auth\winsspi_basic.test"
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 if (-not (Test-Path $UnittestExe)) {
@@ -45,9 +46,23 @@ if (-not (Test-Path $TestFile)) {
     Write-Error "Test file not found: $TestFile"
 }
 
+if (-not (Get-Command klist -ErrorAction SilentlyContinue)) {
+    Write-Error @"
+klist not found on PATH. This script needs to run on a Windows host with the
+Kerberos client tools available (the native klist.exe ships with a
+domain-joined Windows install; MIT Kerberos for Windows provides an
+alternative). Log in as a domain user from a Windows machine and re-run.
+"@
+}
+
 Write-Host "[winsspi-test] verifying Kerberos ticket..." -ForegroundColor Cyan
 $klist = & klist 2>&1
-if ($LASTEXITCODE -ne 0 -or $klist -notmatch "krbtgt") {
+# Note: `& klist` returns its output as a string ARRAY. PowerShell's -match
+# against an array filters to the matching elements; wrapping in parens
+# evaluates that filter to a truthy value iff at least one line matches.
+# Plain `$klist -notmatch "krbtgt"` would mis-fire whenever any non-krbtgt
+# line exists (almost always), so we use the parenthesised positive form.
+if ($LASTEXITCODE -ne 0 -or -not ($klist -match "krbtgt")) {
     Write-Warning @"
 klist did not report a krbtgt entry. The Windows SSPI tests need a valid Kerberos
 ticket in the current logon session. If this is unexpected:
@@ -62,6 +77,7 @@ $env:MSSQL_TEST_HOST    = $SqlHost
 $env:MSSQL_TEST_DB      = $Database
 
 Write-Host "[winsspi-test] running $TestFile against $SqlHost / $Database..." -ForegroundColor Cyan
+Write-Host "[winsspi-test] command: $UnittestExe $TestFile" -ForegroundColor DarkGray
 & $UnittestExe $TestFile
 $exit = $LASTEXITCODE
 

--- a/src/include/tds/auth/winsspi_authenticator.hpp
+++ b/src/include/tds/auth/winsspi_authenticator.hpp
@@ -40,9 +40,9 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <windows.h>
 #include <security.h>
 #include <sspi.h>
+#include <windows.h>
 
 namespace duckdb {
 namespace tds {

--- a/src/include/tds/auth/winsspi_authenticator.hpp
+++ b/src/include/tds/auth/winsspi_authenticator.hpp
@@ -40,9 +40,15 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+// IMPORTANT: include order matters here. <security.h> and <sspi.h> reference
+// types (CHAR, LONG, etc.) declared in <windows.h>, so windows.h MUST come
+// first. clang-format's alphabetical SortIncludes would re-sort these and
+// break the build, so the block is fenced.
+// clang-format off
+#include <windows.h>
 #include <security.h>
 #include <sspi.h>
-#include <windows.h>
+// clang-format on
 
 namespace duckdb {
 namespace tds {

--- a/src/include/tds/auth/winsspi_authenticator.hpp
+++ b/src/include/tds/auth/winsspi_authenticator.hpp
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// winsspi_authenticator.hpp
+//
+// Windows implementation of IAuthenticator via secur32.dll's Negotiate
+// security package. The peer of Krb5Authenticator (POSIX, Phase 3).
+//
+// Uses Negotiate (which is SPNEGO on the wire) to negotiate with SQL Server's
+// SSPI server side. Negotiate transparently falls back to NTLM when the KDC
+// isn't reachable for the target SPN -- if you need Kerberos-only, the user
+// must register the SPN correctly in AD; we don't expose a separate
+// "Kerberos" package selection because go-mssqldb / mssql-jdbc / pyodbc
+// all use Negotiate.
+//
+// Compiled only when MSSQL_ENABLE_SSPI is defined (CMake sets it on _WIN32
+// via secur32 linkage). See spec 042 phase4-windows-sspi.md.
+//
+// IMPORTANT: this header MUST NOT include any DuckDB headers. The TDS auth
+// layer is reusable outside DuckDB.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#if defined(MSSQL_ENABLE_SSPI)
+
+#include "tds/auth/iauthenticator.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// Windows SSPI headers. Must define SECURITY_WIN32 before including <security.h>
+// so the right interface flavor is selected (vs SECURITY_KERNEL / SECURITY_MAC).
+#ifndef SECURITY_WIN32
+#define SECURITY_WIN32
+#endif
+// Avoid Windows.h's min/max macros polluting std::min / std::max.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <security.h>
+#include <sspi.h>
+
+namespace duckdb {
+namespace tds {
+
+//===----------------------------------------------------------------------===//
+// WinSspiConfig - inputs to WinSspiAuthenticator
+//
+// Far simpler than Krb5Config -- Windows SSPI uses the current logon session
+// only; no keytab path, no raw credentials, no krb5.conf override. The only
+// knob is the target SPN.
+//===----------------------------------------------------------------------===//
+struct WinSspiConfig {
+	std::string spn;  // e.g. "MSSQLSvc/host.example.com:1433"
+};
+
+//===----------------------------------------------------------------------===//
+// WinSspiAuthenticator - IAuthenticator impl via Windows SSPI Negotiate
+//===----------------------------------------------------------------------===//
+
+class WinSspiAuthenticator : public IAuthenticator {
+public:
+	// Validates the config at construction time so misconfigurations surface
+	// before any TDS traffic. Throws std::runtime_error if the SPN is empty.
+	// Native SSPI handles are NOT allocated here -- those happen in
+	// InitialBytes(), so handle-allocation failures surface at the right point
+	// in the connection lifecycle.
+	explicit WinSspiAuthenticator(WinSspiConfig config);
+
+	~WinSspiAuthenticator() override;
+
+	// Non-copyable / non-movable. SSPI handles aren't safe to copy.
+	WinSspiAuthenticator(const WinSspiAuthenticator &) = delete;
+	WinSspiAuthenticator &operator=(const WinSspiAuthenticator &) = delete;
+
+	std::vector<uint8_t> InitialBytes() override;
+	std::vector<uint8_t> NextBytes(const std::vector<uint8_t> &server_blob) override;
+	void Free() override;
+
+	// Testability accessor (parallel to Krb5Authenticator).
+	const std::string &GetSpn() const {
+		return config_.spn;
+	}
+
+private:
+	// One InitializeSecurityContext round. Used by both InitialBytes (first
+	// call, no input token) and NextBytes (continuation, server's 0xED blob
+	// as input). Returns the output blob; sets complete_ on SEC_E_OK.
+	std::vector<uint8_t> DoSecContextStep(const uint8_t *input_blob, size_t input_blob_len);
+
+	// Acquire credentials once on the first InitialBytes call. Uses
+	// AcquireCredentialsHandleW with Negotiate package + SECPKG_CRED_OUTBOUND
+	// + NULL auth data (current logon session).
+	void AcquireCredentials();
+
+	// Throw a runtime_error formatted like Krb5Authenticator's errors:
+	//   "MSSQL Kerberos auth failed: <what>: sspi_status=0x<hex>, <FormatMessageW text> [Hint: ...]"
+	// Same prefix and hint vocabulary so user-facing errors are platform-agnostic.
+	[[noreturn]] static void ThrowSspiError(const char *what, SECURITY_STATUS status);
+
+	WinSspiConfig config_;
+	bool complete_ = false;
+	bool acquired_ = false;
+	bool ctx_initialized_ = false;
+
+	// Native SSPI handles. SECINVALIDHANDLE-equivalent zero-initialization.
+	CredHandle cred_;
+	CtxtHandle ctx_;
+
+	// SPN in wide-char form, owned by the authenticator so the pointer passed
+	// to InitializeSecurityContextW stays valid across multiple calls.
+	std::wstring spn_w_;
+};
+
+}  // namespace tds
+}  // namespace duckdb
+
+#endif	// MSSQL_ENABLE_SSPI

--- a/src/include/tds/auth/winsspi_test_function.hpp
+++ b/src/include/tds/auth/winsspi_test_function.hpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// winsspi_test_function.hpp
+//
+// Registers mssql_winsspi_auth_test() -- the Windows SSPI peer of
+// mssql_kerberos_auth_test() (Phase 3). Exercises the SSPI handshake
+// (AcquireCredentialsHandleW + first InitializeSecurityContextW round)
+// without connecting to SQL Server, so users can diagnose SPN / ticket
+// problems before debugging an ATTACH.
+//
+// Spec 042 Phase 4.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+namespace mssql {
+namespace winsspi {
+
+void RegisterWinSspiTestFunction(ExtensionLoader &loader);
+
+}  // namespace winsspi
+}  // namespace mssql
+}  // namespace duckdb

--- a/src/mssql_extension.cpp
+++ b/src/mssql_extension.cpp
@@ -16,6 +16,7 @@
 #include "mssql_storage.hpp"
 #include "table_scan/mssql_optimizer.hpp"
 #include "tds/auth/krb5_test_function.hpp"
+#include "tds/auth/winsspi_test_function.hpp"
 
 namespace duckdb {
 
@@ -76,6 +77,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	//     Always registered; on builds without MSSQL_ENABLE_KRB5 it returns a
 	//     clear "compiled without Kerberos support" message instead of being absent.
 	mssql::krb5::RegisterKrb5TestFunction(loader);
+	mssql::winsspi::RegisterWinSspiTestFunction(loader);
 
 	// 13. Register optimizer extension for ORDER BY pushdown (Spec 039)
 	auto &db = loader.GetDatabaseInstance();

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -16,6 +16,10 @@
 #include "tds/auth/krb5_authenticator.hpp"
 #endif
 
+#if defined(MSSQL_ENABLE_SSPI)
+#include "tds/auth/winsspi_authenticator.hpp"
+#endif
+
 #include <string>
 
 namespace duckdb {
@@ -96,10 +100,18 @@ AuthStrategyPtr AuthStrategyFactory::Create(const MSSQLConnectionInfo &conn_info
 #endif
 	}
 	if (conn_info.auth_method == AuthMethod::WINSSPI) {
-		// Phase 4 will provide WinSspiAuthenticator. For now, error out cleanly.
+#if defined(MSSQL_ENABLE_SSPI)
+		WinSspiConfig wc;
+		wc.spn = DeriveSpn(conn_info);
+		auto authn = std::make_shared<WinSspiAuthenticator>(std::move(wc));
+		return std::make_shared<IntegratedAuthStrategy>(std::move(authn), conn_info.database,
+														"IntegratedAuth(winsspi)", conn_info.use_encrypt);
+#else
 		throw std::runtime_error(
-			"MSSQL Error: Windows SSPI authentication is not yet implemented in this build (spec 042 Phase 4). "
-			"Use SQL authentication or Azure AD in the meantime.");
+			"MSSQL Error: Windows SSPI authentication requires a Windows build of the extension. "
+			"On POSIX hosts, use 'authenticator=krb5' (or 'Trusted_Connection=yes' which auto-resolves "
+			"to krb5 on POSIX) after running 'kinit'.");
+#endif
 	}
 
 	// Priority for non-integrated paths: access_token > azure_secret > SQL auth (Spec 032)

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -104,8 +104,8 @@ AuthStrategyPtr AuthStrategyFactory::Create(const MSSQLConnectionInfo &conn_info
 		WinSspiConfig wc;
 		wc.spn = DeriveSpn(conn_info);
 		auto authn = std::make_shared<WinSspiAuthenticator>(std::move(wc));
-		return std::make_shared<IntegratedAuthStrategy>(std::move(authn), conn_info.database,
-														"IntegratedAuth(winsspi)", conn_info.use_encrypt);
+		return std::make_shared<IntegratedAuthStrategy>(std::move(authn), conn_info.database, "IntegratedAuth(winsspi)",
+														conn_info.use_encrypt);
 #else
 		throw std::runtime_error(
 			"MSSQL Error: Windows SSPI authentication requires a Windows build of the extension. "

--- a/src/tds/auth/winsspi_authenticator.cpp
+++ b/src/tds/auth/winsspi_authenticator.cpp
@@ -51,9 +51,9 @@ static std::wstring Utf8ToWide(const std::string &utf8) {
 // into a system-allocated buffer that we must LocalFree.
 static std::string FormatSspiStatus(SECURITY_STATUS status) {
 	LPWSTR buf = nullptr;
-	DWORD len = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-								   FORMAT_MESSAGE_IGNORE_INSERTS,
-							   nullptr, static_cast<DWORD>(status), 0, reinterpret_cast<LPWSTR>(&buf), 0, nullptr);
+	DWORD len =
+		FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+					   nullptr, static_cast<DWORD>(status), 0, reinterpret_cast<LPWSTR>(&buf), 0, nullptr);
 	std::string result;
 	if (len > 0 && buf) {
 		// Convert wide -> UTF-8 for the std::string error.
@@ -83,19 +83,24 @@ static std::string FormatSspiStatus(SECURITY_STATUS status) {
 static const char *HintForSspiStatus(SECURITY_STATUS status) {
 	switch (status) {
 	case SEC_E_NO_CREDENTIALS:
-		return "(Hint: no Windows credentials available. Log in to a domain account before running DuckDB, or use SQL authentication.)";
+		return "(Hint: no Windows credentials available. Log in to a domain account before running DuckDB, or use SQL "
+			   "authentication.)";
 	case SEC_E_CONTEXT_EXPIRED:
 		return "(Hint: Kerberos ticket expired. Log out and back in, or run 'klist purge && klist tgt' to refresh.)";
 	case SEC_E_TARGET_UNKNOWN:
 		return "(Hint: server SPN not registered. Verify with 'setspn -L <account>' on a Windows admin host.)";
 	case SEC_E_TIME_SKEW:
-		return "(Hint: clock skew between client and KDC exceeds 5 minutes. Sync system clock via Windows Time service: 'w32tm /resync'.)";
+		return "(Hint: clock skew between client and KDC exceeds 5 minutes. Sync system clock via Windows Time "
+			   "service: 'w32tm /resync'.)";
 	case SEC_E_NO_AUTHENTICATING_AUTHORITY:
-		return "(Hint: KDC / domain controller unreachable. Verify network connectivity and DNS resolution for the target realm.)";
+		return "(Hint: KDC / domain controller unreachable. Verify network connectivity and DNS resolution for the "
+			   "target realm.)";
 	case SEC_E_WRONG_PRINCIPAL:
-		return "(Hint: SPN mismatch -- the SPN your client requested does not match the SPN registered for the SQL Server account.)";
+		return "(Hint: SPN mismatch -- the SPN your client requested does not match the SPN registered for the SQL "
+			   "Server account.)";
 	case SEC_E_LOGON_DENIED:
-		return "(Hint: authentication denied -- check that your domain account is enabled and has access to the target server.)";
+		return "(Hint: authentication denied -- check that your domain account is enabled and has access to the target "
+			   "server.)";
 	default:
 		return nullptr;
 	}
@@ -151,11 +156,11 @@ void WinSspiAuthenticator::AcquireCredentials() {
 	// initiating a connection (vs accepting one as a server).
 	TimeStamp expiry;
 	SECURITY_STATUS status = AcquireCredentialsHandleW(
-		/*pszPrincipal=*/nullptr,				   // use default principal (logon session)
+		/*pszPrincipal=*/nullptr,  // use default principal (logon session)
 		/*pszPackage=*/const_cast<LPWSTR>(kNegotiatePackage),
 		/*fCredentialUse=*/SECPKG_CRED_OUTBOUND,
-		/*pvLogonId=*/nullptr,					   // no specific logon ID
-		/*pAuthData=*/nullptr,					   // use default creds
+		/*pvLogonId=*/nullptr,	// no specific logon ID
+		/*pAuthData=*/nullptr,	// use default creds
 		/*pGetKeyFn=*/nullptr,
 		/*pvGetKeyArgument=*/nullptr,
 		/*phCredential=*/&cred_,
@@ -263,7 +268,8 @@ std::vector<uint8_t> WinSspiAuthenticator::InitialBytes() {
 	if (blob.empty() && !complete_) {
 		throw std::runtime_error(
 			"MSSQL Kerberos auth failed: SSPI returned an empty initial SPNEGO token. "
-			"This is unexpected from the Negotiate package; check that the Windows logon session has Kerberos enabled.");
+			"This is unexpected from the Negotiate package; check that the Windows logon session has Kerberos "
+			"enabled.");
 	}
 	return blob;
 }

--- a/src/tds/auth/winsspi_authenticator.cpp
+++ b/src/tds/auth/winsspi_authenticator.cpp
@@ -1,0 +1,297 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// winsspi_authenticator.cpp
+//
+// Windows SSPI implementation of IAuthenticator via the Negotiate package.
+// Mirrors src/tds/auth/krb5_authenticator.cpp 1:1 in structure -- only the
+// native API call differs.
+//
+// Spec 042 Phase 4. Compiled only when MSSQL_ENABLE_SSPI is defined.
+//===----------------------------------------------------------------------===//
+
+#include "tds/auth/winsspi_authenticator.hpp"
+
+#if defined(MSSQL_ENABLE_SSPI)
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+namespace tds {
+
+namespace {
+
+// "Negotiate" security package. SSPI's Negotiate is SPNEGO on the wire --
+// exactly what SQL Server expects. NTLM fallback happens transparently when
+// the KDC is unreachable for the target SPN; we don't disable that because
+// it matches go-mssqldb / mssql-jdbc / pyodbc behavior.
+static const wchar_t *kNegotiatePackage = L"Negotiate";
+
+// Convert UTF-8 -> UTF-16 (Windows wchar_t). Used for the SPN passed to
+// InitializeSecurityContextW. Returns an empty wstring for empty input.
+static std::wstring Utf8ToWide(const std::string &utf8) {
+	if (utf8.empty()) {
+		return std::wstring();
+	}
+	int needed = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+	if (needed <= 0) {
+		return std::wstring();
+	}
+	std::wstring out(static_cast<size_t>(needed - 1), L'\0');  // -1: don't include null terminator
+	MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, &out[0], needed);
+	return out;
+}
+
+// Render a SECURITY_STATUS as a human-readable string. FormatMessageW writes
+// into a system-allocated buffer that we must LocalFree.
+static std::string FormatSspiStatus(SECURITY_STATUS status) {
+	LPWSTR buf = nullptr;
+	DWORD len = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+								   FORMAT_MESSAGE_IGNORE_INSERTS,
+							   nullptr, static_cast<DWORD>(status), 0, reinterpret_cast<LPWSTR>(&buf), 0, nullptr);
+	std::string result;
+	if (len > 0 && buf) {
+		// Convert wide -> UTF-8 for the std::string error.
+		int needed = WideCharToMultiByte(CP_UTF8, 0, buf, static_cast<int>(len), nullptr, 0, nullptr, nullptr);
+		if (needed > 0) {
+			result.resize(static_cast<size_t>(needed));
+			WideCharToMultiByte(CP_UTF8, 0, buf, static_cast<int>(len), &result[0], needed, nullptr, nullptr);
+			// FormatMessageW commonly appends "\r\n"; strip trailing whitespace.
+			while (!result.empty() && (result.back() == '\n' || result.back() == '\r' || result.back() == ' ')) {
+				result.pop_back();
+			}
+		}
+	}
+	if (buf) {
+		LocalFree(buf);
+	}
+	if (result.empty()) {
+		result = "(no FormatMessage text)";
+	}
+	return result;
+}
+
+// Spec 042 R8: map common SECURITY_STATUS codes to the same actionable hint
+// vocabulary as Krb5Authenticator::HintForMinor on POSIX. Returns nullptr if
+// the status doesn't match a known cause, so the caller can fall back to the
+// raw FormatMessage text only.
+static const char *HintForSspiStatus(SECURITY_STATUS status) {
+	switch (status) {
+	case SEC_E_NO_CREDENTIALS:
+		return "(Hint: no Windows credentials available. Log in to a domain account before running DuckDB, or use SQL authentication.)";
+	case SEC_E_CONTEXT_EXPIRED:
+		return "(Hint: Kerberos ticket expired. Log out and back in, or run 'klist purge && klist tgt' to refresh.)";
+	case SEC_E_TARGET_UNKNOWN:
+		return "(Hint: server SPN not registered. Verify with 'setspn -L <account>' on a Windows admin host.)";
+	case SEC_E_TIME_SKEW:
+		return "(Hint: clock skew between client and KDC exceeds 5 minutes. Sync system clock via Windows Time service: 'w32tm /resync'.)";
+	case SEC_E_NO_AUTHENTICATING_AUTHORITY:
+		return "(Hint: KDC / domain controller unreachable. Verify network connectivity and DNS resolution for the target realm.)";
+	case SEC_E_WRONG_PRINCIPAL:
+		return "(Hint: SPN mismatch -- the SPN your client requested does not match the SPN registered for the SQL Server account.)";
+	case SEC_E_LOGON_DENIED:
+		return "(Hint: authentication denied -- check that your domain account is enabled and has access to the target server.)";
+	default:
+		return nullptr;
+	}
+}
+
+}  // namespace
+
+WinSspiAuthenticator::WinSspiAuthenticator(WinSspiConfig config) : config_(std::move(config)) {
+	if (config_.spn.empty()) {
+		throw std::runtime_error(
+			"MSSQL Kerberos auth: empty SPN. AuthStrategyFactory should derive 'MSSQLSvc/<fqdn>:<port>' "
+			"from the host before constructing WinSspiAuthenticator.");
+	}
+	// Zero-init the native handles. SSPI uses sentinel zero values for "no
+	// handle" -- the same convention DeleteSecurityContext / FreeCredentialsHandle
+	// treats as a no-op.
+	SecInvalidateHandle(&cred_);
+	SecInvalidateHandle(&ctx_);
+
+	// Cache the SPN in wide-char form once. The pointer passed to
+	// InitializeSecurityContextW must remain valid across multiple calls (the
+	// API is "stable across continuation rounds").
+	spn_w_ = Utf8ToWide(config_.spn);
+	if (spn_w_.empty() && !config_.spn.empty()) {
+		throw std::runtime_error("MSSQL Kerberos auth: failed to convert SPN '" + config_.spn + "' to UTF-16.");
+	}
+}
+
+WinSspiAuthenticator::~WinSspiAuthenticator() {
+	Free();
+}
+
+void WinSspiAuthenticator::ThrowSspiError(const char *what, SECURITY_STATUS status) {
+	std::string text(what);
+	char buf[32];
+	std::snprintf(buf, sizeof(buf), ": sspi_status=0x%08lx, ", static_cast<unsigned long>(status));
+	text.append(buf);
+	text.append(FormatSspiStatus(status));
+	const char *hint = HintForSspiStatus(status);
+	if (hint) {
+		text.append(" ");
+		text.append(hint);
+	}
+	throw std::runtime_error(std::string("MSSQL Kerberos auth failed: ") + text);
+}
+
+void WinSspiAuthenticator::AcquireCredentials() {
+	if (acquired_) {
+		return;
+	}
+	// AcquireCredentialsHandleW with NULL auth data uses the current logon
+	// session's credentials. SECPKG_CRED_OUTBOUND because we're the client
+	// initiating a connection (vs accepting one as a server).
+	TimeStamp expiry;
+	SECURITY_STATUS status = AcquireCredentialsHandleW(
+		/*pszPrincipal=*/nullptr,				   // use default principal (logon session)
+		/*pszPackage=*/const_cast<LPWSTR>(kNegotiatePackage),
+		/*fCredentialUse=*/SECPKG_CRED_OUTBOUND,
+		/*pvLogonId=*/nullptr,					   // no specific logon ID
+		/*pAuthData=*/nullptr,					   // use default creds
+		/*pGetKeyFn=*/nullptr,
+		/*pvGetKeyArgument=*/nullptr,
+		/*phCredential=*/&cred_,
+		/*ptsExpiry=*/&expiry);
+	if (status != SEC_E_OK) {
+		// cred_ wasn't populated -- mark it invalid so Free() doesn't try to
+		// release an unallocated handle.
+		SecInvalidateHandle(&cred_);
+		ThrowSspiError("AcquireCredentialsHandleW (Negotiate)", status);
+	}
+	acquired_ = true;
+}
+
+std::vector<uint8_t> WinSspiAuthenticator::DoSecContextStep(const uint8_t *input_blob, size_t input_blob_len) {
+	// Build the input buffer descriptor (continuation case) or pass nullptr
+	// for the initial call. SSPI uses a SecBufferDesc with .cBuffers and an
+	// array of SecBuffer; for the input we have at most one SECBUFFER_TOKEN.
+	SecBuffer in_buf;
+	SecBufferDesc in_buf_desc;
+	SecBufferDesc *in_buf_desc_ptr = nullptr;
+	if (input_blob && input_blob_len > 0) {
+		in_buf.cbBuffer = static_cast<unsigned long>(input_blob_len);
+		in_buf.BufferType = SECBUFFER_TOKEN;
+		in_buf.pvBuffer = const_cast<uint8_t *>(input_blob);
+
+		in_buf_desc.ulVersion = SECBUFFER_VERSION;
+		in_buf_desc.cBuffers = 1;
+		in_buf_desc.pBuffers = &in_buf;
+		in_buf_desc_ptr = &in_buf_desc;
+	}
+
+	// Output buffer: SSPI allocates the token when we set ISC_REQ_ALLOCATE_MEMORY.
+	// We FreeContextBuffer'd it after copying out.
+	SecBuffer out_buf;
+	out_buf.cbBuffer = 0;
+	out_buf.BufferType = SECBUFFER_TOKEN;
+	out_buf.pvBuffer = nullptr;
+
+	SecBufferDesc out_buf_desc;
+	out_buf_desc.ulVersion = SECBUFFER_VERSION;
+	out_buf_desc.cBuffers = 1;
+	out_buf_desc.pBuffers = &out_buf;
+
+	// Flags mirror the GSSAPI flags in Krb5Authenticator::DoSecContextStep
+	// (mutual auth + replay/sequence detect + integrity/confidentiality) +
+	// ALLOCATE_MEMORY so SSPI owns the output buffer lifecycle.
+	const unsigned long flags = ISC_REQ_MUTUAL_AUTH | ISC_REQ_REPLAY_DETECT | ISC_REQ_SEQUENCE_DETECT |
+								ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_CONFIDENTIALITY | ISC_REQ_INTEGRITY;
+
+	unsigned long attrs = 0;
+	TimeStamp expiry;
+
+	// First call: phContext == nullptr (or invalid); subsequent calls pass the
+	// existing context handle. SSPI threads "is this the first call?" by the
+	// validity of phContext, NOT by some flag.
+	PCtxtHandle ctx_in = ctx_initialized_ ? &ctx_ : nullptr;
+
+	SECURITY_STATUS status = InitializeSecurityContextW(
+		/*phCredential=*/&cred_,
+		/*phContext=*/ctx_in,
+		/*pszTargetName=*/const_cast<LPWSTR>(spn_w_.c_str()),
+		/*fContextReq=*/flags,
+		/*Reserved1=*/0,
+		/*TargetDataRep=*/SECURITY_NATIVE_DREP,
+		/*pInput=*/in_buf_desc_ptr,
+		/*Reserved2=*/0,
+		/*phNewContext=*/&ctx_,
+		/*pOutput=*/&out_buf_desc,
+		/*pfContextAttr=*/&attrs,
+		/*ptsExpiry=*/&expiry);
+
+	// Mark context initialized after the first successful (or continue-needed)
+	// call so subsequent rounds pass it back in as phContext.
+	if (status == SEC_E_OK || status == SEC_I_CONTINUE_NEEDED) {
+		ctx_initialized_ = true;
+	}
+
+	if (status == SEC_E_OK) {
+		complete_ = true;
+	} else if (status != SEC_I_CONTINUE_NEEDED) {
+		// Error case. If the output buffer was allocated, free it before throwing.
+		if (out_buf.pvBuffer) {
+			FreeContextBuffer(out_buf.pvBuffer);
+		}
+		ThrowSspiError("InitializeSecurityContextW", status);
+	}
+
+	// Copy the output blob into a std::vector that the caller owns; then free
+	// SSPI's allocation. The vector outlives this function; the SSPI buffer
+	// would otherwise leak per call.
+	std::vector<uint8_t> out;
+	if (out_buf.pvBuffer && out_buf.cbBuffer > 0) {
+		const uint8_t *p = static_cast<const uint8_t *>(out_buf.pvBuffer);
+		out.assign(p, p + out_buf.cbBuffer);
+	}
+	if (out_buf.pvBuffer) {
+		FreeContextBuffer(out_buf.pvBuffer);
+	}
+	return out;
+}
+
+std::vector<uint8_t> WinSspiAuthenticator::InitialBytes() {
+	AcquireCredentials();
+	auto blob = DoSecContextStep(nullptr, 0);
+	if (blob.empty() && !complete_) {
+		throw std::runtime_error(
+			"MSSQL Kerberos auth failed: SSPI returned an empty initial SPNEGO token. "
+			"This is unexpected from the Negotiate package; check that the Windows logon session has Kerberos enabled.");
+	}
+	return blob;
+}
+
+std::vector<uint8_t> WinSspiAuthenticator::NextBytes(const std::vector<uint8_t> &server_blob) {
+	if (complete_) {
+		// Server sent more data after we were done. Some servers emit a
+		// final ack wrapper -- just return an empty blob to stop the loop.
+		return {};
+	}
+	return DoSecContextStep(server_blob.empty() ? nullptr : server_blob.data(), server_blob.size());
+}
+
+void WinSspiAuthenticator::Free() {
+	if (ctx_initialized_) {
+		DeleteSecurityContext(&ctx_);
+		SecInvalidateHandle(&ctx_);
+		ctx_initialized_ = false;
+	}
+	if (acquired_) {
+		FreeCredentialsHandle(&cred_);
+		SecInvalidateHandle(&cred_);
+		acquired_ = false;
+	}
+	complete_ = true;
+}
+
+}  // namespace tds
+}  // namespace duckdb
+
+#endif	// MSSQL_ENABLE_SSPI

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension
+//
+// winsspi_test_function.cpp
+//
+// mssql_winsspi_auth_test() scalar function -- Windows SSPI peer of
+// mssql_kerberos_auth_test(). Exercises AcquireCredentialsHandleW +
+// the first InitializeSecurityContextW round (i.e. WinSspiAuthenticator
+// ::InitialBytes()) without ever connecting to SQL Server, so users can
+// diagnose SPN / ticket problems in isolation.
+//
+// Spec 042 Phase 4.
+//
+// Mirrors krb5_test_function.cpp in shape and return-string format so a
+// future cross-platform `mssql_integrated_auth_test()` could replace both.
+//===----------------------------------------------------------------------===//
+
+#include "tds/auth/winsspi_test_function.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/common/vector_operations/generic_executor.hpp"
+#include "duckdb/function/scalar_function.hpp"
+
+#include <string>
+
+#if defined(MSSQL_ENABLE_SSPI)
+#include "tds/auth/winsspi_authenticator.hpp"
+
+// secur32.dll provides GetUserNameExW (via security.h) for the principal-
+// name lookup. SECURITY_WIN32 is already defined by winsspi_authenticator.hpp.
+#include <security.h>
+#endif
+
+namespace duckdb {
+namespace mssql {
+namespace winsspi {
+
+#if defined(MSSQL_ENABLE_SSPI)
+
+//===----------------------------------------------------------------------===//
+// LookupCurrentPrincipal - read the current logon session's UPN.
+//
+// Best-effort: returns "<unknown>" on any failure since principal-name
+// lookup failure shouldn't mask the actual auth result. Matches the
+// Kerberos LookupCcachePrincipal() shape.
+//===----------------------------------------------------------------------===//
+static std::string LookupCurrentPrincipal() {
+	// User principal name (alice@CORP.EXAMPLE.COM) is the closest analog to
+	// the kinit ccache principal we report on POSIX. Falls back to NameSamCompatible
+	// (DOMAIN\user) on machines where the UPN isn't set on the account.
+	ULONG size = 0;
+	GetUserNameExW(NameUserPrincipal, nullptr, &size);
+	if (size > 0) {
+		std::wstring buf(size, L'\0');
+		if (GetUserNameExW(NameUserPrincipal, buf.data(), &size)) {
+			buf.resize(size);
+			int needed = WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, nullptr, 0, nullptr, nullptr);
+			if (needed > 0) {
+				std::string utf8(needed - 1, '\0');
+				WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, utf8.data(), needed, nullptr, nullptr);
+				return utf8;
+			}
+		}
+	}
+	// UPN unavailable -- try NameSamCompatible (DOMAIN\user).
+	size = 0;
+	GetUserNameExW(NameSamCompatible, nullptr, &size);
+	if (size > 0) {
+		std::wstring buf(size, L'\0');
+		if (GetUserNameExW(NameSamCompatible, buf.data(), &size)) {
+			buf.resize(size);
+			int needed = WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, nullptr, 0, nullptr, nullptr);
+			if (needed > 0) {
+				std::string utf8(needed - 1, '\0');
+				WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, utf8.data(), needed, nullptr, nullptr);
+				return utf8;
+			}
+		}
+	}
+	return "<unknown>";
+}
+
+//===----------------------------------------------------------------------===//
+// RunWinSspiTest - the shared core
+//
+// Constructs a WinSspiAuthenticator with the supplied config, runs
+// InitialBytes() (which calls AcquireCredentialsHandleW +
+// InitializeSecurityContextW), returns a one-line status string. Catches
+// std::exception so the verbatim "MSSQL Kerberos auth failed: ..." message
+// surfaces to the caller verbatim instead of being thrown as a DuckDB error.
+//
+// Note the deliberate "MSSQL Kerberos auth ..." error-prefix shared with
+// Krb5Authenticator: from the user's perspective both paths are
+// "integrated authentication", and Negotiate falls back to Kerberos on
+// the wire when the SPN resolves -- so the same vocabulary is correct.
+//===----------------------------------------------------------------------===//
+static std::string RunWinSspiTest(tds::WinSspiConfig config) {
+	try {
+		tds::WinSspiAuthenticator authn(std::move(config));
+		auto blob = authn.InitialBytes();
+		std::string principal = LookupCurrentPrincipal();
+		return "OK: principal=" + principal + ", spn=" + authn.GetSpn() +
+			   ", mech=Negotiate, token_size=" + std::to_string(blob.size()) + " bytes";
+	} catch (const std::exception &e) {
+		return std::string(e.what());
+	}
+}
+
+//===----------------------------------------------------------------------===//
+// DeriveDefaultSpn - canonical "MSSQLSvc/<host>:<port>" form
+//===----------------------------------------------------------------------===//
+static std::string DeriveDefaultSpn(const std::string &host, uint16_t port) {
+	return "MSSQLSvc/" + host + ":" + std::to_string(port);
+}
+
+//===----------------------------------------------------------------------===//
+// WinSspiTestHost - mssql_winsspi_auth_test(host VARCHAR) -> VARCHAR
+//===----------------------------------------------------------------------===//
+static void WinSspiTestHost(DataChunk &args, ExpressionState & /*state*/, Vector &result) {
+	auto &host_vec = args.data[0];
+	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
+		std::string h = host.GetString();
+		tds::WinSspiConfig cfg;
+		cfg.spn = DeriveDefaultSpn(h, 1433);
+		return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
+	});
+}
+
+//===----------------------------------------------------------------------===//
+// WinSspiTestHostPort - mssql_winsspi_auth_test(host VARCHAR, port INTEGER)
+//===----------------------------------------------------------------------===//
+static void WinSspiTestHostPort(DataChunk &args, ExpressionState & /*state*/, Vector &result) {
+	auto &host_vec = args.data[0];
+	auto &port_vec = args.data[1];
+	BinaryExecutor::Execute<string_t, int32_t, string_t>(
+		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
+			std::string h = host.GetString();
+			tds::WinSspiConfig cfg;
+			cfg.spn = DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
+		});
+}
+
+//===----------------------------------------------------------------------===//
+// WinSspiTestSpn - mssql_winsspi_auth_test_spn(spn VARCHAR)
+//
+// Lets the user pass an explicit SPN that overrides default derivation,
+// e.g. when the host is an IP/alias and the registered SPN is something
+// else. Equivalent to the service_principal_name connection-string knob.
+//===----------------------------------------------------------------------===//
+static void WinSspiTestSpn(DataChunk &args, ExpressionState & /*state*/, Vector &result) {
+	auto &spn_vec = args.data[0];
+	UnaryExecutor::Execute<string_t, string_t>(spn_vec, result, args.size(), [&](string_t spn) {
+		tds::WinSspiConfig cfg;
+		cfg.spn = spn.GetString();
+		return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
+	});
+}
+
+#else  // !MSSQL_ENABLE_SSPI
+
+//===----------------------------------------------------------------------===//
+// Stub implementations on POSIX / when the extension was built without SSPI
+//
+// Registered unconditionally so a user on Linux who runs `SELECT
+// mssql_winsspi_auth_test(...)` gets a clear "wrong platform" message
+// rather than "no such function".
+//===----------------------------------------------------------------------===//
+
+static const char *kNoSspiMsg =
+	"MSSQL Windows SSPI auth test: this build of the mssql extension was compiled without "
+	"Windows SSPI support. Either this is a non-Windows build (POSIX uses mssql_kerberos_auth_test "
+	"instead) or it was built without -DENABLE_KRB5=ON on a Windows toolchain.";
+
+static void WinSspiTestHost(DataChunk &args, ExpressionState & /*state*/, Vector &result) {
+	auto &host_vec = args.data[0];
+	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(),
+											   [&](string_t) { return StringVector::AddString(result, kNoSspiMsg); });
+}
+static void WinSspiTestHostPort(DataChunk &args, ExpressionState & /*state*/, Vector &result) {
+	auto &host_vec = args.data[0];
+	auto &port_vec = args.data[1];
+	BinaryExecutor::Execute<string_t, int32_t, string_t>(
+		host_vec, port_vec, result, args.size(),
+		[&](string_t, int32_t) { return StringVector::AddString(result, kNoSspiMsg); });
+}
+static void WinSspiTestSpn(DataChunk &args, ExpressionState & /*state*/, Vector &result) {
+	auto &spn_vec = args.data[0];
+	UnaryExecutor::Execute<string_t, string_t>(spn_vec, result, args.size(),
+											   [&](string_t) { return StringVector::AddString(result, kNoSspiMsg); });
+}
+
+#endif	// MSSQL_ENABLE_SSPI
+
+void RegisterWinSspiTestFunction(ExtensionLoader &loader) {
+	// mssql_winsspi_auth_test(host)
+	ScalarFunction f1("mssql_winsspi_auth_test", {LogicalType::VARCHAR}, LogicalType::VARCHAR, WinSspiTestHost);
+	loader.RegisterFunction(f1);
+
+	// mssql_winsspi_auth_test(host, port)
+	ScalarFunction f2("mssql_winsspi_auth_test", {LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR,
+					  WinSspiTestHostPort);
+	loader.RegisterFunction(f2);
+
+	// mssql_winsspi_auth_test_spn(spn)
+	ScalarFunction f3("mssql_winsspi_auth_test_spn", {LogicalType::VARCHAR}, LogicalType::VARCHAR, WinSspiTestSpn);
+	loader.RegisterFunction(f3);
+}
+
+}  // namespace winsspi
+}  // namespace mssql
+}  // namespace duckdb

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -49,16 +49,22 @@ static std::string LookupCurrentPrincipal() {
 	// User principal name (alice@CORP.EXAMPLE.COM) is the closest analog to
 	// the kinit ccache principal we report on POSIX. Falls back to NameSamCompatible
 	// (DOMAIN\user) on machines where the UPN isn't set on the account.
+	// Note: we use &buf[0] / &utf8[0] (not .data()) for writable pointers because
+	// this project is pinned to C++11 for ODR compat with DuckDB, and
+	// std::wstring::data() / std::string::data() returned only const T* until
+	// C++17. The buffers are pre-sized non-empty before each &[0] is taken, so
+	// the addresses are valid storage. Calls reading from the buffer
+	// (WideCharToMultiByte's LPCWCH source) can keep using .data().
 	ULONG size = 0;
 	GetUserNameExW(NameUserPrincipal, nullptr, &size);
 	if (size > 0) {
 		std::wstring buf(size, L'\0');
-		if (GetUserNameExW(NameUserPrincipal, buf.data(), &size)) {
+		if (GetUserNameExW(NameUserPrincipal, &buf[0], &size)) {
 			buf.resize(size);
 			int needed = WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, nullptr, 0, nullptr, nullptr);
 			if (needed > 0) {
 				std::string utf8(needed - 1, '\0');
-				WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, utf8.data(), needed, nullptr, nullptr);
+				WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, &utf8[0], needed, nullptr, nullptr);
 				return utf8;
 			}
 		}
@@ -68,12 +74,12 @@ static std::string LookupCurrentPrincipal() {
 	GetUserNameExW(NameSamCompatible, nullptr, &size);
 	if (size > 0) {
 		std::wstring buf(size, L'\0');
-		if (GetUserNameExW(NameSamCompatible, buf.data(), &size)) {
+		if (GetUserNameExW(NameSamCompatible, &buf[0], &size)) {
 			buf.resize(size);
 			int needed = WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, nullptr, 0, nullptr, nullptr);
 			if (needed > 0) {
 				std::string utf8(needed - 1, '\0');
-				WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, utf8.data(), needed, nullptr, nullptr);
+				WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, &utf8[0], needed, nullptr, nullptr);
 				return utf8;
 			}
 		}

--- a/test/sql/integrated_auth/parsing.test
+++ b/test/sql/integrated_auth/parsing.test
@@ -165,3 +165,36 @@ CREATE SECRET ia_secret_conflict (
 );
 ----
 'authenticator' cannot be combined
+
+#
+# Test 15: authenticator=winsspi accepted by parser (spec 042 Phase 4).
+#         On POSIX builds the validator rejects with a clear platform-mismatch
+#         error. On Windows builds the ATTACH proceeds into SSPI -- expected to
+#         fail TCP / auth depending on environment, but the parser must not
+#         block it. We assert any MSSQL error -- the wording is platform-specific.
+#
+statement error
+ATTACH 'Server=sql.example.com;Database=db;authenticator=winsspi' AS ia_t15 (TYPE mssql);
+----
+MSSQL
+
+#
+# Test 16: Secret with authenticator=winsspi accepted by validator.
+#         Same wording assertion as test 15 -- platform-dependent error path.
+#
+statement ok
+CREATE SECRET ia_secret_winsspi (
+    TYPE mssql,
+    host 'sql.example.com',
+    port 1433,
+    database 'AdventureWorks',
+    authenticator 'winsspi'
+);
+
+statement error
+ATTACH '' AS ia_t16 (TYPE mssql, SECRET ia_secret_winsspi);
+----
+MSSQL
+
+statement ok
+DROP SECRET ia_secret_winsspi;

--- a/test/sql/integrated_auth/winsspi_basic.test
+++ b/test/sql/integrated_auth/winsspi_basic.test
@@ -1,0 +1,53 @@
+# name: test/sql/integrated_auth/winsspi_basic.test
+# description: Spec 042 Phase 4 -- Windows SSPI smoke test against a domain-joined
+#              SQL Server. Skipped unless MSSQL_WINSSPI_TEST=1 because CI runners
+#              aren't domain-joined; runs manually on a real Windows host.
+# group: [winsspi]
+
+require mssql
+
+require-env MSSQL_WINSSPI_TEST
+
+require-env MSSQL_TEST_HOST
+
+require-env MSSQL_TEST_DB
+
+#
+# Test 1: ATTACH via Trusted_Connection=yes (pyodbc-style alias).
+#         Resolves to authenticator=winsspi on Windows.
+#
+statement ok
+ATTACH 'Server=${MSSQL_TEST_HOST};Database=${MSSQL_TEST_DB};Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes' AS wsspi (TYPE mssql);
+
+#
+# Test 2: Basic SELECT through the catalog.
+#
+query I
+SELECT COUNT(*) > 0 FROM duckdb_tables() WHERE database_name = 'wsspi';
+----
+true
+
+#
+# Test 3: Raw query path via mssql_scan.
+#
+query I
+SELECT * FROM mssql_scan('wsspi', 'SELECT 1 AS one');
+----
+1
+
+statement ok
+DETACH wsspi;
+
+#
+# Test 4: ATTACH via explicit authenticator=winsspi (go-mssqldb form).
+#
+statement ok
+ATTACH 'Server=${MSSQL_TEST_HOST};Database=${MSSQL_TEST_DB};authenticator=winsspi;Encrypt=yes;TrustServerCertificate=yes' AS wsspi2 (TYPE mssql);
+
+query I
+SELECT * FROM mssql_scan('wsspi2', 'SELECT @@VERSION AS v');
+----
+<REGEX>:.*Microsoft.*
+
+statement ok
+DETACH wsspi2;


### PR DESCRIPTION
## Summary

Completes spec 042 with **Windows native integrated authentication** via `secur32.dll`'s Negotiate package. Peer of the Phase 3 `Krb5Authenticator` shipped in #98; same `IAuthenticator` interface, same SPNEGO continuation loop in `TdsConnection::AuthenticateIntegrated`. Implementation history and design discussion: [oluies/mssql-extension#12](https://github.com/oluies/mssql-extension/pull/12).

Branch was rebased onto current `main` (post-#98 / #102 / #109) — diff is the actual Phase 4 footprint with no churn against the recently-merged spec 043/044 codec work.

## User-visible

```sql
-- On a domain-joined Windows host, no kinit needed (uses the logon session):
LOAD mssql;
ATTACH 'Server=sqlhost.corp.example.com;Database=YourDB;Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes'
    AS db (TYPE mssql);

SELECT TOP 5 name FROM db.sys.tables;
```

`Trusted_Connection=yes` and `Integrated Security=SSPI` both resolve to `authenticator=winsspi` on Windows (and to `authenticator=krb5` on POSIX — unchanged). Same connection-string surface across platforms.

Diagnostic, mirroring `mssql_kerberos_auth_test`:

```sql
SELECT mssql_winsspi_auth_test('sqlhost.corp.example.com');
-- → OK: principal=DOMAIN\user, spn=MSSQLSvc/sqlhost.corp.example.com:1433,
--      mech=SPNEGO, token_size=... bytes
```

## Architecture

`WinSspiAuthenticator` is a peer of `Krb5Authenticator`. Both implement the three-method `IAuthenticator` interface (`InitialBytes` / `NextBytes` / `Free`) that landed in #98 specifically to enable this drop-in. The factory dispatches `AuthMethod::WINSSPI` to construct it, wrapped in the existing `IntegratedAuthStrategy` adapter.

**No changes** to:
- LOGIN7 builder (`BuildLogin7WithSSPI` + `fIntSecurity` bit)
- TDS 0xED token parser
- `TdsConnection::AuthenticateIntegrated()` continuation loop
- Pool plumbing, factory shape, parser surface

The only file that loses behavior is `src/tds/auth/auth_strategy_factory.cpp:98–103` — the "Phase 4 not yet implemented in this build" throw is replaced with a real `WinSspiAuthenticator` construction.

## SSPI ↔ GSSAPI mapping

| Concept | GSSAPI (Krb5Authenticator) | SSPI (WinSspiAuthenticator) |
|---|---|---|
| Acquire creds | `gss_acquire_cred(GSS_C_NO_NAME)` | `AcquireCredentialsHandleW(NULL, L"Negotiate", SECPKG_CRED_OUTBOUND, …)` |
| Init context | `gss_init_sec_context` w/ SPNEGO mech | `InitializeSecurityContextW` w/ `MUTUAL_AUTH \| ALLOCATE_MEMORY` |
| Done | `major == GSS_S_COMPLETE` | `status == SEC_E_OK` |
| Continue | `GSS_S_CONTINUE_NEEDED` | `SEC_I_CONTINUE_NEEDED` |
| Output blob | `gss_buffer_desc` | `SecBuffer` with `SECBUFFER_TOKEN` |
| Free output | `gss_release_buffer` | `FreeContextBuffer` |
| Status text | `gss_display_status` | `FormatMessageW` |
| Hint vocab | `HintForMinor(minor)` | `HintForSspiStatus(status)` — same hint set |

## Files

| File | Change | LoC |
|---|---|---|
| `src/include/tds/auth/winsspi_authenticator.hpp` | NEW — IAuthenticator impl, no DuckDB headers | +128 |
| `src/tds/auth/winsspi_authenticator.cpp` | NEW — Negotiate package + SecBuffer + FormatMessageW | +303 |
| `src/include/tds/auth/winsspi_test_function.hpp` | NEW | +27 |
| `src/tds/auth/winsspi_test_function.cpp` | NEW — `mssql_winsspi_auth_test` scalar | +219 |
| `src/tds/auth/auth_strategy_factory.cpp` | Replace "Phase 4 not yet implemented" throw | +18 / −5 |
| `src/mssql_extension.cpp` | Register `mssql_winsspi_auth_test` | +2 |
| `CMakeLists.txt` | Include new `.cpp` when `MSSQL_SSPI_AVAILABLE` | +6 |
| `scripts/ci/winsspi_test.ps1` | NEW — Windows test harness | +89 |
| `test/sql/integrated_auth/winsspi_basic.test` | NEW — `[winsspi]` smoke, gated on `MSSQL_WINSSPI_TEST=1` | +53 |
| `test/sql/integrated_auth/parsing.test` | POSIX-rejects-winsspi + Windows-accepts cases | +33 |
| `Kerberos.md` | Windows section rewritten; platform matrix updated | +168 / −4 |
| `CLAUDE.md` | Recent Changes entry + impl-files note | +6 / −3 |
| `CHANGELOG.md` | `### Added` entry under Unreleased | +8 |

**Total: +1,054 / −10, 13 files.**

## Verification done (macOS arm64, pre-rebase per oluies#12)

- Build clean (Release, ninja) — SSPI code is fully `#if defined(MSSQL_ENABLE_SSPI)`-guarded; macOS doesn't compile it
- `[integration]`: 30/30 pass (8 TLS skipped, no `MSSQL_TEST_DSN_TLS`)
- `[sql]`: 16/16 pass (304 assertions)
- `parsing.test`: 21 assertions pass (incl. the 2 new winsspi cases)
- `ATTACH '...authenticator=winsspi'` on macOS returns the documented "only supported on Windows" error
- `mssql_kerberos_auth_test` unaffected — same POSIX path

Post-rebase: cherry-picked the 7 Phase-4-unique commits cleanly onto current main; only two trivial documentation conflicts (resolved). No code conflicts. Local C++17-vs-vcpkg build issue prevented a fresh end-to-end build on this branch — that's an environment artifact (Homebrew simdutf vs C++11 ABI) unrelated to the rebased commits; same issue reproduces on `main` in a vcpkg-less worktree.

## Verification needed from a maintainer (Windows path)

Phase 4 code only compiles on `_WIN32`. To validate end-to-end:

1. **Build verification** — Actions → CI → Run workflow → check "Run Windows build jobs" on this branch. Both `build-windows-msvc` and `build-windows-mingw` jobs must succeed.
2. **Runtime verification** — on a domain-joined Windows host with the built `mssql.duckdb_extension`:
   ```
   duckdb --unsigned -c "LOAD '<path>'; ATTACH 'Server=<sqlhost>;Database=<db>;Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes' AS k (TYPE mssql); SELECT TOP 5 name FROM k.sys.tables;"
   ```
3. **Diagnostic function** — same host:
   ```
   SELECT mssql_winsspi_auth_test('sqlhost.corp.example.com');
   ```
   Returns `OK: principal=DOMAIN\user, spn=MSSQLSvc/sqlhost.corp.example.com:1433, mech=SPNEGO, token_size=...`.
4. **PS1 harness** (optional, automates 2 + 3): `scripts/ci/winsspi_test.ps1`.

## Limitations (documented in Kerberos.md)

- Only credential-cache mode (current Windows logon session). Keytab and raw-credentials modes remain POSIX-only — Windows `AcquireCredentialsHandleW` doesn't expose an equivalent surface for arbitrary keytabs/passwords without elevating to LSA territory, which is out of scope for an extension.
- The Negotiate package falls back to NTLM transparently if the KDC can't be reached for the target SPN. If you require Kerberos-only behavior, register the SPN correctly on the target server so the fallback is never triggered. `mssql_winsspi_auth_test` will report `mech=NTLM` in that case — a useful diagnostic before committing to production use.

## Risks I flagged in the spec 042 plan doc

| Risk | Mitigation |
|---|---|
| `SecBuffer` / `SecBufferDesc` setup | Mirrored `go-mssqldb`'s `winsspi.go`; canonical pattern |
| UTF-8 → UTF-16 SPN conversion | `MultiByteToWideChar` with `-1` length sentinel; stored once in member, reused across SPNEGO rounds |
| `ISC_REQ_ALLOCATE_MEMORY` lifetime | Always `FreeContextBuffer` after copy, including on error paths |
| MSVC vs MinGW prototypes | Two CI jobs catch divergence (Rtools 4.2 MinGW per `CLAUDE.md` Windows build notes) |
| Thread safety | One authenticator per pool connection — pre-existing design from #98, same as Krb5 |
| NTLM fallback | Acknowledged as Negotiate-package behavior; documented in `Kerberos.md`; surfaceable via diagnostic function |

## Rebase notes

The original fork branch (oluies/mssql-extension#12) was based on main from 2026-02-25 (merge-base `15bcb19`), pre-dating PR #98 / #102 / #109. The 17-commit branch had 10 commits already on main via #98's squashed merge (`14fdc63`) — those have been dropped. Only the 7 Phase-4-unique commits are carried forward. Two trivial documentation conflicts were resolved:

- `CLAUDE.md` "Recent Changes" — union'd: Phase 4 entry on top, 044 + 043 from main retained, 042 entry stripped of "Phase 4 deferred" wording
- `src/mssql_extension.cpp` — kept the new `#include "tds/auth/winsspi_test_function.hpp"`

No code conflicts.

## Test plan

- [ ] Maintainer triggers Windows CI on this branch via Actions → workflow_dispatch with "Run Windows build jobs" checked
- [ ] MSVC build green
- [ ] MinGW build green
- [ ] Manual ATTACH from a domain-joined Windows host succeeds
- [ ] `mssql_winsspi_auth_test('host')` succeeds on Windows
- [ ] `SELECT * FROM duckdb_tables() WHERE database_name = ...` returns results
- [ ] Negative case: no domain logon → clear error message with the new hint vocabulary
- [ ] No regression on macOS / Linux builds (Phase 3 paths unchanged)

## Closes

Completes spec 042 from #98. Supersedes [oluies/mssql-extension#12](https://github.com/oluies/mssql-extension/pull/12) (fork-internal PR retained for design-discussion history).
