### PR TITLE
docs(spec): named-instance resolution via SQL Browser (spec 045)

### DIFF
--- a/specs/045-named-instance-resolution/plan.md
+++ b/specs/045-named-instance-resolution/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan: SQL Server Named-Instance Resolution
+
+**Branch**: `045-named-instance-resolution` | **Date**: 2026-05-16 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/045-named-instance-resolution/spec.md`
+**Research**: [research.md](./research.md) — wire format, mock-browser design, code placement, error taxonomy
+
+## Summary
+
+Resolve `Server=host\instance` connection strings via the SQL Server Browser
+service ([MS-SQLR]) before opening the TDS socket. Closes issue #77.
+
+The change is small and bounded: a new `InstanceResolver` under
+`src/connection/`, two new connection-info fields (`instance_name`,
+`server_spec`), surgical edits in `src/mssql_storage.cpp`
+(ADO.NET + URI parsers) and `src/tds/tds_connection.cpp` (LOGIN7
+`ServerName` keeps the instance), and a self-contained docker-compose
+test stack under `test/named-instance/` modelled on `test/kerberos/`.
+No new vcpkg dependencies. ~250 lines of new C++, ~60 lines of Python
+for the mock browser, ~150 lines of test harness.
+
+## Technical Context
+
+**Language/Version**: C++17 source, C++11-compatible ABI per the [[feedback_extension_version_stamp]] ODR rule on Linux.
+**Dependencies**: stdlib UDP socket only (BSD sockets on POSIX, Winsock2 on Windows — both already linked). Python 3 for the mock-browser test image.
+**Storage**: None. Resolution is stateless per-call; no cache (per [research.md §R5](./research.md#r5-caching-revisited)).
+**Testing**: GoogleTest C++ unit tests for the parser (no network), docker-compose integration tests for end-to-end (mock browser + SQL Server + test client). Targets macOS host + Linux CI; Windows + SSPI + named-instance verified manually per [research.md §R10](./research.md#r10-open--windows-test-path).
+**Target Platform**: Linux x86_64/ARM64, macOS ARM64, Windows x64.
+**Project Type**: DuckDB extension (single project, no client/server split).
+**Performance Goals**: SC-001 — < 200ms end-to-end attach against a healthy LAN browser.
+**Constraints**: No new vcpkg packages (NFR-003). Must not regress spec-042 integrated-auth (SC-005). Errors must distinguish Browser-broken from SQL-Server-broken (FR-007).
+**Scale/Scope**: One resolver call per connection-pool fill (not per query). Default pool size is 64 (`mssql_connection_limit`); resolution storm bounded at 64 × `pool_count` UDP packets per ATTACH burst — negligible.
+
+## Constitution Check
+
+**Bounded blast radius**: Resolver lives in `src/connection/`, called only from `MSSQLConnectionInfo::FromConnectionString`. The TDS layer is untouched apart from the LOGIN7 `ServerName` field. Failure modes are localised to ATTACH-time errors; no impact on running connections.
+
+**Reversible**: One CMake-toggleable setting (`mssql_named_instance_resolution`) lets users opt out at runtime. Removing the feature is a single-PR revert.
+
+**Explicit error surface**: Four distinct error categories (research.md §R8), each with a recommended user action. No silent fallbacks (e.g. *not* "if Browser fails, try port 1433 anyway" — that would mask config errors and is precisely why the current behaviour fails opaquely).
+
+**No new external dependencies**: stdlib sockets only. The mock browser is a Python test fixture, not shipped in the extension binary.
+
+**Test parity with `test/kerberos/`**: Mirrors the existing self-contained docker stack pattern, including the multi-stage Dockerfile that builds the extension inside Linux so macOS hosts can run integration tests.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/045-named-instance-resolution/
+├── spec.md         # what + why
+├── research.md     # MC-SQLR wire format, mock design, code placement, settings
+├── plan.md         # this file
+├── tasks.md        # phased task list
+└── quickstart.md   # bring-up + manual repro (written in Phase 2)
+```
+
+### Source Code (added or modified)
+
+```text
+src/
+├── connection/
+│   ├── instance_resolver.cpp           # NEW — ~150 LOC
+│   └── (mssql_settings.cpp)            # MOD — register two new settings
+├── include/
+│   └── connection/
+│       └── instance_resolver.hpp       # NEW — public interface
+├── include/
+│   └── mssql_storage.hpp               # MOD — new fields on MSSQLConnectionInfo
+├── mssql_storage.cpp                   # MOD — invoke resolver in FromConnectionString;
+│                                       #       fix ParseConnectionString + ParseUri
+│                                       #       to split host vs instance
+└── tds/
+    └── tds_connection.cpp              # MOD — populate tds_server_name_ from
+                                        #       host + instance_name (not host only)
+test/
+├── cpp/
+│   └── test_instance_resolver.cpp      # NEW — parser unit tests (canned UDP bytes)
+├── sql/
+│   └── named_instance/
+│       ├── resolve_basic.test          # NEW — happy path
+│       ├── resolve_unknown.test        # NEW — instance not found
+│       ├── resolve_browser_down.test   # NEW — timeout error message
+│       └── resolve_explicit_port.test  # NEW — instance + ,port skips browser
+└── named-instance/                     # NEW — mirrors test/kerberos/
+    ├── docker-compose.yml
+    ├── mock-browser/
+    │   ├── Dockerfile
+    │   └── browser.py
+    ├── sql/
+    │   ├── Dockerfile                  # bakes init.sql like test/kerberos/sql/
+    │   └── init.sql
+    ├── test-client/
+    │   ├── Dockerfile                  # multi-stage; builds extension in Linux
+    │   └── run-tests.sh
+    └── README.md
+```
+
+**Structure decision**: Single-project layout — same as every prior spec. Resolver under `src/connection/` because it's a connection-string concern (research.md §R4). Test stack under `test/named-instance/` to match `test/kerberos/`.
+
+## Phase 0: Wire format + parser
+
+**Deliverable**: A parser that turns canned `SVR_RESP` byte buffers into `vector<BrowserInstance>`, with unit tests covering happy path, multi-instance, truncated payload, garbage bytes, missing `tcp;` field, malformed key/value pairs.
+
+**Files**:
+- `src/include/connection/instance_resolver.hpp` (new)
+- `src/connection/instance_resolver.cpp` (new — parser only, no UDP yet)
+- `test/cpp/test_instance_resolver.cpp` (new)
+
+**No network in this phase.** The parser is pure: `vector<BrowserInstance> ParseBrowserResponse(string_view raw)`. Failures throw `IOException` with the diagnostic hex dump from research.md §R8.
+
+**Exit criteria**: `make test` passes; parser handles every canned input from the unit tests; coverage report shows 100% line coverage on the parser TU.
+
+## Phase 1: UDP transport + end-to-end resolver
+
+**Deliverable**: `InstanceResolver::Resolve(host, instance, timeout) → expected<uint16_t, ResolveError>`. Sends the `CLNT_UCAST_INST` query, parses the response, returns the TCP port. One retry on timeout. Tested against the mock browser (Phase 1 of the test stack — Phase 2 below).
+
+**Files**:
+- `src/connection/instance_resolver.cpp` (add `Resolve`, UDP socket code via `tds_platform.hpp` shims)
+
+**Cross-platform**: Use the same socket-creation pattern as `src/tds/tds_socket.cpp`. UDP-specific calls (`SOCK_DGRAM`, `recvfrom` with timeout via `SO_RCVTIMEO`) are minimal — no need for a new abstraction layer.
+
+**Exit criteria**: Resolver returns the mock browser's advertised port for a known instance; returns the expected typed error for each of the four failure modes in research.md §R8.
+
+## Phase 2: Test stack — mock browser + SQL Server + client
+
+**Deliverable**: `cd test/named-instance && docker compose up -d --build && docker compose exec test-client /run-tests.sh` passes on macOS Apple Silicon and Linux x86_64 / ARM64.
+
+**Files**:
+- `test/named-instance/docker-compose.yml`
+- `test/named-instance/mock-browser/{Dockerfile,browser.py}`
+- `test/named-instance/sql/{Dockerfile,init.sql}`
+- `test/named-instance/test-client/{Dockerfile,run-tests.sh}`
+- `test/named-instance/README.md`
+
+**Compose layout**: Two-hostname variant (research.md §R3) — mock browser on `browser.example.com`, SQL Server on `sql.example.com:11433`. Browser's `tcp;` field points its responses at `sql.example.com:11433`. Test client attaches via `Server=browser.example.com\TESTINST`, resolver returns `11433`, TDS connect goes to `sql.example.com:11433`, attach succeeds.
+
+**Mock-browser fault injection**: `MOCK_BROWSER_MODE` env var supports `truncate`, `garbage`, `silent`, `slow` for negative tests.
+
+**Exit criteria**: All four `test/sql/named_instance/*.test` files pass inside the test-client container. Stack starts cleanly on first run on a fresh macOS Docker Desktop install.
+
+## Phase 3: Plumbing — connection string parsers + LOGIN7
+
+**Deliverable**: `Server=host\instance` is accepted by ADO.NET, URI (with `%5C`), and secret forms. The resolver is invoked at `FromConnectionString` time. LOGIN7 `ServerName` carries `host\instance`. Default SPN under integrated auth uses the discovered port.
+
+**Files**:
+- `src/mssql_storage.cpp` — split host vs instance in `ParseConnectionString` + `ParseUri`; invoke resolver; populate `instance_name`.
+- `src/include/mssql_storage.hpp` — new fields on `MSSQLConnectionInfo`.
+- `src/tds/tds_connection.cpp` — `tds_server_name_` composition uses `host + "\\" + instance_name` when `instance_name` is non-empty; remove the "we don't use SQL Browser service" comment on line 340.
+- `src/connection/mssql_settings.cpp` — register `mssql_browser_timeout_seconds` (default 3, range 1..30) and `mssql_named_instance_resolution` (default true).
+
+**Spec-042 interaction**: No code change in `src/tds/auth/krb5_authenticator.cpp`. The discovered port lands in `info.port` before SPN derivation runs, so `MSSQLSvc/<host>:<discovered_port>` falls out naturally (research.md §R6).
+
+**Exit criteria**: SQL test suite under `test/sql/named_instance/` passes against the mock-browser stack. Manual smoke against the Kerberos stack confirms SPN derivation is unchanged.
+
+## Phase 4: Polish — quickstart + CLAUDE.md + release notes
+
+**Deliverable**:
+- `specs/045-named-instance-resolution/quickstart.md` — bring-up commands, manual repro steps for issue #77, Windows SSPI manual-test recipe (research.md §R10 path b).
+- `CLAUDE.md` updated with new settings and a one-line entry under "Recent Changes".
+- `Kerberos.md` cross-references named-instance support in the SPN section.
+- A small section in the user-facing README (if one exists) — defer this if the README is unmaintained, document in `CLAUDE.md` only.
+
+**Exit criteria**: Manual repro per `quickstart.md` works against a real Windows host (deferred to release-checklist; not a CI gate).
+
+## Risk Register
+
+| # | Risk | Likelihood | Mitigation |
+|---|------|------------|------------|
+| R1 | Docker DNS round-robins between the two hostname aliases, breaking the single-hostname compose variant | Medium (per research.md §R3) | Use the two-hostname variant from the start; documented in plan Phase 2. |
+| R2 | UDP 1434 blocked by host firewall (especially on macOS dev boxes) | High in dev, low in CI | Default 3s timeout + clear error message ("SQL Browser unreachable"). Document the firewall check in quickstart.md. |
+| R3 | Dynamic-port change between resolver and TCP connect (TOCTOU) | Very low (window is < 10ms) | Connection-pool retry on initial connect failure already handles this; if it bites, fail with a re-attach hint. No code change. |
+| R4 | Real SQL Server in unusual configs (clusters, AlwaysOn AGs) emits different Browser fields | Low | Parser ignores unknown fields; key off `InstanceName` + `tcp;` only. Clusters get a follow-up if anyone files a bug. |
+| R5 | Windows SSPI + named instance untested in CI | Medium | Manual smoke per quickstart.md. Linux Kerberos path exercises all the resolver code; SSPI differs only in the SPN-acquisition side, which spec 042 already covers. |
+| R6 | A user with `mssql_named_instance_resolution=false` and `Server=host\instance` hits a worse error than today | Low | Parse-time error: "named-instance resolution is disabled; set `mssql_named_instance_resolution=true` or use `Server=host,port`". |
+
+## Decisions Locked
+
+- **No port caching in v1** (research.md §R5).
+- **No LocalDB pipe support** (spec.md "Out of Scope").
+- **URI requires `%5C`**, no auto-decode of literal `\` (research.md §R7).
+- **Two new settings**, no retry-count setting (research.md §R9).
+- **Mock browser in Python**, not Go or C++ (research.md §R2).
+- **Two-hostname compose layout**, not single-alias trick (research.md §R3).
+- **Windows + SSPI + named instance is manual-test only**, not CI-gated (research.md §R10 → plan §Risk R5).
+
+## Cross-spec links
+
+- [[042-integrated-authentication]] — SPN derivation under integrated auth uses the resolved port.
+- [[031-connection-fedauth-refactor]] — same `MSSQLConnectionInfo` plumbing.
+- [[028-ansi-connection-options]] — ADO.NET parser entry point.

--- a/specs/045-named-instance-resolution/research.md
+++ b/specs/045-named-instance-resolution/research.md
@@ -1,0 +1,211 @@
+# Research: SQL Server Named-Instance Resolution (spec 045)
+
+Resolved questions and design decisions. All items are decision-locked unless flagged `OPEN`.
+
+## R1. Wire format — `CLNT_UCAST_INST` and `SVR_RESP`
+
+Source: [MS-SQLR] §2.2.1–2.2.4, cross-referenced against `microsoft/go-mssqldb/msdsn/browser.go` and the wire captures from `Microsoft.Data.SqlClient` (open-source `SqlConnectionFactory`).
+
+### Request — `CLNT_UCAST_INST`
+
+```
++---------+-------------------+------+
+| 0x04    | InstanceName ASCII| 0x00 |
++---------+-------------------+------+
+   1 byte    1..32 bytes        1
+```
+
+- Opcode `0x04` selects the unicast-by-name query (vs `0x02` `CLNT_UCAST_DAC` for dedicated admin connection, `0x03` `CLNT_UCAST_EX` for all instances on the host, `0x01` `CLNT_BCAST_EX` for subnet broadcast).
+- Instance name is ASCII, NUL-terminated, max 32 bytes including the NUL per the spec — *but* SQL Server only ever registers names of `[A-Za-z0-9_$#]{1,16}` (the engine itself rejects longer at install time), and we enforce the tighter range at parse time (FR-010). The 32-byte cap is the wire limit, not a permission to send longer.
+- Sent as a single UDP datagram to `host:1434`.
+
+### Response — `SVR_RESP`
+
+```
++---------+----------+----------------------+
+| 0x05    | RespSize | RespData (ASCII)     |
++---------+----------+----------------------+
+   1 byte    2 bytes    RespSize bytes
+                        NUL-terminated
+```
+
+- `RespSize` is little-endian.
+- `RespData` is a NUL-terminated ASCII string of `key;value;` pairs, one **logical record** per instance, concatenated. The record separator is implicit — `;;` marks end of record, but in practice SQL Server emits `IsClustered;No;` then immediately the next `ServerName;…` for the next instance, so the parser must key off the appearance of a second `ServerName;` to delimit records.
+- Standard keys for `CLNT_UCAST_INST` (always emitted, in this order): `ServerName`, `InstanceName`, `IsClustered`, `Version`, `tcp`, `np` (named pipes — present even when disabled, value `\\.\pipe\...`).
+- A record without a `tcp;` entry means TCP is disabled on that instance — we surface that as an explicit error ("instance found but TCP transport not enabled"), not as "instance not found".
+
+### Decision
+
+Implement the parser as a single state machine over the ASCII buffer: scan key, scan value, until end of buffer or `;;`. Build `vector<map<string, string>>`. Then `for each record: if record["InstanceName"].lower() == requested.lower(): return stoi(record["tcp"])`. ~80 lines of C++.
+
+## R2. Mock Browser — language and shape
+
+**Decision**: Python 3 + stdlib `socket`. ~60 lines. Lives at `test/named-instance/mock-browser/browser.py`.
+
+Alternatives considered:
+
+- **Go**: nicest concurrency story, but adds a second build toolchain to the test image.
+- **C++ reusing our own parser inverted**: looks neat but couples test infra to the implementation under test (a parser bug would mask itself).
+- **`nmap --script ms-sql-info`**: not a server, just a client.
+
+Python wins because every dev box already has `python3` and Docker's `python:3.12-slim` image is < 50MB. The mock implements `CLNT_UCAST_INST` only — broadcast / `UCAST_EX` return an empty response.
+
+Skeleton:
+
+```python
+import socket, os, struct
+
+INSTANCES = {
+    # InstanceName (case-insensitive) -> (server_name, tcp_port, version)
+    "TESTINST": ("sql.example.com", int(os.environ.get("SQL_TCP_PORT", "11433")), "15.0.4123.1"),
+    "SECONDARY": ("sql.example.com", int(os.environ.get("SQL_TCP_PORT_2", "11434")), "15.0.4123.1"),
+}
+
+def build_response(records):
+    body = ""
+    for name, (server, port, version) in records:
+        body += f"ServerName;{server};InstanceName;{name};IsClustered;No;Version;{version};tcp;{port};;"
+    body_bytes = body.encode("ascii") + b"\x00"
+    return bytes([0x05]) + struct.pack("<H", len(body_bytes)) + body_bytes
+
+def handle(data, addr, sock):
+    if not data or data[0] != 0x04:
+        return  # silently drop non-UCAST_INST queries
+    requested = data[1:].rstrip(b"\x00").decode("ascii", errors="replace")
+    match = [(n, v) for n, v in INSTANCES.items() if n.lower() == requested.lower()]
+    sock.sendto(build_response(match), addr)
+
+def main():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("0.0.0.0", 1434))
+    while True:
+        data, addr = sock.recvfrom(4096)
+        try: handle(data, addr, sock)
+        except Exception as e: print("err:", e)
+
+if __name__ == "__main__":
+    main()
+```
+
+The mock honours an env var `MOCK_BROWSER_MODE` for fault injection: `truncate` (drop the final NUL), `garbage` (send 8 random bytes), `silent` (don't reply at all), `slow` (sleep 5s before replying — exercises the resolver's 3s timeout + retry path).
+
+## R3. Docker compose layout
+
+Three services on a private bridge network, mirroring `test/kerberos/`:
+
+```
+test/named-instance/
+├── docker-compose.yml
+├── mock-browser/
+│   ├── Dockerfile        # FROM python:3.12-slim; COPY browser.py
+│   └── browser.py
+├── sql/
+│   └── init.sql          # CREATE DATABASE NamedInstTest; CREATE TABLE ...
+├── test-client/
+│   ├── Dockerfile        # multi-stage: build extension, copy into runtime
+│   └── run-tests.sh
+└── README.md
+```
+
+Services:
+
+| service        | hostname              | image                                     | exposed   |
+|----------------|-----------------------|-------------------------------------------|-----------|
+| `sql`          | `sql.example.com`     | `mcr.microsoft.com/mssql/server:2022-latest` (started on port 11433, not 1433, to prove the resolver actually does something) | 11433/tcp |
+| `mock-browser` | `sql.example.com`     | local Python build                        | 1434/udp  |
+| `test-client`  | `client.example.com`  | local multi-stage build of the extension  | —         |
+
+**Key choice**: `mock-browser` shares the `sql.example.com` hostname alias with the SQL Server container — Docker networking lets two services answer on different ports of the same hostname only if they don't both bind 0.0.0.0 inside their containers. We instead give `mock-browser` and `sql` **distinct service names** but both `aliases: [sql.example.com]` on the network. The mock binds `0.0.0.0:1434/udp`, the SQL container binds `0.0.0.0:11433/tcp` — no conflict because Docker DNS resolves `sql.example.com` to two IPs and the client picks based on port. *Verify on first compose-up*: if Docker DNS round-robins, fall back to two distinct hostnames (`browser.example.com` for the mock, `sql.example.com` for SQL) and the mock points its `tcp;` field at `sql.example.com:11433`. The client only resolves `browser.example.com` for the UDP send, then resolves whatever hostname the Browser returned for the TCP connect.
+
+**Decision**: start with the **two-hostname** layout because it's robust and matches real-world Browser semantics (Browser can advertise a different host than itself, e.g. failover-cluster scenarios). The single-alias trick is a micro-optimisation that buys nothing.
+
+## R4. Resolver placement in code
+
+```
+src/connection/instance_resolver.{hpp,cpp}   // new file, ~250 LOC
+src/include/connection/instance_resolver.hpp
+test/cpp/test_instance_resolver.cpp          // parser unit tests, no network
+```
+
+**Why under `connection/`, not `tds/`**: the resolver is a connection-string concern, not a TDS protocol concern. It runs *before* the first byte of TDS hits the wire. Placing it in `tds/` would force `tds_connection.cpp` to know about UDP, which it doesn't today.
+
+**Entry point**: `MSSQLConnectionInfo::FromConnectionString` already centralises parsing in `src/mssql_storage.cpp`. After it sets `result->host` and `result->port`, a new branch:
+
+```cpp
+if (server_spec.instance.has_value() && !server_spec.explicit_port.has_value()) {
+    auto resolved = InstanceResolver::Resolve(result->host, *server_spec.instance,
+                                              settings.browser_timeout_seconds);
+    if (resolved.is_error()) throw IOException(resolved.error_message());
+    result->port = resolved.value();
+}
+result->instance_name = server_spec.instance.value_or("");  // for LOGIN7 ServerName + SPN
+```
+
+The `instance_name` field on `MSSQLConnectionInfo` is new and consumed by `tds_connection.cpp` when composing `tds_server_name_` (replacing the current `host` → `host\instance` reconstruction logic, which today only works for routing-redirect targets).
+
+## R5. Caching: revisited
+
+Spec text already commits to "no caching in v1". Restating *why* for future reviewers:
+
+- Resolution is one UDP RTT on a healthy LAN. Measured at ~2ms in dev; 10ms is the conservative upper bound (NFR-001).
+- Dynamic ports change on every SQL Server service restart. A cache means the first attach *after* a service restart silently connects to a stale port and gets either a TCP RST or — worse, in a multi-instance setup — a connection to the *wrong* instance.
+- The work to do caching safely (TTL + invalidation on connect failure) is non-trivial relative to the work to skip caching (zero).
+- Connection pooling already reuses authenticated sessions; the resolver only fires for pool-fill, not for query execution.
+
+If someone shows a benchmark where the 2ms matters, we'll revisit. Until then: no cache.
+
+## R6. SPN derivation under integrated auth
+
+The current SPN derivation in `src/tds/auth/krb5_authenticator.cpp` builds `MSSQLSvc/<host>:<port>` from `info.host` and `info.port`. After spec 045:
+
+- `info.host` is unchanged (the original hostname token, instance stripped).
+- `info.port` is the **discovered** port from the Browser response.
+- The default SPN therefore becomes `MSSQLSvc/<host>:<discovered_port>`, which is what AD registers for named instances by default ([the SQL Server docs page on SPN registration](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/register-a-service-principal-name-for-kerberos-connections) is explicit on this).
+
+**No code change in the auth path** — the resolver writes the discovered port into `info.port` before auth ever runs.
+
+**Override path** is also unchanged: `service_principal_name=` short-circuits derivation. FR-009 explicit.
+
+## R7. URI parsing — backslash handling
+
+The URI grammar (RFC 3986 §3.2.2 host) does not permit `\` in `host`. Three options:
+
+1. **Reject literal `\`**, require `%5C` (current spec — FR via User Story 2 AS#3).
+2. **Tolerate literal `\`** by URL-decoding in a pre-pass — most users won't know to encode.
+3. **Tolerate, with a deprecation warning** — soften over one release.
+
+**Decision**: option 1. The URI form is the niche surface (ADO.NET is what most users paste); tolerating malformed URIs is a lifetime of paper cuts (every parser disagreement is a new bug). A clear error pointing at `%5C` is one Google search away from a fix.
+
+## R8. Error taxonomy
+
+Four distinct failure modes; each MUST produce a distinct error so support questions are triagable from the message alone:
+
+| Failure                       | Message prefix                                            | Suggested action                                       |
+|-------------------------------|-----------------------------------------------------------|--------------------------------------------------------|
+| Browser unreachable (timeout) | `SQL Browser unreachable at <host>:1434/udp after Ns`     | Check firewall (UDP 1434), `SQL Server Browser` service |
+| Browser reachable, instance unknown | `instance '<name>' not found on host '<host>'; available: <list>` | Check spelling, `SELECT @@SERVERNAME` on the instance  |
+| Instance found, TCP disabled  | `instance '<name>' exists but TCP transport is disabled`  | Enable TCP/IP in SQL Server Configuration Manager      |
+| Malformed Browser response    | `malformed SQL Browser response: <hex dump first 32 bytes>` | File a bug — should never happen with real SQL Server  |
+
+The hex dump in case 4 is intentional: we've seen security middleboxes mangle UDP 1434 responses, and the dump is the only diagnostic that survives the user-bug-report game of telephone.
+
+## R9. Settings names — bikeshed-locked
+
+Two new DuckDB settings:
+
+| Setting                                | Default | Range         |
+|----------------------------------------|---------|---------------|
+| `mssql_browser_timeout_seconds`        | `3`     | `1..30`       |
+| `mssql_named_instance_resolution`      | `true`  | `true`/`false`|
+
+Naming follows the existing `mssql_<thing>_<unit>` convention (cf. `mssql_connection_timeout`, `mssql_idle_timeout`). No setting for retry count — one retry is hard-coded (FR-006). If we ever need to disable the retry, a setting is a one-line addition.
+
+## R10. OPEN — Windows test path
+
+The mock-browser stack is Linux-containers-only. SSPI integrated-auth on a real named instance is the one combination that won't be exercised by the CI mock stack (because the mock SQL Server has no Browser of its own and the test client uses Kerberos via the `test/kerberos/` stack on Linux, not SSPI). Options:
+
+- **(a)** Add a Windows runner job to `.github/workflows/ci.yml` that installs SQL Server Express with a named instance and runs a slimmed-down smoke test. Slow (~10 min) but real.
+- **(b)** Mark "Windows + SSPI + named instance" as manually verified in the release checklist, document the manual repro steps, do not gate CI on it.
+- **(c)** Defer to a follow-up spec.
+
+Lean toward **(b)** because the Linux Kerberos path already exercises every byte of the resolver and the SPN-derivation logic, and option (a) would more than double total CI wall time. *Decision deferred to plan.md.*

--- a/specs/045-named-instance-resolution/spec.md
+++ b/specs/045-named-instance-resolution/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: SQL Server Named-Instance Resolution (SQL Browser)
+
+**Feature Branch**: `045-named-instance-resolution`
+**Created**: 2026-05-16
+**Status**: Draft
+**Resolves**: [#77 — Unable to connect to the named instance](https://github.com/hugr-lab/mssql-extension/issues/77)
+**Input**: User request: "Add support for `host\instance` server strings, like every other SQL Server client does."
+
+## Problem Statement
+
+Users with multiple SQL Server instances on a single host — the standard developer-laptop and shared-test-server pattern on Windows — install each engine as a **named instance** (e.g. `MSSQLSERVER` plus `SS2022` plus `SS2019`). Every instance other than the first listens on a **dynamic TCP port** chosen at service startup. Microsoft's reference page for [database engine instances](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/database-engine-instances-sql-server) is explicit that named instances are accessed by `host\instance` and that the port discovery happens via the **SQL Server Browser** service on UDP **1434** ([MC-SQLR]).
+
+Today the extension treats the whole `host\instance` token as a DNS name:
+
+```sql
+ATTACH 'Server=localhost\SS2022;Database=db;User Id=sa;Password=...' AS db (TYPE mssql);
+-- Error: Cannot resolve hostname 'localhost\SS2022'
+```
+
+The connection-string parser in `src/mssql_storage.cpp` splits on `,` (port) only, not on `\` (instance), so `host` ends up as the literal `"localhost\\SS2022"` and `getaddrinfo()` rejects it. The TDS connection layer does strip the instance for routing-redirect targets (`src/tds/tds_connection.cpp:340–347`, with the comment *"we don't use SQL Browser service"*) but never for the initial connect, and never to discover the actual port. Reporter @Stan-RED hit this with three coexisting engines on one host; @VGSML (contributor) confirmed it is unimplemented and recommended the manual fixed-port workaround.
+
+This feature adds a real **SQL Server Browser** client that:
+
+1. Recognises `host\instance` in the `Server` field (ADO.NET, URI, secret).
+2. Sends a `CLNT_UCAST_INST` UDP query to `host:1434`.
+3. Parses the `tcp;<port>` token out of the response.
+4. Hands `(host, discovered_port)` to the existing TDS connect path.
+
+The user-visible surface — `Server=host\instance` with no extra knobs — matches every other SQL Server client (pyodbc, `sqlcmd`, JDBC, `go-mssqldb`).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Connect to a named instance on a Windows dev box (Priority: P1)
+
+A developer has SQL Server 2019, 2022, and a Developer-edition Express install on `localhost`, each as a named instance (`SS2019`, `SS2022`, `SQLEXPRESS`). The 2022 instance is on a dynamic port that changes whenever the service restarts. They attach using the standard `host\instance` form, with no port specified:
+
+```sql
+ATTACH 'Server=localhost\SS2022;Database=AdventureWorks;User Id=sa;Password=...;TrustServerCertificate=yes'
+  AS adw (TYPE mssql);
+SELECT TOP 1 name FROM adw.sys.tables;
+```
+
+The extension queries SQL Browser on `localhost:1434/udp`, gets back the current TCP port for `SS2022`, connects there, and the query succeeds. Restarting the SQL Server service may change the dynamic port — the next ATTACH still works because each new connection re-resolves.
+
+**Why this priority**: This is the *only* user-visible feature in this spec. P1 is what fixes #77 for the reporter and the user who commented "this would be a very useful enhancement".
+
+**Independent Test**: Bring up the test stack (see User Story 4); from the test client, `ATTACH 'Server=mock-browser-host\TESTINST;...'` and run a `SELECT 1`. Delivers end-to-end named-instance resolution against a faithful mock Browser.
+
+**Acceptance Scenarios**:
+
+1. **Given** SQL Browser is running on the target host and the named instance exists, **When** the user attaches with `Server=host\instance`, **Then** the connection succeeds and catalog queries return rows.
+2. **Given** the user supplies `Server=host\instance,1433`, **When** they attach, **Then** the explicit port is honoured and SQL Browser is **not** contacted (the instance name is still sent in LOGIN7 `ServerName`).
+3. **Given** SQL Browser is unreachable (firewall, service stopped), **When** the user attaches with `Server=host\instance`, **Then** ATTACH fails fast (within `mssql_browser_timeout_seconds`, default 3s) with an error containing `"SQL Browser unreachable"` and the resolved address.
+4. **Given** SQL Browser responds but the requested instance is not in the response, **When** the user attaches, **Then** ATTACH fails with `"instance '<name>' not found on host '<host>'; available instances: <list>"`.
+5. **Given** a subsequent ATTACH/connection-pool refill, **When** the dynamic port has changed since the last resolve, **Then** the next connect re-resolves and picks up the new port (no stale-port caching by default).
+
+### User Story 2 — URI and secret forms accept `host\instance` (Priority: P2)
+
+The same `host\instance` form works in the alternate connection-string surfaces:
+
+- URI: `mssql://sa:pw@localhost%5CSS2022/db` (URL-encoded backslash, since `\` is not a valid URI host character).
+- Secret: `CREATE SECRET (TYPE mssql, host 'localhost\SS2022', database 'db', user 'sa', password '...')`.
+
+**Why this priority**: Consistency across our three input surfaces. Users who paste a URI from CI config or pull from a secret should not have to know which surface the resolver is plumbed through.
+
+**Acceptance Scenarios**:
+
+1. **Given** a URI with `%5C` between host and instance, **When** the user attaches, **Then** the resolver is invoked with the decoded `host\instance` pair.
+2. **Given** a secret with `host = 'localhost\SS2022'`, **When** the user attaches via the secret, **Then** the resolver is invoked identically to ADO.NET form.
+3. **Given** a URI with a literal backslash (`mssql://sa:pw@localhost\SS2022/db`), **When** the user attaches, **Then** ATTACH fails with a parse-time error pointing at `%5C`, since the URI grammar forbids the bare character.
+
+### User Story 3 — Integrated auth (Kerberos / SSPI) against a named instance (Priority: P2)
+
+A user with `Trusted_Connection=yes` connects to `host\instance`. The resolver discovers the port; the existing integrated-auth code derives the SPN from the **original** `host` and the **discovered** port — `MSSQLSvc/host.fqdn:<discovered-port>` — matching AD's default SPN registration for named instances.
+
+**Why this priority**: Spec 042 shipped Kerberos/SSPI; named-instance support is incomplete without it interoperating, and AD-joined SQL Server users on dev boxes are the most likely hitters of #77.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Kerberos TGT and `Server=host\instance;Trusted_Connection=yes`, **When** the user attaches, **Then** SPN derivation uses the discovered port and the SPNEGO negotiation succeeds.
+2. **Given** the user supplies an explicit `service_principal_name=MSSQLSvc/fixed-spn:1433`, **When** they attach with `host\instance`, **Then** the explicit SPN is used (override takes precedence over derivation), and resolution still discovers the port for the TCP connect.
+
+### User Story 4 — Mock Browser docker stack runs in CI (Priority: P1, *test infrastructure*)
+
+The CI build brings up a self-contained 3-service compose stack: a SQL Server container (one instance, fixed port — the Linux image has no Browser concept), a small UDP responder that mimics SQL Server Browser's `CLNT_UCAST_INST` reply pointing at the SQL Server container on a non-default port, and the test client. Tests run end-to-end on macOS hosts (no Windows runner needed).
+
+**Why this priority**: Without this, the only way to test the feature is a hand-installed Windows SQL Server with two named instances — slow, flaky, and incompatible with the project's existing macOS-first developer workflow.
+
+**Acceptance Scenarios**:
+
+1. **Given** `cd test/named-instance && docker compose up -d --build`, **When** the developer runs `docker compose exec test-client /run-tests.sh`, **Then** the suite passes on Linux and on macOS (Apple Silicon) without modification.
+2. **Given** the suite, **When** it executes, **Then** it covers: (a) successful resolve, (b) unknown-instance, (c) Browser unreachable, (d) explicit-port skip-resolver, (e) malformed-response handling.
+
+### Edge Cases
+
+- **Empty instance name** (`Server=localhost\`): reject at parse time, mirroring `sqlcmd`.
+- **Instance name with whitespace or `;`**: reject at parse time (the instance grammar in [MC-SQLR] is `[A-Za-z0-9_$#]`).
+- **Browser reachable but returns a UDP packet > 65535 bytes / truncated**: cap at one MTU (1472 bytes), parse what we got, fail-clean on truncation rather than reading past the buffer.
+- **Browser returns multiple instances**: pick the one whose `InstanceName` matches the requested instance **case-insensitively**, matching SQL Server's own comparison (`Latin1_General_CI_AS` for identifiers).
+- **IPv6 hosts**: the UDP send goes to the same address family that DNS resolves, no special-casing required.
+- **`(local)\instance` and `.\instance`** (legacy `sqlcmd` forms): resolve to `localhost` before the UDP send.
+- **Concurrent attaches racing the same Browser**: each connection resolves independently — Browser is cheap (one UDP RTT) and a tiny shared cache risks stale ports after service restarts. *No caching in v1.* Revisit only if benchmarks show measurable cost.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When the `Server` field in ADO.NET, URI, or secret form contains `\` and no explicit port, the extension MUST treat the suffix after `\` as a SQL Server instance name and resolve it via SQL Server Browser before connecting.
+- **FR-002**: When the `Server` field contains both `\instance` and `,port`, the extension MUST use the explicit port and MUST NOT contact SQL Browser. The instance name is still passed in LOGIN7 `ServerName`.
+- **FR-003**: The resolver MUST send a `CLNT_UCAST_INST` packet (`0x04` + ASCII instance name + `0x00`) to `host:1434/udp` as specified in [MC-SQLR] §2.2.1.
+- **FR-004**: The resolver MUST parse the `SVR_RESP` body — a NUL-terminated `key;value;key;value;…` ASCII string with one record per instance — and extract the `tcp;<port>` token for the matching `InstanceName`. Comparison is case-insensitive.
+- **FR-005**: The resolver MUST time out after `mssql_browser_timeout_seconds` (default **3s**). The default has to be short because the resolver is on the critical path of every connect for a named-instance attach.
+- **FR-006**: The resolver MUST retry the UDP send **once** on timeout before failing (UDP is lossy; the cost of a single retry is small relative to the cost of a spurious ATTACH failure).
+- **FR-007**: On unreachable Browser, unknown instance, or malformed response, the extension MUST surface a typed error distinguishable from generic TCP-connect failures, so users can tell "Browser broken" apart from "SQL Server broken".
+- **FR-008**: The resolved `(host, port)` MUST flow through the existing TDS connect path unchanged. `tds_server_name_` (LOGIN7 `ServerName`) MUST keep the original `host\instance` form, not the discovered port.
+- **FR-009**: When `Trusted_Connection=yes` and `Server=host\instance` are combined, the default SPN MUST be derived as `MSSQLSvc/<host.fqdn>:<discovered-port>` — *not* `MSSQLSvc/host\instance` (which AD does not register). An explicit `service_principal_name=` override takes precedence.
+- **FR-010**: The instance grammar MUST be enforced at parse time: `[A-Za-z0-9_$#]{1,16}` per [MC-SQLR] §2.2.2. Reject empties and out-of-grammar characters with a clear error.
+- **FR-011**: The legacy `(local)\instance` and `.\instance` aliases MUST be normalised to `localhost\instance` before resolution.
+- **FR-012**: The `mssql_named_instance_resolution` setting (default `true`) MUST allow disabling the resolver entirely; with it `false`, a `host\instance` server string fails at parse time with "named-instance resolution disabled". Gives an escape hatch for environments that strip outbound UDP.
+- **FR-013**: All error messages MUST include both the original `host\instance` token and (where known) the resolved address, so support questions on the issue tracker have enough context to triage without a reproducer.
+
+### Non-Functional Requirements
+
+- **NFR-001** (Performance): Resolution overhead on a healthy LAN MUST be < 10ms typical (one UDP RTT), and the implementation MUST NOT block other connections — the UDP send is per-connection and self-contained.
+- **NFR-002** (Portability): The resolver MUST work on Linux, macOS, and Windows. UDP socket APIs differ enough (Winsock vs BSD) that the implementation reuses `tds_platform.hpp` shims rather than introducing a new abstraction.
+- **NFR-003** (No new dependencies): UDP socket + parse — no new vcpkg packages. The whole resolver is `< 400` lines of C++ plus tests.
+- **NFR-004** (Test independence): The mock-browser test stack MUST work on macOS Docker Desktop without modification, following the `test/kerberos/` precedent.
+
+### Key Entities
+
+- **InstanceServerSpec**: parsed `Server` field — `{ host: string, instance: optional<string>, explicit_port: optional<uint16_t> }`. Produced by the connection-string parsers, consumed by the resolver.
+- **BrowserResponse**: parsed Browser reply — `vector<BrowserInstance>` where `BrowserInstance = { name, server, instance, tcp_port, version, is_clustered }`. Only `tcp_port` for the matching `instance` flows further; the rest is kept for diagnostic error messages ("available instances: …").
+- **BrowserResolver**: free function or small class with a single method `Resolve(host, instance, timeout) → expected<port, error>`. Holds no state — one UDP socket per call.
+
+## Out of Scope (v1)
+
+- **Port caching across connections**. Adds complexity for a sub-millisecond saving on second-and-later attaches. Revisit after benchmarks.
+- **`(localdb)` / SQL Server LocalDB pipe instances**. LocalDB uses named pipes, not TCP; a separate transport, not just a resolver.
+- **`MSSQL_SERVERNAME` Windows registry probe**. We use only the documented MC-SQLR wire protocol so the same code path works identically on Linux and macOS.
+- **Browser multicast discovery** (`CLNT_BCAST_EX`). The user has the host already; we never need to enumerate hosts.
+- **Hiding the `instance` field**. Some SQL Server installs have a "hide instance" flag that suppresses Browser advertisement — those installs require fixed-port configuration regardless of client. We document this as a known limitation and point at the same MS docs (`configure-a-server-to-listen-on-a-specific-tcp-port`) that @VGSML already referenced on the issue.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A clean attach with `Server=localhost\SS2022` against the mock-browser stack returns rows in `< 200ms` end-to-end (resolver + connect + query).
+- **SC-002**: Issue #77 reporter @Stan-RED can attach all three coexisting instances (`SS2019`, `SS2022`, `SQLEXPRESS`) on a single Windows host without specifying ports.
+- **SC-003**: The pyodbc-equivalent connection string `Server=host\instance;Database=db;User Id=sa;Password=…` works unmodified in DuckDB. (Spot-check against pyodbc on the same host.)
+- **SC-004**: CI green on Linux + macOS Apple Silicon with the mock-browser stack, no Windows runner required for the resolver tests.
+- **SC-005**: Spec-042 integrated-auth tests still pass when re-pointed at the mock-browser-fronted SQL Server (regression: SPN derivation honours the discovered port).

--- a/specs/045-named-instance-resolution/tasks.md
+++ b/specs/045-named-instance-resolution/tasks.md
@@ -1,0 +1,252 @@
+---
+description: "Task list for spec 045 — SQL Server Named-Instance Resolution"
+---
+
+# Tasks: Named-Instance Resolution
+
+**Input**: Design documents from `/specs/045-named-instance-resolution/`
+**Prerequisites**: spec.md, plan.md, research.md (all present). `quickstart.md` is a Phase 4 deliverable.
+
+**Legend**:
+- `[P0]` Phase 0 — wire format + pure parser, no network
+- `[P1]` Phase 1 — UDP transport + end-to-end resolver
+- `[P2]` Phase 2 — docker test stack (mock browser + SQL + client)
+- `[P3]` Phase 3 — connection-string plumbing + LOGIN7 + settings
+- `[P4]` Phase 4 — docs + manual-test recipe
+- `[T]` Test-only task (not shipped in extension binary)
+- `[X]` Cross-phase or refactor
+
+## Ordering note
+
+Phases run **in numeric order**. Phase 2 (docker stack) can start as soon as
+Phase 0 (parser) lands — the mock browser does not depend on the resolver
+itself — so a contributor can split the work. Phase 3 needs Phase 1 (resolver
+API) and Phase 2 (test stack) both green to be testable end-to-end.
+
+---
+
+## Phase 0 — Wire format + pure parser
+
+### T001 [P0] Define types in header
+`src/include/connection/instance_resolver.hpp` (NEW)
+- `struct BrowserInstance { string server_name; string instance_name; string version; uint16_t tcp_port; bool tcp_enabled; }`
+- `struct ResolveError { enum Kind { Unreachable, InstanceNotFound, TcpDisabled, Malformed } kind; string message; }`
+- `vector<BrowserInstance> ParseBrowserResponse(string_view raw);` — throws `IOException` with hex-dump message on malformed input.
+- `class InstanceResolver { public: static expected<uint16_t, ResolveError> Resolve(const string& host, const string& instance, int timeout_seconds); };` — declaration only.
+- **No** DuckDB headers in this file (mirrors [[feedback_iauthenticator_layering]] for `tds/auth/iauthenticator.hpp` — the resolver is logically reusable outside DuckDB).
+
+### T002 [P0] Implement `ParseBrowserResponse`
+`src/connection/instance_resolver.cpp` (NEW, parser section only)
+- State machine over `string_view`: scan key, scan value separated by `;`, end of record on `;;` or end of buffer.
+- Build `map<string,string>` per record, then materialise `BrowserInstance`.
+- `tcp_enabled = record.count("tcp") > 0 && !record["tcp"].empty()`.
+- Malformed input → `IOException("malformed SQL Browser response: " + hex_dump(raw, 32))`.
+
+### T003 [T][P0] Unit tests — parser happy paths
+`test/cpp/test_instance_resolver.cpp` (NEW)
+- Single instance with all standard fields.
+- Multiple instances in one response.
+- Case-insensitive instance match (`testinst` matches `TESTINST` advertisement).
+- Instance with TCP disabled (`tcp` field absent) → `tcp_enabled = false`.
+
+### T004 [T][P0] Unit tests — parser error paths
+Same file as T003.
+- Truncated payload (RespSize > actual buffer).
+- Random garbage bytes.
+- Missing leading `0x05` opcode → `IOException`.
+- Empty `RespData`.
+- `RespData` not NUL-terminated.
+
+### T005 [P0] CMake wiring
+`CMakeLists.txt`
+- Add `src/connection/instance_resolver.cpp` to extension sources.
+- Add `test/cpp/test_instance_resolver.cpp` to the C++ test binary.
+- No new external dependencies.
+
+**Phase 0 exit gate**: `make test` green on macOS and Linux; new tests cover both success and all malformed-input cases.
+
+---
+
+## Phase 1 — UDP transport + end-to-end resolver
+
+### T006 [P1] Implement `InstanceResolver::Resolve` (POSIX)
+`src/connection/instance_resolver.cpp`
+- Open `SOCK_DGRAM` socket, `connect()` to `host:1434/udp` (lets us use `send`/`recv` instead of `sendto`/`recvfrom`).
+- Build `CLNT_UCAST_INST` packet: `0x04` + instance ASCII + `0x00`.
+- `SO_RCVTIMEO` set to `timeout_seconds` seconds.
+- One send → one recv (up to 1472 bytes — MTU cap). On `EAGAIN`/`EWOULDBLOCK`, retry **once** (FR-006). After the retry, return `ResolveError{Unreachable}`.
+- On recv, hand the buffer to `ParseBrowserResponse`. Find the matching `BrowserInstance` by case-insensitive `instance_name`. Return its `tcp_port`.
+- Distinguish the four error cases per research.md §R8.
+
+### T007 [P1] Windows port
+`src/connection/instance_resolver.cpp` — `#ifdef _WIN32` branch
+- Use Winsock2 (`WSAStartup` already initialised by the TDS layer — spec 019).
+- `SOCKET` instead of `int`, `closesocket` instead of `close`.
+- `SO_RCVTIMEO` takes `DWORD` milliseconds on Winsock, not `timeval` — handle the divergence with a tiny helper rather than `#ifdef`'ing every call site.
+
+### T008 [P1] Hostname normalisation
+`src/connection/instance_resolver.cpp` (before the `Resolve` socket code)
+- Translate `(local)` → `localhost`.
+- Translate leading `.` (alone) → `localhost`.
+- Keep IPv6-literal hosts as-is (no normalisation needed; UDP send goes to whatever family `getaddrinfo` returns).
+- FR-011 covered.
+
+### T009 [T][P1] Unit-ish test — loopback UDP echo
+`test/cpp/test_instance_resolver.cpp` (extend)
+- Spin a UDP listener on `127.0.0.1:<ephemeral>` inside the test process; have it reply with a canned `SVR_RESP`.
+- `Resolve("127.0.0.1", "TESTINST", 1)` returns the canned port.
+- Trick: the resolver hard-codes port 1434, so the test passes the listener port via a test-only `Resolve` overload (`Resolve_ForTest(host, port, instance, timeout)`) that the production `Resolve` calls with port=1434.
+- Negative: listener silent → returns `ResolveError{Unreachable}` after 1s timeout + 1 retry (≈ 2s wall).
+
+### T010 [T][P1] Settings registration
+`src/connection/mssql_settings.cpp`
+- `mssql_browser_timeout_seconds` (INTEGER, default `3`, range `1..30`).
+- `mssql_named_instance_resolution` (BOOLEAN, default `true`).
+- Add to the settings table in `CLAUDE.md` (defer the doc edit to T024 in Phase 4 to keep this task surgical).
+
+**Phase 1 exit gate**: T009 passes deterministically (`make test` 5× consecutive). No flakiness on the timeout path (set `timeout_seconds = 1` not `3` for the negative test to keep test wall-time tolerable).
+
+---
+
+## Phase 2 — Docker test stack
+
+### T011 [T][P2] Mock-browser Python implementation
+`test/named-instance/mock-browser/browser.py` (NEW)
+- Skeleton from research.md §R2.
+- Two preconfigured instances: `TESTINST` (port from `SQL_TCP_PORT` env, default 11433) and `SECONDARY` (`SQL_TCP_PORT_2`, default 11434 — even though the compose stack only runs one SQL Server today, the second entry exercises the multi-instance parse path).
+- Fault-injection modes via `MOCK_BROWSER_MODE`: `truncate`, `garbage`, `silent`, `slow`.
+- Logs every request to stdout so `docker compose logs mock-browser` is useful.
+
+### T012 [T][P2] Mock-browser Dockerfile
+`test/named-instance/mock-browser/Dockerfile` (NEW)
+- `FROM python:3.12-slim`
+- `COPY browser.py /app/browser.py`
+- `EXPOSE 1434/udp`
+- `CMD ["python3", "/app/browser.py"]`
+
+### T013 [T][P2] SQL Server init
+`test/named-instance/sql/init.sql` (NEW)
+- `CREATE DATABASE NamedInstTest;`
+- `USE NamedInstTest; CREATE TABLE Probe (id INT, payload NVARCHAR(100)); INSERT INTO Probe VALUES (1, N'spec045 lives');`
+
+### T014 [T][P2] SQL Server Dockerfile
+`test/named-instance/sql/Dockerfile` (NEW)
+- Same multi-stage init-script-baker pattern as `test/kerberos/sql/Dockerfile`, but listen on TCP 11433 (set via `MSSQL_TCP_PORT` env or `mssql.conf`). The non-default port is deliberate — proves the resolver is actually doing work, not just defaulting back to 1433.
+
+### T015 [T][P2] Test-client Dockerfile
+`test/named-instance/test-client/Dockerfile` (NEW)
+- Multi-stage build of the extension inside `mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04` (mirrors `test/kerberos/test-client/Dockerfile`).
+- Runtime stage: `ubuntu:22.04` + `duckdb` CLI + the freshly-built `mssql.duckdb_extension`.
+
+### T016 [T][P2] Test runner
+`test/named-instance/test-client/run-tests.sh` (NEW)
+- Runs every `test/sql/named_instance/*.test` against the live stack.
+- Bails with a clear message if `sql.example.com:11433` isn't reachable (e.g. compose dependency ordering glitch).
+
+### T017 [T][P2] Compose file
+`test/named-instance/docker-compose.yml` (NEW)
+- Three services: `sql`, `mock-browser`, `test-client`.
+- Two-hostname variant from plan.md Phase 2.
+- Healthchecks: `sql` waits for init.sql; `mock-browser` is up as soon as the process binds 1434/udp; `test-client` `depends_on` both healthy.
+- `command: ["sleep", "infinity"]` on test-client so the user can `docker compose exec`.
+
+### T018 [T][P2] README for the stack
+`test/named-instance/README.md` (NEW)
+- One-page how-to: bring up, run tests, tear down. Cross-link to issue #77 and to `test/kerberos/README.md` for the precedent.
+
+### T019 [T][P2] SQLLogicTest cases
+`test/sql/named_instance/*.test` (NEW — four files per plan.md Phase 2)
+- `resolve_basic.test` — `ATTACH 'Server=browser.example.com\TESTINST;...'`, `SELECT id, payload FROM ... .Probe`.
+- `resolve_unknown.test` — `Server=browser.example.com\NONESUCH` expects `MSSQL Error.*not found on host`.
+- `resolve_browser_down.test` — `MOCK_BROWSER_MODE=silent`; expects `SQL Browser unreachable` within ~5s wall.
+- `resolve_explicit_port.test` — `Server=browser.example.com\TESTINST,11433` skips the browser (verify by stopping the mock; attach still works).
+
+**Phase 2 exit gate**: `docker compose up -d --build && docker compose exec test-client /run-tests.sh` passes from a cold start on macOS Apple Silicon and Linux x86_64.
+
+---
+
+## Phase 3 — Connection-string plumbing + LOGIN7
+
+### T020 [P3] Parse `host\instance` in ADO.NET form
+`src/mssql_storage.cpp`
+- After the `,port` split at lines 694–702, split the host part on `\`:
+  - No `\` → `instance` stays empty.
+  - `\` with empty suffix → `InvalidInputException("empty instance name after backslash in Server")`.
+  - `\` with suffix → validate against `[A-Za-z0-9_$#]{1,16}` (FR-010); store on `MSSQLConnectionInfo::instance_name`.
+- Add `instance_name` (string) and `server_spec` (parsed-once struct) fields to `MSSQLConnectionInfo` in `src/include/mssql_storage.hpp`.
+
+### T021 [P3] Parse `%5C` in URI form
+`src/mssql_storage.cpp` — `ParseUri`
+- URL-decode the host token before the same split-on-`\` logic from T020.
+- Bare literal `\` in URI → parse-time `InvalidInputException` pointing at `%5C` (User Story 2 AS#3).
+
+### T022 [P3] Invoke resolver in `FromConnectionString`
+`src/mssql_storage.cpp`
+- After host/port/instance are parsed, before returning:
+  ```cpp
+  if (!result->instance_name.empty() && !explicit_port_given) {
+      if (!DBConfig::GetConfig(*context).options.set_options["mssql_named_instance_resolution"]) {
+          throw InvalidInputException(
+              "named-instance resolution is disabled; set mssql_named_instance_resolution=true "
+              "or use Server=host,port");
+      }
+      auto port = InstanceResolver::Resolve(result->host, result->instance_name,
+                                            settings.browser_timeout_seconds);
+      if (!port.ok()) throw IOException(port.error().message);
+      result->port = port.value();
+  }
+  ```
+- The `context`-availability detail: `FromConnectionString` is sometimes called without a `ClientContext` (in secret resolution paths). Plumb the settings via a struct passed in by the caller rather than a global lookup — mirrors how `mssql_connection_timeout` is already threaded.
+
+### T023 [P3] Populate `tds_server_name_` from instance
+`src/tds/tds_connection.cpp`
+- When `info_->instance_name` is non-empty, `tds_server_name_ = info_->host + "\\" + info_->instance_name` (LOGIN7 `ServerName` field).
+- When empty, `tds_server_name_ = info_->host` (unchanged).
+- Delete the misleading "we don't use SQL Browser service" comment at line 340.
+
+### T024 [X] CLAUDE.md + Kerberos.md updates
+- New settings in the settings table.
+- One-line entry under "Recent Changes": `045-named-instance-resolution: …`.
+- Kerberos.md SPN section: brief note that SPN derivation uses the discovered port for named instances.
+
+**Phase 3 exit gate**: All four `test/sql/named_instance/*.test` pass against the live mock-browser stack; spec-042 Kerberos test suite (`docker compose exec test-client /run-tests.sh` in `test/kerberos/`) passes unchanged.
+
+---
+
+## Phase 4 — Docs + manual test recipe
+
+### T025 [P4] quickstart.md
+`specs/045-named-instance-resolution/quickstart.md` (NEW)
+- Bring-up commands for the mock-browser stack.
+- Manual repro for issue #77: install SQL Server Developer with two named instances on a Windows host, attach from DuckDB CLI.
+- Windows + SSPI + named-instance manual-test recipe (research.md §R10 option b).
+
+### T026 [P4] Issue-tracker update
+- Comment on #77 with: spec link, what shipped, how to test, the manual workaround that's no longer needed.
+
+### T027 [P4] PR description
+- Standard template: summary, what changed, test plan (mock stack commands), screenshots/log snippets, link to spec.
+
+**Phase 4 exit gate**: Issue #77 closed. Maintainer-team smoke test (one of us with a real multi-instance Windows install) reports back on the manual repro.
+
+---
+
+## Out-of-scope (not in this task list)
+
+These were considered and explicitly deferred — *do not* add them to this PR:
+
+- LocalDB pipe transport.
+- Browser response caching.
+- Auto-decoding of literal `\` in URI form.
+- A Windows GHA runner for named-instance integration tests.
+- A retry-count setting (one retry is hard-coded; revisit if needed).
+- Hidden-instance probing (out-of-band of MC-SQLR).
+
+## Suggested PR split
+
+This spec can ship in one PR or two. Recommended split if reviewing in two:
+
+1. **#1 (this PR)**: Phase 0–2 — parser + resolver + test stack, *no behaviour change to user-visible connect path yet*. The resolver exists but nothing calls it. Reviewable as pure additive code with strong test coverage.
+2. **#2**: Phase 3–4 — connection-string parser changes, LOGIN7 wiring, docs. Small surgical diff that becomes trivial to review once #1 is in.
+
+Single-PR is acceptable too — total diff is ~800 lines including tests and the docker stack.


### PR DESCRIPTION
## Summary

Spec for #77 — support `Server=host\instance` connection strings by querying SQL Server Browser on UDP 1434 ([MS-SQLR]) to resolve the dynamic TCP port, then connecting via the existing TDS path. Closes the long-standing gap where named instances on a Windows dev host (the standard case with multiple coexisting engines) cannot be attached without manually configuring fixed ports.

**No implementation in this PR** — design docs only. Implementation follows the suggested 2-PR split in `tasks.md` (parser + docker stack additive first, then user-visible wiring).

## What's in the spec

- **spec.md** — 4 user stories, 13 FRs. P1 = named-instance ATTACH end-to-end against the mock-browser stack. P2 = URI/secret surfaces + Kerberos SPN derivation against the discovered port. Out-of-scope explicitly enumerated (no port caching, no LocalDB pipes, no `\` auto-decode in URI form).
- **research.md** — MC-SQLR wire format (`CLNT_UCAST_INST` / `SVR_RESP`), Python mock-browser sketch with fault-injection modes (`truncate`, `garbage`, `silent`, `slow`), two-hostname docker-compose layout, resolver placement under `src/connection/`, four-category error taxonomy, two new settings (`mssql_browser_timeout_seconds` = 3, `mssql_named_instance_resolution` = true).
- **plan.md** — 5 phases, risk register (Docker DNS round-robin, dynamic-port TOCTOU, UDP firewall on macOS dev), decisions locked from research.
- **tasks.md** — 27 numbered tasks across the 5 phases. No new vcpkg deps; ~250 LOC C++ + ~60 LOC Python mock + ~150 LOC test harness.

## Why a mock-browser docker stack

The `mcr.microsoft.com/mssql/server` Linux image ships no Browser service — a container is one instance on one port. To test the resolver end-to-end on Linux + macOS CI without a Windows runner, the stack runs a small Python UDP responder on `browser.example.com:1434/udp` that returns canned `SVR_RESP` packets pointing at a real SQL Server container on a non-default TCP port (11433, deliberately not 1433, so a passing test proves the resolver actually did work). Modelled on the existing self-contained `test/kerberos/` stack.

The wire protocol is fully documented ([MS-SQLR]) so a faithful mock is feasible; fault-injection modes exercise the resolver's error paths without contriving real network failures.

## Cross-spec interaction

- **Spec 042 (Kerberos / SSPI)** — SPN derivation under `Trusted_Connection=yes` uses `MSSQLSvc/<host>:<discovered_port>`. No code change in the auth path; the resolver writes the discovered port into `info.port` before SPN derivation runs.
- **Spec 031 (FedAuth refactor)** — same `MSSQLConnectionInfo` plumbing.
- **Spec 028 (ANSI connection options)** — ADO.NET parser entry point.

## Test plan

This PR is docs-only; no executable changes. Reviewer test plan:

- [ ] Read `spec.md` — confirm the 4 user stories cover the scope you'd expect for #77.
- [ ] Read `research.md` §R2–R3 — confirm the mock-browser test-stack approach is acceptable (alternative: Windows GHA runner with real SQL Server — documented as deferred in §R10).
- [ ] Read `plan.md` Risk Register — confirm none of the risks need a different mitigation.
- [ ] Skim `tasks.md` — confirm the suggested 2-PR split (parser/stack additive first, then wiring) is the preferred reviewer experience, or comment if single-PR is OK.
- [ ] Sanity-check the locked decisions in `research.md`: no port caching, no LocalDB, `%5C` required in URI, Python mock, two-hostname compose layout, Windows + SSPI + named instance is manual-test only.

Refs #77.