### PR TITLE
ci(codeql): three-part speedup — target restriction + vcpkg cache + submodule trim

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,14 +35,37 @@ jobs:
       contents: read
       security-events: write
 
+    env:
+      # Route vcpkg's binary cache through GitHub Actions' built-in cache so
+      # OpenSSL / libcurl / simdutf etc. aren't rebuilt from source on every
+      # run. Cold runs save ~10-15 min; warm runs save the entire vcpkg-install
+      # phase. Note: ccache is intentionally NOT used here because it
+      # short-circuits compiler invocations and CodeQL's tracer would miss
+      # those translation units, leaving holes in the analysis.
+      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        # We intentionally do NOT pass submodules: recursive here. The default
+        # `submodules: false` is paired with an explicit duckdb-only init
+        # below, which avoids cloning `extension-ci-tools` (used only by the
+        # project Makefile, not by the direct cmake build CodeQL drives).
 
       - name: Checkout DuckDB submodule
+        # --recursive picks up DuckDB's own third_party/* submodules that the
+        # build needs (parquet decoders, etc.). extension-ci-tools is skipped.
         run: git submodule update --init --recursive duckdb
+
+      - name: Expose GitHub Actions cache env vars for vcpkg x-gha provider
+        # vcpkg's x-gha binary-source provider needs ACTIONS_CACHE_URL and
+        # ACTIONS_RUNTIME_TOKEN. GitHub injects them into actions/* steps but
+        # not into plain `run:` steps, so we re-export them via the toolkit.
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -63,6 +86,12 @@ jobs:
           ./vcpkg/bootstrap-vcpkg.sh
 
       - name: Build (CodeQL traces compiler invocations)
+        # We restrict the build to the loadable mssql extension target rather
+        # than the default ALL_BUILD. DuckDB's static lib is still pulled in
+        # as a build dependency, but we skip parquet_loadable_extension,
+        # core_functions_loadable_extension, the unittest binary, and the
+        # static-link variant -- none of which contain mssql sources CodeQL
+        # needs to analyze. ~15-20% wall-time saving on a typical run.
         run: |
           mkdir -p build/release
           cd build/release
@@ -72,7 +101,7 @@ jobs:
             -DVCPKG_MANIFEST_DIR="$(pwd)/../.." \
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
             ../../duckdb
-          cmake --build . --config Release
+          cmake --build . --config Release --target mssql_loadable_extension
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

The CodeQL job currently runs ~25–35 min, dominated by the build trace. Three changes:

1. **Restrict the build to the `mssql_loadable_extension` target** instead of the default `ALL_BUILD`. DuckDB's static lib is still a build dependency, but `parquet_loadable_extension`, `core_functions_loadable_extension`, the unittest binary, and the static-link extension variant are skipped. None of them contain mssql sources for CodeQL to analyze.
2. **vcpkg binary cache via `x-gha`** — `VCPKG_BINARY_SOURCES=clear;x-gha,readwrite`. Cold runs save the OpenSSL / libcurl / simdutf compile (~10–15 min); warm runs skip the vcpkg-install phase entirely. `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` are re-exported via `actions/github-script` because GitHub only injects them into `actions/*` steps, not plain `run:` blocks.
3. **Drop the redundant submodule recursion** in checkout. The previous workflow did both `submodules: recursive` AND an explicit `git submodule update --init --recursive duckdb`, recursively cloning `extension-ci-tools` (used only by the project Makefile, not the cmake build CodeQL drives). Keep only the explicit duckdb init.

## ccache — considered, rejected

It's the obvious "make compiles faster" lever, but it short-circuits compiler invocations, and CodeQL's C++ tracer works by intercepting them. Caching a `.o` means the compiler doesn't run, the TU is invisible to CodeQL, analysis gaps appear. The "fix" is `CCACHE_RECACHE=1`, which disables ccache entirely. So: real net win with CodeQL is zero. There's an env-block comment in the workflow so the next person doesn't try it again.

## Expected effect

| | Before | After (cold) | After (warm) |
|---|---|---|---|
| Wall-clock | 25–35 min | 12–18 min | 10–14 min |
| Coverage | baseline | same | same |

Numbers are estimates; the first run on this branch will be a cold run (vcpkg cache populates on success) and the second will be the warm baseline.

## Coverage check

Same queries (`security-extended`), same source tree, same translation-unit set the CodeQL tracer would have seen with the old workflow — restricting to one target only changes which final-link targets are produced, not which source files get compiled and traced. After this PR lands, the next CodeQL run on `main` should produce an identical findings count to the last pre-change run on `main`.

If findings disappear after this lands, the most likely cause is that a TU was reachable only via parquet/core_functions/static-link targets — flag it and I'll widen the target list.

## Test plan

- [ ] First CodeQL run on this PR completes successfully and produces a SARIF upload
- [ ] Second run (after vcpkg cache populates) is materially faster than the first
- [ ] No drop in findings count vs the last pre-change CodeQL run on `main`
- [ ] No new yamllint findings on the workflow itself

## Risk surface

- vcpkg `x-gha` is the documented Microsoft path; not custom. Risk of the cache eating disk: zero — Actions cache is auto-evicted at 10GB / 7 days idle.
- Target restriction: if CodeQL's tracer somehow needs the linker step to attribute results, that would be the surprise. Unlikely — the documented C++ flow is per-TU.
- Submodule cleanup: only risk is build failing on a fresh `extension-ci-tools` dependency we don't currently realize we have. If so, CI fails loudly on this PR and we revert that line.

Independent of #112 and #113.
