### PR TITLE
docs(spec): add spec 049 — fix partitioned-table catalog (issue #85)

### DIFF
--- a/specs/049-fix-partitioned-table-catalog/checklists/requirements.md
+++ b/specs/049-fix-partitioned-table-catalog/checklists/requirements.md
@@ -1,0 +1,52 @@
+# Specification Quality Checklist: Fix Partitioned Table Catalog
+
+**Purpose**: Validate specification completeness and quality before proceeding to implementation
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) in spec.md user stories — implementation details live in plan.md/contracts/.
+- [x] Focused on user value (`SELECT *` works; row counts are accurate) and business need (unblocks log/event tables in DuckDB).
+- [x] Written so a non-engineer can read US1-US3 and understand what's broken and why it matters.
+- [x] All mandatory sections completed: User Scenarios & Testing, Requirements, Success Criteria.
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain in spec.md.
+- [x] Requirements are testable and unambiguous (FR-001 through FR-012 each map to an SC or a test artifact).
+- [x] Success criteria are measurable (SC-001 names the query that must succeed; SC-002 names the equality the row count must satisfy).
+- [x] Success criteria are technology-agnostic to the extent meaningful (the spec is about a SQL Server interop fix, so SQL Server constructs are unavoidable; no DuckDB-internal API names appear in SC).
+- [x] All three user stories have acceptance scenarios in Given/When/Then form.
+- [x] Edge cases are identified (heap + partitions, empty table, view, columnstore, 0-row partition, concurrent split).
+- [x] Scope is bounded: three SQL templates in one file + one test fixture + one test file. Anything else is out of scope.
+- [x] Dependencies (SQL Server `sys.partitions`) and assumptions (`approx_row_count` is an estimate) are documented.
+
+## Feature Readiness
+
+- [x] Every functional requirement has a corresponding acceptance criterion or success criterion.
+- [x] User scenarios cover the primary read path (US1), the metadata enumeration path (US2), and the bulk preload path (US3).
+- [x] Success criteria match Measurable Outcomes in spec.md.
+- [x] No implementation details leak into spec.md user stories or success criteria (SQL appears only in the "Key Entities" reference subsection, which is informational).
+
+## Bug-fix Audit
+
+- [x] Root cause identified and documented (per-partition row multiplication via un-aggregated `LEFT JOIN sys.partitions`).
+- [x] All affected code paths enumerated (three SQL templates, one C++ caller `MakeTableInfo`).
+- [x] Adjacent code paths confirmed unaffected (`src/copy/target_resolver.cpp` queries `sys.columns` without joining `sys.partitions` — verified during investigation).
+- [x] Silent-correctness bug identified alongside the loud crash (row-count miscount in `TABLE_DISCOVERY_SQL_TEMPLATE`).
+- [x] Backward-compatibility analysis: non-partitioned tables (single heap/clustered partition) MUST report bit-for-bit identical `approx_rows` after the fix.
+
+## Test Plan Completeness
+
+- [x] Integration test creates a partitioned table with ≥3 partitions and ≥2 columns (matches the reported reproducer shape).
+- [x] Integration test asserts column metadata is non-duplicated AND row count is correctly aggregated.
+- [x] Integration test exercises the bulk preload path (`mssql_preload_catalog`), not just single-table load.
+- [x] Test fixture is isolated in its own init SQL file so failures don't cascade into the main test database.
+- [x] Optional C++ unit-test guard is specified so a future refactor that drops aggregation fails fast.
+
+## Notes
+
+- All items pass validation.
+- Spec is intentionally scoped to the bug fix — no opportunistic refactoring of the metadata cache (that path would belong in a separate refactoring spec, e.g., a hypothetical "050-metadata-query-builder").
+- Issue #85 reporter (`@keen85`) reproduced the bug with a `DATETIME2(7)` partition key; the fix is partition-key-type-agnostic, so the test fixture uses `INT` for simplicity while the spec narrative references the user's `DATETIME2` example for context.

--- a/specs/049-fix-partitioned-table-catalog/contracts/metadata-query-contract.md
+++ b/specs/049-fix-partitioned-table-catalog/contracts/metadata-query-contract.md
@@ -1,0 +1,116 @@
+# Contract: Metadata Cache SQL Templates
+
+**Phase 1 Output** | **Date**: 2026-05-19
+
+## Scope
+
+Three `static const char *` template strings in `src/catalog/mssql_metadata_cache.cpp`:
+
+| Template | Lines (current) | Caller |
+| -------- | ---------------:| ------ |
+| `TABLE_DISCOVERY_SQL_TEMPLATE`         | 44-53  | `MSSQLMetadataCache::EnsureTablesLoaded`, `LoadTables` |
+| `SINGLE_TABLE_METADATA_SQL_TEMPLATE`   | 57-75  | `MSSQLMetadataCache::GetTableMetadata` |
+| `BULK_METADATA_SCHEMA_SQL_TEMPLATE`    | 79-105 | `MSSQLMetadataCache::LoadAllTableMetadata`, `BulkLoadAll` |
+
+## Row-shape contract
+
+### `TABLE_DISCOVERY_SQL_TEMPLATE`
+
+**Result columns** (order matters — callers index by position):
+
+| Idx | Name | Type | Nullability |
+| --: | ---- | ---- | ----------- |
+| 0 | `object_name` | sysname / NVARCHAR(128) | NOT NULL |
+| 1 | `object_type` | CHAR(2) | NOT NULL |
+| 2 | `approx_rows` | BIGINT | NOT NULL (via `ISNULL(..., 0)`) |
+
+**Row cardinality**: Exactly **one row per object** in the target schema where `o.type IN ('U', 'V')` and `o.is_ms_shipped = 0`. Independent of the number of partitions on any object.
+
+**`approx_rows` semantics**: `COALESCE(SUM(p.rows), 0)` over all rows of `sys.partitions` matching the object's `object_id` with `index_id IN (0, 1)`.
+
+### `SINGLE_TABLE_METADATA_SQL_TEMPLATE`
+
+**Result columns** (order matters):
+
+| Idx | Name | Type | Nullability |
+| --: | ---- | ---- | ----------- |
+| 0 | `object_type` | CHAR(2) | NOT NULL |
+| 1 | `approx_rows` | BIGINT | NOT NULL |
+| 2 | `column_name` | sysname / NVARCHAR(128) | NOT NULL |
+| 3 | `column_id` | INT | NOT NULL |
+| 4 | `type_name` | sysname / NVARCHAR(128) | NOT NULL (via `ISNULL`/`TYPE_NAME` fallback) |
+| 5 | `max_length` | SMALLINT | NOT NULL |
+| 6 | `precision` | TINYINT | NOT NULL |
+| 7 | `scale` | TINYINT | NOT NULL |
+| 8 | `is_nullable` | BIT | NOT NULL |
+| 9 | `collation_name` | sysname / NVARCHAR(128) | NOT NULL (via `ISNULL(..., '')`) |
+
+**Row cardinality**: Exactly **one row per `(object_id, column_id)` pair** for the object identified by `OBJECT_ID('<schema>.<table>')`. Independent of the number of partitions.
+
+**`approx_rows` semantics**: As above. Identical value on every emitted row (callers only read it on the first row).
+
+### `BULK_METADATA_SCHEMA_SQL_TEMPLATE`
+
+**Result columns** (order matters):
+
+| Idx | Name | Type | Nullability |
+| --: | ---- | ---- | ----------- |
+| 0 | `schema_name` | sysname / NVARCHAR(128) | NOT NULL |
+| 1 | `object_name` | sysname / NVARCHAR(128) | NOT NULL |
+| 2 | `object_type` | CHAR(2) | NOT NULL |
+| 3 | `approx_rows` | BIGINT | NOT NULL |
+| 4 | `column_name` | sysname / NVARCHAR(128) | NOT NULL |
+| 5 | `column_id` | INT | NOT NULL |
+| 6-11 | (as in single-table query) | | |
+
+**Row cardinality**: Exactly **one row per `(schema, object_id, column_id)` triple** in the target schema. Independent of the number of partitions on any object.
+
+## Required SQL shape
+
+Each template MUST contain a `LEFT JOIN` against `sys.partitions` whose right-hand side is a derived table that:
+
+1. Selects `object_id` and `SUM(rows) AS rows`.
+2. Filters `WHERE index_id IN (0, 1)`.
+3. Groups `BY object_id`.
+
+The canonical form (used in all three templates):
+
+```sql
+LEFT JOIN (
+    SELECT object_id, SUM(rows) AS rows
+    FROM sys.partitions
+    WHERE index_id IN (0, 1)
+    GROUP BY object_id
+) p ON p.object_id = o.object_id
+```
+
+Variations that satisfy the contract (any equivalent rewrite):
+
+- Aliasing the derived table differently (e.g., `parts` instead of `p`), provided downstream references match.
+- Placing the derived table earlier in the JOIN chain (semantics are unchanged for an outer reference via `o.object_id`).
+- Using `COALESCE(SUM(rows), 0)` inside the derived table instead of `ISNULL(..., 0)` in the outer projection.
+
+Variations that violate the contract:
+
+- Direct `LEFT JOIN sys.partitions p ON ...` without aggregation — re-introduces the bug.
+- `LEFT JOIN sys.partitions p ON ... AND p.partition_number = 1` — would only count partition 1's rows, silently undercounting partitioned tables.
+- Dropping the `index_id IN (0, 1)` filter — would count rows once per non-clustered index per partition, inflating the row count by `(1 + N_nonclustered_indexes)`.
+- Including `index_id` in the `GROUP BY` — would re-multiply rows when both heap (0) and a clustered index (1) exist for the same object (impossible by SQL Server's data model, but defensive: don't add it).
+
+## Caller-side guarantees
+
+Given a result that satisfies the row-shape contract:
+
+- `MakeTableInfo` (`src/catalog/mssql_table_entry.cpp`) MUST NOT throw "Column with name X already exists!" for any well-formed SQL Server table.
+- `MSSQLTableMetadata.approx_row_count` MUST equal the sum of `rows` across all heap/clustered partitions of the table.
+- `TableStorageInfo.cardinality` (returned from `MSSQLTableEntry::GetStorageInfo`) MUST equal that sum.
+
+## Unit-test guard (recommended)
+
+A C++ unit test in `test/cpp/test_metadata_cache_queries.cpp` SHOULD assert, for each of the three templates, that the literal text contains:
+
+- The substring `GROUP BY object_id`.
+- The substring `SUM(rows)`.
+- The substring `index_id IN (0, 1)`.
+
+This is a structural guard, not a semantic test — it catches a future refactor that drops the aggregation but does not validate that the aggregation produces correct values. The integration test in `test/sql/catalog/partitioned_table.test` provides the semantic validation.

--- a/specs/049-fix-partitioned-table-catalog/data-model.md
+++ b/specs/049-fix-partitioned-table-catalog/data-model.md
@@ -1,0 +1,208 @@
+# Data Model: Partitioned Table Metadata Queries
+
+**Phase 1 Output** | **Date**: 2026-05-19
+
+## `sys.partitions` row multiplication
+
+`sys.partitions` is a SQL Server DMV with the schema:
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `partition_id` | BIGINT | Unique per partition |
+| `object_id` | INT | The table or indexed view |
+| `index_id` | INT | 0 = heap; 1 = clustered index; ≥ 2 = non-clustered |
+| `partition_number` | INT | 1-based within the (object, index) pair |
+| `rows` | BIGINT | Approximate row count, maintained by stats |
+
+For a **non-partitioned heap**: one row with `(object_id, 0, 1, <rows>)`.
+For a **non-partitioned clustered table**: one row with `(object_id, 1, 1, <rows>)`.
+For a **partitioned clustered table with N partitions**: N rows with `(object_id, 1, k, <rows_in_partition_k>)` for `k = 1..N`.
+
+The current extension query says:
+
+```sql
+LEFT JOIN sys.partitions p
+    ON o.object_id = p.object_id
+    AND p.index_id IN (0, 1)
+```
+
+For an N-partition clustered table this multiplies the outer row by N.
+
+## Outer query shapes (before / after)
+
+### `SINGLE_TABLE_METADATA_SQL_TEMPLATE`
+
+**Before**:
+
+```sql
+SELECT
+    o.type AS object_type,
+    ISNULL(p.rows, 0) AS approx_rows,
+    c.name AS column_name,
+    c.column_id,
+    ISNULL(t.name, TYPE_NAME(c.user_type_id)) AS type_name,
+    c.max_length, c.precision, c.scale, c.is_nullable,
+    ISNULL(c.collation_name, '') AS collation_name
+FROM sys.objects o
+INNER JOIN sys.columns c ON c.object_id = o.object_id
+LEFT JOIN sys.types t ON c.system_type_id = t.user_type_id AND t.system_type_id = t.user_type_id
+LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)
+WHERE o.object_id = OBJECT_ID('%s')
+ORDER BY c.column_id
+```
+
+For a 4-partition table with 2 columns: 2 × 4 = 8 rows. Each column appears 4 times.
+
+**After**:
+
+```sql
+SELECT
+    o.type AS object_type,
+    ISNULL(p.rows, 0) AS approx_rows,
+    c.name AS column_name,
+    c.column_id,
+    ISNULL(t.name, TYPE_NAME(c.user_type_id)) AS type_name,
+    c.max_length, c.precision, c.scale, c.is_nullable,
+    ISNULL(c.collation_name, '') AS collation_name
+FROM sys.objects o
+INNER JOIN sys.columns c ON c.object_id = o.object_id
+LEFT JOIN sys.types t ON c.system_type_id = t.user_type_id AND t.system_type_id = t.user_type_id
+LEFT JOIN (
+    SELECT object_id, SUM(rows) AS rows
+    FROM sys.partitions
+    WHERE index_id IN (0, 1)
+    GROUP BY object_id
+) p ON p.object_id = o.object_id
+WHERE o.object_id = OBJECT_ID('%s')
+ORDER BY c.column_id
+```
+
+For the same table: 2 rows. Each column appears once. `approx_rows = SUM(rows)`.
+
+### `BULK_METADATA_SCHEMA_SQL_TEMPLATE`
+
+Same transformation applied to the per-schema bulk query. Row count formula: was `Σ(columns × partitions)` per table; now `Σ(columns)` per table.
+
+### `TABLE_DISCOVERY_SQL_TEMPLATE`
+
+**Before**:
+
+```sql
+SELECT
+    o.name AS object_name,
+    o.type AS object_type,
+    ISNULL(p.rows, 0) AS approx_rows
+FROM sys.objects o
+LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)
+WHERE o.type IN ('U', 'V')
+  AND o.is_ms_shipped = 0
+  AND SCHEMA_NAME(o.schema_id) = '%s'
+```
+
+For a 4-partition table this emits 4 rows with the same `object_name`. `std::map::emplace` keeps only the first; `approx_rows` is the row count of whichever partition `sys.partitions` happens to emit first. This is the silent miscount.
+
+**After**:
+
+```sql
+SELECT
+    o.name AS object_name,
+    o.type AS object_type,
+    ISNULL(p.rows, 0) AS approx_rows
+FROM sys.objects o
+LEFT JOIN (
+    SELECT object_id, SUM(rows) AS rows
+    FROM sys.partitions
+    WHERE index_id IN (0, 1)
+    GROUP BY object_id
+) p ON p.object_id = o.object_id
+WHERE o.type IN ('U', 'V')
+  AND o.is_ms_shipped = 0
+  AND SCHEMA_NAME(o.schema_id) = '%s'
+```
+
+One row per table. `approx_rows = SUM(per-partition rows)`.
+
+## Worked example: issue #85's `dbo.log` table
+
+Schema (from the issue):
+
+```sql
+CREATE PARTITION FUNCTION [pf_logs_by_month] (DATETIME2(7))
+AS RANGE RIGHT FOR VALUES (
+    '2026-02-01 00:00:00',
+    '2026-03-01 00:00:00',
+    '2026-04-01 00:00:00'
+);
+
+CREATE PARTITION SCHEME [ps_logs_by_month]
+AS PARTITION [pf_logs_by_month] ALL TO ([PRIMARY]);
+
+CREATE TABLE dbo.log (
+    log_ts  DATETIME2(7) DEFAULT (GETUTCDATE()) NOT NULL,
+    message NVARCHAR(255)
+);
+
+INSERT INTO dbo.log (message) VALUES ('bar');
+
+CREATE CLUSTERED INDEX ix_ci_log_log_ts
+    ON dbo.log (log_ts DESC)
+    WITH (DATA_COMPRESSION = PAGE, OPTIMIZE_FOR_SEQUENTIAL_KEY = ON)
+    ON [ps_logs_by_month] (log_ts);
+```
+
+3 boundary values → 4 partitions. After the single INSERT (which lands in whichever partition contains `GETUTCDATE()` at insert time), `sys.partitions` reports:
+
+| partition_number | rows |
+| ---------------: | ---: |
+| 1                | 0    |
+| 2                | 1    |
+| 3                | 0    |
+| 4                | 0    |
+
+**Before fix** — `SINGLE_TABLE_METADATA` returns 8 rows:
+
+```
+object_type | approx_rows | column_name | column_id
+U           | 0           | log_ts      | 1
+U           | 1           | log_ts      | 1
+U           | 0           | log_ts      | 1
+U           | 0           | log_ts      | 1
+U           | 0           | message     | 2
+U           | 1           | message     | 2
+U           | 0           | message     | 2
+U           | 0           | message     | 2
+```
+
+`MakeTableInfo` loops these rows, calling `info.columns.AddColumn("log_ts")` four times. The second call throws "Column with name log_ts already exists!" → user sees the error from issue #85.
+
+**After fix** — `SINGLE_TABLE_METADATA` returns 2 rows:
+
+```
+object_type | approx_rows | column_name | column_id
+U           | 1           | log_ts      | 1
+U           | 1           | message     | 2
+```
+
+`MakeTableInfo` adds each column once. `approx_rows = SUM(0+1+0+0) = 1`. Query succeeds.
+
+## Aggregation cost analysis
+
+For a schema with T tables and P average partitions per table:
+
+| Stage | Pre-fix | Post-fix |
+| ----- | ------- | -------- |
+| `sys.partitions` rows scanned | T × P | T × P |
+| Rows materialized to client | T × P × avg_columns | T × avg_columns |
+| Client-side processing | Multiplied by P (then deduped or crashed) | Linear in columns |
+
+The server-side hash/stream aggregate adds an `O(T × P)` operator with `O(T)` state. For typical ERP / OLTP schemas (T ≤ 10,000, P ≤ 50), this is a few-millisecond overhead at most. Net effect: fewer rows on the wire, slightly more CPU on the server, lower client memory.
+
+## Related cache state
+
+`MSSQLTableMetadata.approx_row_count` (in `src/include/catalog/mssql_metadata_cache.hpp`) currently holds whatever the first emitted partition row had. After the fix, it holds `SUM(rows)`. Consumers of this field:
+
+- `MSSQLTableEntry::GetStorageInfo` → `TableStorageInfo.cardinality` (used by DuckDB's planner for join ordering and filter selectivity).
+- `MSSQLStatisticsProvider::PreloadRowCount` (used as the cached row count for `mssql_pool_stats()`).
+- `MSSQLPreloadCatalog` summary message (used for the user-visible "Preloaded N schemas, M tables, K columns" return value).
+
+All three consumers benefit from the corrected value — none of them have any assumption that the count must be "less than or equal to" the true count.

--- a/specs/049-fix-partitioned-table-catalog/plan.md
+++ b/specs/049-fix-partitioned-table-catalog/plan.md
@@ -1,0 +1,203 @@
+# Implementation Plan: Fix Partitioned Table Catalog
+
+**Branch**: `049-fix-partitioned-table-catalog` | **Date**: 2026-05-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/049-fix-partitioned-table-catalog/spec.md`
+
+## Summary
+
+Replace the per-partition `LEFT JOIN sys.partitions` clause in the three metadata-cache SQL templates with a pre-aggregated derived table. Add a docker init fixture for a partitioned table and a SQLLogicTest regression test (`test/sql/catalog/partitioned_table.test`). Optional C++ assertion test on the templates to guard the aggregation marker.
+
+Single hot point of change: `src/catalog/mssql_metadata_cache.cpp` — three `static const char *` SQL templates at lines 44, 57, 79.
+
+## Technical Context
+
+**Language/Version**: C++17 (C++11-compatible for ODR on Linux)
+**Primary Dependencies**: DuckDB (main branch), OpenSSL (vcpkg) — none added by this spec
+**Storage**: In-memory metadata cache (`MSSQLMetadataCache`). No persistence.
+**Testing**: SQLLogicTest integration tests (require SQL Server via `make docker-up`), C++ unit tests (Catch2, no SQL Server needed)
+**Target Platform**: Linux (GCC), macOS (Clang), Windows (MSVC, MinGW)
+**Project Type**: DuckDB extension (single shared library)
+**Performance Goals**: Metadata-query wall-clock unchanged (the optimizer's plan changes from scan-then-flatten to scan-then-aggregate, both O(partitions)). No regression expected on the 99% non-partitioned case.
+**Constraints**: Must use `GEN=ninja` for builds; no new vcpkg deps; SQL must work on SQL Server 2016+ including Azure SQL DB / MI / SQL Server on Linux; ODR-safe (no C++17-only headers)
+**Scale/Scope**: 3 SQL template edits, 1 docker init file, 1 SQLLogicTest file, 1 optional unit test. Net diff ≈ 60 lines incl. tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --------- | :----: | ----- |
+| I. Native and Open | PASS | Pure SQL template fix; no new libraries; uses standard `sys.partitions` documented since SQL Server 2005 |
+| II. Streaming First | PASS | No buffering changes. The aggregation runs server-side; result-row streaming through `MSSQLSimpleQuery::ExecuteWithCallback` is unchanged. |
+| III. Correctness over Convenience | PASS | Fixes a hard crash for partitioned tables AND a silent cardinality bug. No correctness trade-off introduced. |
+| IV. Explicit State Machines | PASS | No state-machine changes. Metadata cache state transitions (`NOT_LOADED → LOADING → LOADED`) untouched. |
+| V. DuckDB-Native UX | PASS | Restores ability to use DuckDB's standard catalog operators (`SELECT *`, `DESCRIBE`, `duckdb_tables`) against partitioned SQL Server tables. |
+| VI. Incremental Delivery | PASS | Three queries change independently; the spec ships as a single PR but each query change is independently testable. |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/049-fix-partitioned-table-catalog/
+├── spec.md                         # Feature specification
+├── plan.md                         # This file
+├── research.md                     # Phase 0 — why aggregate vs. DISTINCT vs. DMV alternatives
+├── data-model.md                   # SQL shape: before vs. after, sys.partitions semantics
+├── quickstart.md                   # Drop-in SQL diff + repro steps
+├── checklists/
+│   └── requirements.md             # Spec quality checklist
+├── contracts/
+│   └── metadata-query-contract.md  # Output-row shape contract for the three templates
+└── tasks.md                        # Phase 2 output
+```
+
+### Source Code (files to modify)
+
+```text
+src/catalog/mssql_metadata_cache.cpp
+    # Edit 3 static SQL templates (TABLE_DISCOVERY, SINGLE_TABLE_METADATA, BULK_METADATA_SCHEMA)
+    # Replace `LEFT JOIN sys.partitions p ON ... AND index_id IN (0,1)`
+    # with `LEFT JOIN (SELECT object_id, SUM(rows) AS rows FROM sys.partitions WHERE index_id IN (0,1) GROUP BY object_id) p ON p.object_id = o.object_id`
+
+docker/init/init-partitioned-tables.sql       # New: partition function/scheme + Logs table + seed rows
+docker/docker-compose.yml                      # Mount the new init file (if not auto-loaded by /init/)
+test/sql/catalog/partitioned_table.test        # New: SQLLogicTest regression coverage
+test/cpp/test_metadata_cache_queries.cpp       # Optional: unit test asserting GROUP BY appears in each template
+```
+
+No header changes. No CMakeLists changes unless the C++ unit test is added (in which case append the new source to the unittest target).
+
+**Structure Decision**: Pure data-fix scoped to three SQL string literals in one file. No new classes, no API surface change, no migration. The optional C++ unit test exists only to make future refactors fail loudly if the aggregation is removed.
+
+### Review Findings Incorporated
+
+Three findings from the spec/security/cross-cutting review were folded into the spec before this plan was finalised:
+
+1. **Statistics provider already correct** — `src/catalog/mssql_statistics.cpp:14-22` uses `ISNULL(SUM(p.rows), 0)` on `sys.dm_db_partition_stats`. The fix brings the metadata cache into alignment with code that already exists; risk of follow-on inconsistency is low.
+2. **Pre-existing SQL-injection finding (deferred)** — `mssql_metadata_cache.cpp` does not escape `'` in substituted identifiers, unlike `mssql_statistics.cpp::FetchRowCount`. Documented as US5 in spec.md with explicit "out of scope for this PR" note. A separate hardening PR should add the same `'`→`''` escape across `MSSQLMetadataCache` callers.
+3. **Cross-cutting test gaps** — issue #85 reports a read failure but the fix path is the foundation of every DML/COPY/CTAS/filter operation. US4 added with smoke tests for filter pushdown, INSERT, UPDATE/DELETE (with a `PartitionedWithPK` fixture), and COPY. These are new tasks T009a-d.
+
+## Phase 0 — Research (see research.md)
+
+Three candidate fix shapes evaluated:
+
+1. **Derived-table aggregation** (chosen) — `LEFT JOIN (SELECT object_id, SUM(rows) AS rows FROM sys.partitions WHERE index_id IN (0,1) GROUP BY object_id) p`. Minimal change, correct, portable. Selected.
+2. **`OUTER APPLY` with scalar aggregate** — works, but adds a correlated-subquery shape that some older SQL Server versions don't optimize as cleanly. Rejected.
+3. **`sys.dm_db_partition_stats` instead of `sys.partitions`** — has the same per-partition granularity; switching DMV doesn't fix the problem and introduces stricter permission requirements (`VIEW DATABASE STATE` is sometimes denied to read-only ETL accounts). Rejected.
+
+Open questions resolved during spec authoring (no NEEDS CLARIFICATION items remain in spec.md).
+
+## Phase 1 — Design (see contracts/ and data-model.md)
+
+**Query-output contract** (`contracts/metadata-query-contract.md`): all three templates emit exactly one row per `(object, column)` or `(object)` tuple; `approx_rows` equals `COALESCE(SUM(p.rows), 0)` across partitions where `index_id IN (0,1)`.
+
+**Data model** (`data-model.md`): documents the before/after SQL shape, the `sys.partitions` row multiplication rule, and worked examples for a 4-partition log table.
+
+**Test fixture** (`docker/init/init-partitioned-tables.sql`): creates a partition function on `DATETIME2(7)` with 3 boundary values (→ 4 partitions), a partition scheme aliasing all partitions to `[PRIMARY]`, a `dbo.PartitionedLog` table with a non-PK clustered partitioned index, and seed rows distributed across the partitions (with known per-partition counts so the test can assert `SUM = expected_total`).
+
+**Integration test** (`test/sql/catalog/partitioned_table.test`):
+
+```sql
+require mssql
+require-env MSSQL_TESTDB_DSN
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_part (TYPE mssql);
+
+# US1: column metadata does not duplicate
+query II
+SELECT column_name, data_type FROM (DESCRIBE testdb_part.dbo.PartitionedLog) ORDER BY column_name;
+----
+... expected one row per column ...
+
+# US1: scan succeeds
+query I
+SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog;
+----
+<expected total>
+
+# US2: cardinality estimate equals sum across partitions
+query I
+SELECT estimated_size FROM duckdb_tables() WHERE database_name = 'testdb_part' AND table_name = 'PartitionedLog';
+----
+<expected total>
+
+# US3: preload handles partitioned tables
+statement ok
+SELECT mssql_preload_catalog('testdb_part');
+
+statement ok
+DETACH testdb_part;
+```
+
+## Constitution Re-Check (Post Phase 1 Design)
+
+| Principle | Status | Notes |
+| --------- | :----: | ----- |
+| I. Native and Open | PASS | Still SQL-only, no deps added |
+| II. Streaming First | PASS | Server aggregates; client streaming pattern unchanged |
+| III. Correctness over Convenience | PASS | Restores correctness for two distinct bug classes (crash + silent miscount) |
+| IV. Explicit State Machines | PASS | No state-machine changes |
+| V. DuckDB-Native UX | PASS | Restores standard catalog UX |
+| VI. Incremental Delivery | PASS | Three SQL edits + test, all in one PR; each query individually testable |
+
+All gates pass post-design.
+
+## Implementation Tasks Overview
+
+### Task T001: Fix `TABLE_DISCOVERY_SQL_TEMPLATE` (P2, ~2 min)
+
+Replace the `LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)` at line ~50 with the pre-aggregated derived table form. See `contracts/metadata-query-contract.md` for the exact SQL.
+
+### Task T002: Fix `SINGLE_TABLE_METADATA_SQL_TEMPLATE` (P1, ~2 min)
+
+Same replacement at line ~72. This is the MVP fix — it unblocks `SELECT * FROM <partitioned_table>`.
+
+### Task T003: Fix `BULK_METADATA_SCHEMA_SQL_TEMPLATE` (P1, ~2 min)
+
+Same replacement at line ~97. Required for `mssql_preload_catalog()` and `MSSQLTableSet::Scan` to handle partitioned tables in any schema.
+
+### Task T004: Add docker init fixture (P1, ~10 min)
+
+Create `docker/init/init-partitioned-tables.sql` with a partition function, partition scheme, `dbo.PartitionedLog` table, and seed rows distributed across ≥3 partitions. Wire it into the compose init order (after `init.sql`).
+
+### Task T005: Add integration test (P1, ~15 min)
+
+Create `test/sql/catalog/partitioned_table.test` per the design above. Cover US1 (scan succeeds, columns not duplicated), US2 (cardinality is the sum), and US3 (`mssql_preload_catalog` succeeds).
+
+### Task T006: Add C++ unit-test guard (P3, ~10 min)
+
+Optional but recommended. New `test/cpp/test_metadata_cache_queries.cpp` asserts that each of the three SQL template strings contains `GROUP BY` and `SUM(rows)` substrings. This catches future refactors that drop the aggregation without needing to spin up SQL Server.
+
+### Task T007: Build & full test suite (P1, ~5 min)
+
+- `GEN=ninja make` — verify clean compile.
+- `./build/release/test/unittest` — verify C++ tests pass (including T006 if added).
+- `make docker-down && make docker-up` — rebuild container so T004 fixture is loaded.
+- `make integration-test` — verify all existing integration tests still pass + new test passes.
+
+### Task T008: Update CLAUDE.md / docs (P3, ~5 min)
+
+Add a line to `CLAUDE.md` under "Recent Changes" noting that spec 049 fixes partitioned-table catalog support. No user-facing documentation change required — the bug fix restores expected behaviour rather than adding a feature.
+
+## Risk & Rollback
+
+- **Rollback**: Reverting the commit restores prior behaviour exactly. The SQL templates are pure data; no schema migration, no on-disk format change.
+- **Performance risk**: For schemas with many partitioned tables and many partitions per table, server-side aggregation cost is `O(total_partitions_in_schema)`. The pre-fix query scans the same rows; the aggregation adds a hash/stream-aggregate node but the working set is identical. Expected delta: well under 5% on typical schemas.
+- **Permission risk**: `sys.partitions` is readable by any user with `VIEW DEFINITION` on the schema, same as today. The fix changes the SQL shape but not the underlying objects queried — no new permission requirement.
+- **Edge-case risk**: A table with no rows in `sys.partitions` (e.g., a freshly-`CREATE`d table before any insert + before statistics maintenance) still benefits from the `ISNULL(p.rows, 0)` wrapper. Verified in spec §Edge Cases.
+
+## Artifacts Generated
+
+| Artifact   | Path                                                       | Status |
+| ---------- | ---------------------------------------------------------- | :----: |
+| Spec       | specs/049-fix-partitioned-table-catalog/spec.md            | Complete |
+| Plan       | specs/049-fix-partitioned-table-catalog/plan.md            | Complete |
+| Research   | specs/049-fix-partitioned-table-catalog/research.md        | Complete |
+| Data Model | specs/049-fix-partitioned-table-catalog/data-model.md      | Complete |
+| Contract   | specs/049-fix-partitioned-table-catalog/contracts/metadata-query-contract.md | Complete |
+| Quickstart | specs/049-fix-partitioned-table-catalog/quickstart.md      | Complete |
+| Checklist  | specs/049-fix-partitioned-table-catalog/checklists/requirements.md | Complete |
+| Tasks      | specs/049-fix-partitioned-table-catalog/tasks.md           | Complete |

--- a/specs/049-fix-partitioned-table-catalog/quickstart.md
+++ b/specs/049-fix-partitioned-table-catalog/quickstart.md
@@ -1,0 +1,111 @@
+# Quickstart: Fix Partitioned Table Catalog
+
+**Phase 1 Output** | **Date**: 2026-05-19
+
+## The fix (5 minutes)
+
+In `src/catalog/mssql_metadata_cache.cpp`, find each occurrence of:
+
+```sql
+LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)
+```
+
+and replace with:
+
+```sql
+LEFT JOIN (
+    SELECT object_id, SUM(rows) AS rows
+    FROM sys.partitions
+    WHERE index_id IN (0, 1)
+    GROUP BY object_id
+) p ON p.object_id = o.object_id
+```
+
+There are three occurrences (one per SQL template at lines ~50, ~72, ~97).
+
+## Build & test
+
+```bash
+# Build
+GEN=ninja make
+
+# Unit tests (no SQL Server needed)
+./build/release/test/unittest
+
+# Rebuild SQL Server container with the new partitioned-table fixture
+make docker-down && make docker-up
+
+# Run all integration tests (including new partitioned_table.test)
+make integration-test
+```
+
+## Reproduce the bug (without the fix)
+
+```sql
+-- In SQL Server (SSMS or sqlcmd):
+CREATE PARTITION FUNCTION [pf_qs_demo] (INT)
+AS RANGE RIGHT FOR VALUES (10, 20, 30);
+GO
+
+CREATE PARTITION SCHEME [ps_qs_demo]
+AS PARTITION [pf_qs_demo] ALL TO ([PRIMARY]);
+GO
+
+CREATE TABLE dbo.qs_demo (id INT NOT NULL, payload NVARCHAR(50));
+INSERT INTO dbo.qs_demo VALUES (5, 'a'), (15, 'b'), (25, 'c'), (35, 'd');
+CREATE CLUSTERED INDEX ix_qs_demo ON dbo.qs_demo (id)
+    ON [ps_qs_demo] (id);
+GO
+```
+
+```sql
+-- In DuckDB:
+LOAD mssql;
+ATTACH 'Server=localhost,1433;Database=TestDB;User Id=sa;Password=TestPassword1'
+    AS db (TYPE mssql);
+
+SELECT * FROM db.dbo.qs_demo;
+-- Before fix:  Catalog Error: Column with name id already exists!
+-- After fix:   id | payload
+--              ---+--------
+--              5  | a
+--              15 | b
+--              25 | c
+--              35 | d
+```
+
+## Verify the row count fix
+
+```sql
+-- In DuckDB after the fix:
+SELECT estimated_size
+FROM duckdb_tables()
+WHERE database_name = 'db' AND table_name = 'qs_demo';
+-- Should equal 4 (sum across all 4 partitions),
+-- not 1 (the row count of whichever partition was first emitted).
+```
+
+## Cleanup (after testing)
+
+```sql
+-- In SQL Server:
+DROP TABLE dbo.qs_demo;
+DROP PARTITION SCHEME ps_qs_demo;
+DROP PARTITION FUNCTION pf_qs_demo;
+```
+
+## Files modified
+
+1. `src/catalog/mssql_metadata_cache.cpp` — three SQL template strings.
+2. `docker/init/init-partitioned-tables.sql` — new fixture file with `dbo.PartitionedLog` + seed rows.
+3. `docker/docker-compose.yml` — mount/load the new init file (if not already auto-loaded by container init).
+4. `test/sql/catalog/partitioned_table.test` — new SQLLogicTest regression test.
+5. *(optional)* `test/cpp/test_metadata_cache_queries.cpp` — unit-test guard for the aggregation marker.
+6. `CLAUDE.md` — append "Recent Changes" entry referencing spec 049.
+
+## Files NOT modified
+
+- Any header file — no API surface change.
+- `src/include/catalog/mssql_metadata_cache.hpp` — only the SQL strings change; cache structures, lazy loading, TTL logic all unchanged.
+- `src/catalog/mssql_table_entry.cpp` — `MakeTableInfo` is unchanged; it stops throwing because the duplicate rows stop arriving.
+- Any other `src/` file — bug is isolated to three SQL string literals.

--- a/specs/049-fix-partitioned-table-catalog/research.md
+++ b/specs/049-fix-partitioned-table-catalog/research.md
@@ -1,0 +1,90 @@
+# Research: Fix Partitioned Table Catalog
+
+**Phase 0 Output** | **Date**: 2026-05-19
+
+## Findings
+
+No NEEDS CLARIFICATION items existed in the spec. The investigation that produced this spec already established the bug location, the SQL Server semantics, and the candidate fix shapes.
+
+### Decision 1: Use a pre-aggregated derived table
+
+**Decision**: Replace `LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)` with:
+
+```sql
+LEFT JOIN (
+    SELECT object_id, SUM(rows) AS rows
+    FROM sys.partitions
+    WHERE index_id IN (0, 1)
+    GROUP BY object_id
+) p ON p.object_id = o.object_id
+```
+
+**Rationale**:
+- One row per `object_id` regardless of partition count → no more column-row multiplication in the outer `INNER JOIN sys.columns`.
+- `SUM(rows)` gives the correct table-level cardinality estimate (the very thing the outer projection wants in `approx_rows`).
+- Pure SQL, no schema dependency, no permission change vs. the existing query.
+- Optimizer can stream-aggregate or hash-aggregate this trivially; cost is comparable to the existing per-partition scan.
+
+**Alternatives considered**:
+
+| Option | Why rejected |
+| ------ | ------------ |
+| **`OUTER APPLY (SELECT SUM(rows) ...)`** | Works, but introduces a correlated subquery shape. On older optimizer builds (SQL Server 2016/2017 RTM, before the legacy CE fixes) the planner sometimes generates a nested loop with per-row aggregate instead of a single aggregate. Derived-table form is more uniformly optimized across versions. |
+| **`SELECT DISTINCT` outer wrapper** | Wrong semantics: the columns row already varies by partition count via `p.rows`, so DISTINCT on the projected columns doesn't dedupe. Would require selecting an artificial `MAX(p.rows)` per group, which is not the right answer (we want SUM, not MAX). |
+| **Drop `sys.partitions` join from the column queries; fetch row counts separately** | Two round trips per single-table load; doubles the metadata query count for an already-hot path. Goes against spec 033's incremental-cache design which collapsed everything into single round trips. |
+| **Switch to `sys.dm_db_partition_stats`** | Same per-partition granularity — switching DMV doesn't avoid aggregation. Adds a permission requirement (`VIEW DATABASE STATE`) that some hardened read-only ETL accounts don't have. No win. |
+| **Switch to `sys.dm_db_partition_stats` aggregated** | Same aggregation needed as `sys.partitions`. Adds permission requirement for no benefit. |
+| **Use `OBJECTPROPERTYEX(object_id, 'Cardinality')`** | Not documented as a public OBJECTPROPERTYEX value; behaviour varies across versions. Not portable. |
+| **Use `sys.dm_db_stats_properties`** | Requires statistics to be present. Newly-created tables with no stats return NULL. Less reliable than `sys.partitions.rows` (which is maintained per insert/update/delete). |
+
+### Decision 2: Apply the fix to all three SQL templates in one change
+
+**Decision**: Modify `TABLE_DISCOVERY_SQL_TEMPLATE`, `SINGLE_TABLE_METADATA_SQL_TEMPLATE`, and `BULK_METADATA_SCHEMA_SQL_TEMPLATE` in the same commit.
+
+**Rationale**:
+- The three queries are tightly coupled: they're the three load paths of the same metadata cache. Fixing one but not the others means a partitioned table works when accessed one way (`SELECT * FROM <table>`) but crashes when accessed another (`mssql_preload_catalog(...)` or `SHOW ALL TABLES` populating the bulk cache).
+- The fix shape is identical for all three templates — one mechanical replacement.
+- Splitting across multiple PRs would leave a confusing intermediate state where some catalog operations work and others don't on the same table.
+
+**Alternatives considered**:
+- **MVP-only fix (SINGLE_TABLE only)**: Would resolve issue #85 but leave `mssql_preload_catalog` and `SHOW ALL TABLES` broken for partitioned tables. Not shipped.
+
+### Decision 3: Test fixture lives in its own init SQL file
+
+**Decision**: Create `docker/init/init-partitioned-tables.sql` rather than appending to `docker/init/init.sql`.
+
+**Rationale**:
+- `init.sql` is 770 lines. Adding partition function + partition scheme + filegroup-dependent objects to the bottom risks ordering issues (partition function must exist before partition scheme; partition scheme must exist before the indexed table).
+- Partitioning depends on `PRIMARY` filegroup being writable. Test isolation: if this fixture ever fails on a CI flavour that has a restricted filegroup setup, the rest of `init.sql` is unaffected.
+- Mirrors `init-transaction-tests.sql` precedent (already a separate file for the same reason).
+
+**Alternatives considered**:
+- **Append to `init.sql`**: Couples the partition fixture to the main init; ordering risk; harder to skip on CI flavours where partitioning isn't testable.
+- **Create the partitioned table at test setup time via `mssql_exec`**: SQLLogicTest's per-test setup runs inside the test runner; can't reliably hold the partition function across test runs. Container-init time is the right boundary.
+
+### Decision 4: Optional C++ unit test guards the templates
+
+**Decision**: Add `test/cpp/test_metadata_cache_queries.cpp` asserting that each template literal contains the substrings `"GROUP BY"` and `"SUM(rows)"`.
+
+**Rationale**:
+- The bug was a subtle one: the query "worked" for non-partitioned tables, so the unit-test coverage for these templates only caught the single-partition case. A future maintainer rewriting the query to avoid the derived-table form might inadvertently drop the aggregation.
+- A 5-line unit test that checks for the aggregation marker is cheap and makes the regression caught at unit-test time (fast) rather than integration-test time (requires docker-up).
+- The test is intentionally weak (substring check) — it doesn't validate the *correctness* of the aggregation (integration test does that), just the *presence* of the construct.
+
+**Alternatives considered**:
+- **Parse the SQL and check the AST**: Heavyweight; would require a SQL parser as a test-only dep. Not worth it for a guard test.
+- **Skip the unit test entirely**: Acceptable — the integration test catches real regressions. Listed as P3 / "optional" in plan.md.
+
+### Decision 5: No new vcpkg dependency
+
+**Decision**: The fix uses only standard SQL constructs and the existing test infrastructure (SQLLogicTest, Catch2). No new vcpkg packages, no new third-party dependencies.
+
+**Rationale**: This is a bug fix; introducing dependencies for a fix would be inappropriate scope creep. Spec 044 just consolidated dependencies — adding new ones here would partially undo that work.
+
+## Background Reading
+
+- [Microsoft Docs: sys.partitions (Transact-SQL)](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-partitions-transact-sql) — confirms the per-partition row granularity and that `rows` is BIGINT.
+- [Microsoft Docs: Partitioned Tables and Indexes](https://learn.microsoft.com/en-us/sql/relational-databases/partitions/partitioned-tables-and-indexes) — confirms the `RANGE RIGHT FOR VALUES (...)` creates N+1 partitions for N boundary values.
+- [Microsoft Docs: index_id semantics](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-indexes-transact-sql) — confirms index_id=0 is heap, index_id=1 is clustered index, index_id≥2 is non-clustered.
+- Issue #85 (https://github.com/hugr-lab/mssql-extension/issues/85) — original bug report with reproducer.
+- Spec 033 (specs/033-fix-catalog-scan/) — context on the catalog/metadata caching architecture being patched.

--- a/specs/049-fix-partitioned-table-catalog/spec.md
+++ b/specs/049-fix-partitioned-table-catalog/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Fix Partitioned Table Catalog
+
+**Feature Branch**: `049-fix-partitioned-table-catalog`
+**Created**: 2026-05-19
+**Status**: Draft
+**Input**: User description: "Fix issue #85 — querying a SQL Server table with a partitioned clustered index fails with `Catalog Error: Column with name <col> already exists!`. Root cause: the three catalog metadata queries in `src/catalog/mssql_metadata_cache.cpp` join `sys.partitions` without aggregating, so for an N-partition table every column row is multiplied N times. Fix the queries, add a regression test, and confirm tables with single partitions still report the same row counts."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query a table with a partitioned clustered index (Priority: P1)
+
+A user ATTACHes a SQL Server database that contains one or more tables with a partitioned clustered index. They run `SELECT * FROM attached_db.dbo.<table>` (or any other read against that table). The query succeeds and returns the expected rows.
+
+**Why this priority**: This is the reported bug. Without the fix any table whose clustered index sits on a partition scheme — a common pattern in time-series / append-only OLTP designs (logs, events, telemetry, audit trails) — is unreadable. The failure mode is at catalog binding time, so even `LIMIT 1`, `SELECT 1`, and `DESCRIBE` fail with the same error. Users cannot work around the bug from DuckDB; the only escape is `mssql_scan()` (raw T-SQL), which bypasses the catalog entirely and loses filter/projection pushdown.
+
+**Independent Test**: Create a partitioned-clustered-index table in SQL Server (3 boundary values → 4 partitions is sufficient), `ATTACH`, then run `SELECT * FROM attached.dbo.<table>`. The query returns rows without the "Column with name X already exists!" exception.
+
+**Acceptance Scenarios**:
+
+1. **Given** a SQL Server table with a partitioned clustered index across N≥2 partitions, **When** the user runs `SELECT * FROM attached_db.dbo.<table>` for the first time after `ATTACH`, **Then** the query succeeds and column metadata is built with each column appearing exactly once.
+2. **Given** the same table, **When** the user runs `DESCRIBE attached_db.dbo.<table>`, **Then** each column appears exactly once with its correct type, nullability, and collation.
+3. **Given** the same table, **When** the user runs `SELECT col_a, col_b FROM attached_db.dbo.<table>` with projection pushdown enabled, **Then** the generated T-SQL projects each column once (no duplicate-column SQL error from SQL Server).
+4. **Given** a partitioned heap (no clustered index — partitioned table without an explicit clustered index), **When** queried, **Then** behaviour is the same as US1.1 — columns are not duplicated.
+
+---
+
+### User Story 2 - Correct row-count estimate for partitioned tables (Priority: P2)
+
+A user runs `SHOW ALL TABLES` (or `duckdb_tables()`, or any query that reads the table's cardinality estimate) against a partitioned table. The row count returned is the **sum of rows across all partitions**, not the row count of an arbitrary single partition.
+
+**Why this priority**: The current code accidentally reports the row count of whichever partition `sys.partitions` happens to emit first (it's not even consistently the first partition — SQL Server is free to order rows). For a log table with 100M rows spread across 12 monthly partitions, DuckDB may report ~8M rows and pick wildly wrong join orders. The bug is invisible (no error) but corrupts every cardinality-driven optimization. Fixing US1 without fixing US2 leaves a silent correctness bug behind.
+
+**Independent Test**: Create a partitioned table, insert known counts into multiple partitions (e.g., 100 rows into partition 1, 200 into partition 2, 300 into partition 3), `ATTACH`, then read the cardinality via `SELECT estimated_size FROM duckdb_tables() WHERE table_name = '<name>'`. Expected: 600. Without the fix: 100 (or 200, or 300 — whichever partition SQL Server emits first).
+
+**Acceptance Scenarios**:
+
+1. **Given** a partitioned table with known row counts per partition, **When** the user reads `duckdb_tables().estimated_size`, **Then** the value equals `SUM(p.rows)` from `sys.partitions WHERE index_id IN (0, 1)` for that object.
+2. **Given** a non-partitioned table (single partition), **When** the user reads `duckdb_tables().estimated_size`, **Then** the value equals the table's row count and is bit-for-bit identical to the pre-fix value (no regression on the 99% case).
+3. **Given** a partitioned table, **When** the planner picks a join order, **Then** the chosen order reflects the full table size, not a single partition's size.
+
+---
+
+### User Story 3 - Bulk catalog preload handles partitioned tables (Priority: P2)
+
+A user calls `mssql_preload_catalog('ctx')` against a database that contains one or more partitioned tables. The preload completes without error, each table has columns loaded exactly once, and row counts are aggregated across partitions.
+
+**Why this priority**: `mssql_preload_catalog` runs the `BULK_METADATA_SCHEMA_SQL_TEMPLATE` query — the same query path as US1, just batched. If US1 is fixed but the bulk path isn't, calling preload on a database that contains any partitioned table will crash with the same "Column with name X already exists!" error and abort the entire schema load. All three queries must be fixed together.
+
+**Independent Test**: Attach to a database containing at least one partitioned table, call `SELECT mssql_preload_catalog('ctx')`, then read any non-partitioned and any partitioned table. Both succeed; preload reports the expected total column count (no inflated count from partition multiplication).
+
+**Acceptance Scenarios**:
+
+1. **Given** a database containing at least one partitioned table, **When** the user calls `SELECT mssql_preload_catalog('ctx')`, **Then** the call succeeds and the returned `column_count` equals `SUM(column count per table)` with each column counted once.
+2. **Given** the same setup, **When** the user runs `SHOW ALL TABLES` after preload, **Then** all tables (partitioned and not) are listed with correct row counts.
+3. **Given** `LoadAllTableMetadata` is called for a schema that contains partitioned tables, **When** the cache is populated, **Then** each table in the cache has its columns vector free of duplicates.
+
+---
+
+### User Story 4 - Cross-cutting paths against a partitioned table (Priority: P2)
+
+The catalog fix unblocks partitioned-table reads, but a user typically does more than `SELECT *`. They push filters on the partition key, INSERT new rows, UPDATE/DELETE (when a PK is present), and use `COPY TO` for bulk loads. Each of these paths consumes catalog metadata before doing its own work — a fresh-eyes audit must confirm they all still work end-to-end against a partitioned table, not just the catalog read.
+
+**Why this priority**: Without explicit coverage, the fix could silently regress in any of these paths. The metadata cache is the foundation; every DML/COPY/CTAS/filter operation walks it first. Adding even smoke-level coverage on each cross-cutting path is cheap insurance and turns latent regressions into clear test failures.
+
+**Independent Test**: Against the same partitioned `dbo.PartitionedLog` fixture used by US1-3, run one assertion per cross-cutting path and verify the expected behaviour. Each path is independently testable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a partitioned table whose clustered key is its partition key (`id`), **When** the user runs `SELECT * FROM testdb_part.dbo.PartitionedLog WHERE id < 100`, **Then** the query returns exactly the rows in partition 1 (10 rows in the fixture) and the pushed-down T-SQL contains the predicate (verified by `EXPLAIN`).
+2. **Given** a partitioned table, **When** the user runs `INSERT INTO testdb_part.dbo.PartitionedLog (id, message) VALUES (250, 'inserted')`, **Then** the INSERT succeeds and `SELECT COUNT(*) WHERE id = 250` returns 1, and the cardinality estimate (after `mssql_refresh_cache`) goes up by 1.
+3. **Given** a partitioned table **with** a primary key (`dbo.PartitionedWithPK`, added to the fixture), **When** the user runs an `UPDATE` and a `DELETE` filtered by PK, **Then** both succeed and the rowid path executes correctly — the spec 001 rowid pseudo-column is exposed by `GetVirtualColumns()` because the PK exists.
+4. **Given** an empty partitioned target table, **When** the user runs `COPY testdb_part.dbo.PartitionedLog FROM '<file.csv>'` (or `COPY (SELECT ...) TO 'mssql:testdb_part.dbo.PartitionedLog' (FORMAT BCP)`), **Then** the BCP path succeeds — `src/copy/target_resolver.cpp` queries `sys.columns` directly (no `sys.partitions` join), so it should remain unaffected, but the catalog binding that precedes target resolution depends on the fix.
+
+---
+
+### User Story 5 - Tighten SQL injection surface in metadata cache (Priority: P3, follow-up scope)
+
+The three SQL templates in `src/catalog/mssql_metadata_cache.cpp` substitute `schema_name` and `table_name` via `StringUtil::Format` without escaping single quotes — unlike `src/catalog/mssql_statistics.cpp:155-169` which does escape them. This is **pre-existing** behaviour, not introduced by this fix, but the audit performed for spec 049 surfaced it.
+
+**Why this priority** (P3, not P1): DuckDB's parser rejects single quotes in unquoted identifiers, and `ATTACH` options also reject them — so realistic user input never reaches this code path with a quote. The exploit window requires a SQL Server-side table created with `CREATE TABLE [name'with'quote] (...)` (legal in T-SQL) that DuckDB then enumerates. Possible but exotic. Hardening is worth doing, but it's a separate hygiene improvement, not part of the issue #85 crash fix.
+
+**Scope decision**: US5 is documented here so the finding isn't lost, but it is **out of scope for this spec's PR**. A follow-up spec or PR should add the same `'` → `''` escape used by `mssql_statistics.cpp::FetchRowCount` to `MSSQLMetadataCache::GetTableMetadata`, `LoadAllTableMetadata`, `BulkLoadAll`, and `EnsureTablesLoaded`.
+
+**Acceptance Scenarios** (deferred):
+
+1. **Given** a SQL Server table named `[evil';DROP TABLE x;--]`, **When** DuckDB enumerates the schema containing it, **Then** the generated metadata SQL escapes the quote to `''` and SQL Server treats the string as a literal — no extra statements execute.
+2. **Given** the same setup, **When** the user runs `SELECT * FROM attached.dbo.[evil';DROP TABLE x;--]`, **Then** the query either succeeds (if the name is otherwise valid) or fails cleanly with "object not found", but never executes the injected statement.
+
+---
+
+### Edge Cases
+
+- **Heap with partitions** (partitioned table with no clustered index — `index_id = 0` rows in `sys.partitions`). The fix must still aggregate row counts across partitions for heaps, since the existing predicate `index_id IN (0, 1)` covers both heaps (0) and clustered indexes (1).
+- **Table with no partitions and no rows** (newly created, never inserted). `sys.partitions` still has one row with `rows = 0`. The `LEFT JOIN` should yield `approx_rows = 0`, not NULL — `ISNULL(p.rows, 0)` must remain in the outer projection.
+- **System / hidden tables** with no entry in `sys.partitions`. The `LEFT JOIN` (not `INNER`) preserves the row; `ISNULL(p.rows, 0)` yields 0. Same behaviour as today.
+- **Multiple non-clustered indexes** on a partitioned table. `sys.partitions` has rows with `index_id` ≥ 2 for those, but the `WHERE index_id IN (0, 1)` filter excludes them. The fix must keep this filter (or aggregation will inflate row counts by index count).
+- **Partitioned columnstore index** (clustered or non-clustered). Clustered columnstore uses `index_id = 1`, so it's covered. Non-clustered columnstore uses `index_id ≥ 2`, so it's excluded by the filter — correct behaviour (we don't want to count rows twice).
+- **Partition with 0 rows in the middle** (e.g., empty Q1 partition between full Q4 prev year and Q2 current year). `SUM(rows)` correctly handles this — zero contributes zero.
+- **Very large partitioned tables** (1B+ rows across hundreds of partitions). `SUM(rows)` returns BIGINT; SQL Server's `rows` column is already BIGINT, so no overflow risk.
+- **Concurrent partition split** mid-query. The aggregation runs in a single SELECT under SQL Server's read-committed semantics; we get a consistent snapshot for that query.
+- **View on a partitioned table**. Views don't have entries in `sys.partitions`. `o.type IN ('U', 'V')` includes views; the `LEFT JOIN` yields no match for views and `approx_rows = 0` — unchanged behaviour.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Column duplication fix (bug)**:
+
+- **FR-001**: `SINGLE_TABLE_METADATA_SQL_TEMPLATE` MUST return exactly one row per `(object_id, column_id)` pair, regardless of how many partitions the table has.
+- **FR-002**: `BULK_METADATA_SCHEMA_SQL_TEMPLATE` MUST return exactly one row per `(schema, object_id, column_id)` triple, regardless of how many partitions any table in the schema has.
+- **FR-003**: `MakeTableInfo()` (in `src/catalog/mssql_table_entry.cpp`) MUST NOT throw "Column with name X already exists!" for any partitioned table after the fix.
+
+**Row-count accuracy**:
+
+- **FR-004**: `TABLE_DISCOVERY_SQL_TEMPLATE` MUST report `approx_rows` equal to `SUM(p.rows)` across all heap (`index_id = 0`) and clustered-index (`index_id = 1`) partitions of the object. For non-partitioned tables this equals the single partition's row count (no regression).
+- **FR-005**: The `SINGLE_TABLE_METADATA_SQL_TEMPLATE` and `BULK_METADATA_SCHEMA_SQL_TEMPLATE` queries MUST report the same aggregated `approx_rows` value as FR-004 for the same object.
+
+**Backward compatibility**:
+
+- **FR-006**: For tables with exactly one heap-or-clustered partition (the 99% case — i.e., every non-partitioned user table), the reported `approx_rows` value MUST be bit-for-bit identical to the pre-fix value. No existing integration test may begin to fail because of a different cardinality estimate.
+- **FR-007**: The fix MUST work on SQL Server 2016 and later. `sys.partitions` and `SUM()` in a derived table have been available since SQL Server 2000; the chosen approach must not depend on any 2019+ feature (since the extension supports older versions for ad-hoc connections).
+- **FR-008**: The fix MUST work on SQL Server 2017 and later, on Azure SQL Database, on Azure SQL Managed Instance, and on SQL Server on Linux. No platform-specific SQL is introduced.
+- **FR-009**: The `index_id IN (0, 1)` filter MUST be preserved. Including additional `index_id` values would count rows once per non-clustered index per partition and inflate row counts.
+
+**Regression coverage**:
+
+- **FR-010**: A new integration test MUST create a SQL Server table with a partitioned clustered index (≥3 partitions, ≥2 columns), insert rows into multiple partitions, then verify: (a) `SELECT *` succeeds, (b) `DESCRIBE` returns each column exactly once, (c) `duckdb_tables().estimated_size` equals the aggregated row count.
+- **FR-011**: The docker init SQL MUST set up the regression-test partitioned table so the test runs against `make integration-test` without per-test setup. Setup may live in a dedicated init file (loaded after `init.sql`) so the partition-function dependency on `tempdb`/`PRIMARY` filegroup is isolated.
+- **FR-012**: A C++ unit test SHOULD assert that the generated SQL for the three templates contains a `GROUP BY object_id` (or equivalent aggregation marker), so a future refactor that drops aggregation breaks at unit-test time rather than at integration-test time.
+
+**Cross-cutting coverage (US4)**:
+
+- **FR-013**: The integration test suite MUST include a filter-pushdown smoke test against the partitioned-table fixture verifying `WHERE id < <boundary>` returns only rows in the matching partition.
+- **FR-014**: The integration test suite MUST include a basic INSERT smoke test against the partitioned table that confirms a new row lands and is visible on a subsequent SELECT.
+- **FR-015**: The docker init fixture MUST also provide a partitioned table **with** a primary key (`dbo.PartitionedWithPK`) so UPDATE/DELETE/rowid coverage can be added without changing the no-PK `dbo.PartitionedLog` table (which exists to mirror issue #85's exact shape).
+- **FR-016**: The integration test suite MUST include UPDATE and DELETE smoke tests against `dbo.PartitionedWithPK` to confirm the rowid path (spec 001) still binds correctly when the table is partitioned.
+- **FR-017**: The integration test suite MUST include a `COPY TO` smoke test against the partitioned table to confirm `src/copy/target_resolver.cpp`'s catalog-binding step works for partitioned targets.
+
+### Key Entities
+
+- **`sys.partitions`**: SQL Server DMV. One row per `(object_id, index_id, partition_number)`. A non-partitioned heap or clustered-index table has one row per index. A partitioned table has N rows per index (one per partition). The `rows` column is the per-partition row count (BIGINT, updated by statistics maintenance — approximate, not exact).
+- **`SINGLE_TABLE_METADATA_SQL_TEMPLATE`** (`src/catalog/mssql_metadata_cache.cpp:57-75`): Loads object type, row count, and all columns for one table in a single round trip. Driver path for `MSSQLTableSet::LoadSingleEntry` (every `SELECT ... FROM <fresh table>`).
+- **`BULK_METADATA_SCHEMA_SQL_TEMPLATE`** (`src/catalog/mssql_metadata_cache.cpp:79-105`): Loads all tables + columns for one schema in one query. Driver path for `MSSQLTableSet::Scan` and `mssql_preload_catalog`.
+- **`TABLE_DISCOVERY_SQL_TEMPLATE`** (`src/catalog/mssql_metadata_cache.cpp:44-53`): Lists table names + row counts (no columns). Driver path for `MSSQLMetadataCache::EnsureTablesLoaded`. Does not crash today (`std::map::emplace` dedups by name) but silently reports a single-partition row count.
+- **`MakeTableInfo`** (`src/catalog/mssql_table_entry.cpp:40-51`): Builds a `CreateTableInfo` from `MSSQLTableMetadata.columns`. Calls `info.columns.AddColumn(...)`, which throws if a column name repeats. This is where the user-visible error surfaces.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The query `SELECT * FROM attached_db.dbo.<partitioned_table>` succeeds against a SQL Server table with 4+ partitions. Before the fix: throws `Catalog Error: Column with name <col> already exists!`. After the fix: returns rows.
+- **SC-002**: `duckdb_tables().estimated_size` for a partitioned table equals `SELECT SUM(rows) FROM sys.partitions WHERE object_id = OBJECT_ID('<table>') AND index_id IN (0, 1)`. Before the fix: equals the rows column of the first emitted partition row (non-deterministic).
+- **SC-003**: `SELECT mssql_preload_catalog('ctx')` succeeds against a database containing partitioned tables; reported `column_count` equals the actual unique column count (no inflation).
+- **SC-004**: All existing integration tests in `test/sql/catalog/`, `test/sql/integration/`, and the rest of `test/sql/` pass unchanged. No row-count regressions on any non-partitioned table.
+- **SC-005**: The new regression test (`test/sql/catalog/partitioned_table.test`) passes against the dockerized SQL Server.
+- **SC-006**: The fix is contained to `src/catalog/mssql_metadata_cache.cpp` (SQL template strings only). No header changes, no API changes, no new dependencies. (US5 — SQL injection hardening — is explicitly out of scope and tracked as a follow-up.)
+- **SC-007**: Cross-cutting smoke tests added in US4 pass: filter pushdown on partition key, INSERT, UPDATE/DELETE on `PartitionedWithPK`, and `COPY TO` against a partitioned target. Each test demonstrates that the catalog fix did not break any consumer that walks catalog metadata.
+
+## Security Notes
+
+- **No new SQL injection surface introduced by this fix.** The three modified templates substitute the same `schema_name`/`table_name` values via `StringUtil::Format` as before. The fix adds *literal* SQL (no new `%s` substitutions, no new identifiers concatenated into queries).
+- **Pre-existing finding (deferred to US5/follow-up)**: `mssql_metadata_cache.cpp` does not escape `'` in `schema_name`/`table_name` before substitution, in contrast to `mssql_statistics.cpp::FetchRowCount` which does. This is reachable only through SQL Server-side identifiers that contain literal quotes — unusual but legal. The crash fix in issue #85 must not be blocked on the hardening work; both can ship independently.
+- **No expanded permission requirement.** `sys.partitions` is readable by any principal with `VIEW DEFINITION` (or its membership in `db_owner`, `db_datareader`, etc.) — identical to today's requirement.
+- **No information disclosure expansion.** The fix changes only the *aggregation* shape of metadata results, not which rows are visible. Same objects, same columns.
+
+## Assumptions
+
+- The extension's existing approach of treating `approx_row_count` as an estimate (not an exact count) remains acceptable. `sys.partitions.rows` is updated by statistics maintenance and may lag the true count; this is unchanged behaviour and accepted by all upstream callers.
+- SQL Server's query optimizer handles the derived-table aggregation efficiently. For each `sys.objects` row the optimizer can use a streaming aggregate over `sys.partitions` keyed on `object_id`; the cost is `O(total_partitions)` per query, which is the same as the current query's cost (the current query also scans every partition row, just without aggregating).
+- The fix does not need a new `sys.dm_db_partition_stats` path. That DMV has the same per-partition granularity and would require the same aggregation; using `sys.partitions` keeps the change minimal and avoids introducing a new dependency on dynamic management views (which have stricter permission requirements in some hardened environments).
+- Users running `mssql_refresh_cache()` after the upgrade will pick up the corrected row counts on the next access. No migration path is required since the cache is in-memory only.

--- a/specs/049-fix-partitioned-table-catalog/tasks.md
+++ b/specs/049-fix-partitioned-table-catalog/tasks.md
@@ -1,0 +1,217 @@
+# Tasks: Fix Partitioned Table Catalog
+
+**Input**: Design documents from `/specs/049-fix-partitioned-table-catalog/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Integration tests are part of the deliverable — without a regression test the bug can be re-introduced silently. The C++ unit-test guard (T009) is optional but recommended.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation. All three SQL fixes (T002-T004) are independent in the sense that they edit different `static const char *` literals, but they must all ship together (see plan.md Decision 2).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files or independent template strings, no dependencies between them)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, or shared)
+
+## Path Conventions
+
+- **Source**: `src/catalog/mssql_metadata_cache.cpp` (sole production file changed)
+- **Test fixtures**: `docker/init/init-partitioned-tables.sql` (new), `docker/docker-compose.yml` (mount/order)
+- **Integration tests**: `test/sql/catalog/partitioned_table.test` (new, SQLLogicTest format, requires SQL Server)
+- **Unit tests**: `test/cpp/test_metadata_cache_queries.cpp` (optional, Catch2, no SQL Server needed)
+
+---
+
+## Phase 1: Setup
+
+No setup required. Branch `task/issue85-cc4234` (mapped to spec branch `049-fix-partitioned-table-catalog`) is already checked out as a worktree.
+
+---
+
+## Phase 2: Foundational (Test Fixture)
+
+**Purpose**: Stand up a deterministic partitioned table in the dockerized SQL Server so the integration test has known row counts to assert against. This must be complete before T006-T008 can run.
+
+- [ ] **T001** [Shared] Create `docker/init/init-partitioned-tables.sql`:
+   - `USE TestDB` and idempotency guard (`IF NOT EXISTS` for partition function and scheme).
+   - `CREATE PARTITION FUNCTION [pf_test_by_id] (INT) AS RANGE RIGHT FOR VALUES (100, 200, 300);` → 4 partitions: (-∞,100), [100,200), [200,300), [300,+∞).
+   - `CREATE PARTITION SCHEME [ps_test_by_id] AS PARTITION [pf_test_by_id] ALL TO ([PRIMARY]);`
+   - `CREATE TABLE dbo.PartitionedLog (id INT NOT NULL, log_ts DATETIME2(3) NOT NULL DEFAULT SYSUTCDATETIME(), message NVARCHAR(255) NULL);` — no PK, mirrors the issue's `dbo.log` shape.
+   - `CREATE CLUSTERED INDEX ix_PartitionedLog_id ON dbo.PartitionedLog (id) ON [ps_test_by_id] (id);`
+   - Seed rows with known per-partition counts: 10 rows with id < 100, 20 rows with id ∈ [100,200), 30 with id ∈ [200,300), 40 with id ≥ 300. Total = 100. Plus a non-partitioned control table `dbo.NonPartitionedControl` (a clone schema without partitioning) seeded with the same 100 rows for FR-006 regression coverage.
+   - **For US4 cross-cutting coverage**: also create `dbo.PartitionedWithPK` with a primary key on `id`, partitioned identically (`ON [ps_test_by_id] (id)`), seeded with the same 100 rows. This table enables UPDATE/DELETE/rowid testing without disturbing the no-PK `dbo.PartitionedLog` fixture.
+
+- [ ] **T002** [Shared] Wire the new init file into the container. If `docker-compose.yml` already mounts `./docker/init` and SQL Server's init runs all `.sql` files in alphabetical order, simply ensure the new filename sorts *after* `init.sql` (e.g., name it `init-partitioned-tables.sql` so it loads after `init.sql`). Otherwise, add an explicit mount/command sequence to the compose file. Verify with `make docker-down && make docker-up && docker compose -f docker/docker-compose.yml exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P TestPassword1 -d TestDB -Q "SELECT COUNT(*) FROM dbo.PartitionedLog"` reports 100.
+
+**Checkpoint**: `dbo.PartitionedLog` queryable via `sqlcmd` with row count 100; `SELECT $PARTITION.pf_test_by_id(id), COUNT(*) FROM dbo.PartitionedLog GROUP BY $PARTITION.pf_test_by_id(id)` returns 4 groups with counts 10/20/30/40.
+
+---
+
+## Phase 3: User Story 1 — Scan a partitioned table (Priority: P1) MVP
+
+**Goal**: `SELECT * FROM attached.dbo.PartitionedLog` succeeds. The "Column with name X already exists!" error from issue #85 is gone.
+
+**Independent Test**: After T003, running the new `partitioned_table.test` should pass at least the column-uniqueness and scan-succeeds assertions.
+
+### Implementation for User Story 1
+
+- [ ] **T003** [US1] Fix `SINGLE_TABLE_METADATA_SQL_TEMPLATE` in `src/catalog/mssql_metadata_cache.cpp` (line ~57-75). Replace the line `LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)` with the derived-table form from `contracts/metadata-query-contract.md`. This is the smallest possible fix that unblocks the issue.
+
+- [ ] **T004** [P] [US3] Fix `BULK_METADATA_SCHEMA_SQL_TEMPLATE` in the same file (line ~79-105). Same replacement. Required so `mssql_preload_catalog` and `MSSQLTableSet::Scan` work on partitioned tables.
+
+- [ ] **T005** [P] [US2] Fix `TABLE_DISCOVERY_SQL_TEMPLATE` in the same file (line ~44-53). Same replacement. Required so `approx_rows` reported for partitioned tables equals the true total.
+
+**Note**: T003-T005 edit different template strings in the same file. They are listed as [P] because they're logically independent edits (separate string literals); in practice, do all three in one edit pass since they share the same pattern.
+
+- [ ] **T006** [US1] Build: `GEN=ninja make`. Verify no compile errors or warnings in `mssql_metadata_cache.cpp`.
+
+- [ ] **T007** [US1] Run existing C++ unit tests: `./build/release/test/unittest`. Verify no regressions (none expected — change is SQL-only).
+
+**Checkpoint**: Build green. Existing unit tests pass. Without integration tests we cannot yet prove the fix, so the next phase is mandatory for shipping.
+
+---
+
+## Phase 4: Integration Test (Priority: P1)
+
+**Goal**: Regression test that fails on a future commit which re-introduces the per-partition multiplication.
+
+**Independent Test**: New test file passes against the dockerized SQL Server with the T001-T002 fixture loaded.
+
+- [ ] **T008** [US1, US2, US3] Create `test/sql/catalog/partitioned_table.test`. Follow the pattern in `test/sql/catalog/datetimeoffset.test` for `require mssql` / `require-env MSSQL_TESTDB_DSN` / `ATTACH ... AS testdb_part` / `DETACH` boilerplate. Cover:
+   - **US1.1**: `query II SELECT column_name, data_type FROM (DESCRIBE testdb_part.dbo.PartitionedLog) ORDER BY column_name;` — verify 3 columns appear once each.
+   - **US1.2**: `query I SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog;` — expect 100.
+   - **US1.3**: `query II SELECT id, message FROM testdb_part.dbo.PartitionedLog WHERE id = 5;` — verify projection pushdown emits each column once (no duplicate-column SQL error).
+   - **US2.1**: `query I SELECT estimated_size FROM duckdb_tables() WHERE database_name = 'testdb_part' AND table_name = 'PartitionedLog';` — expect 100 (sum across all partitions, not 10/20/30/40 from any single partition).
+   - **US2.2 / FR-006**: same query against `NonPartitionedControl` — expect 100 (regression check that the fix doesn't change non-partitioned cardinalities).
+   - **US3.1**: `statement ok SELECT mssql_preload_catalog('testdb_part');` — preload must succeed in presence of partitioned tables.
+   - **US3.2**: Re-run `SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog;` after preload — must still return 100 (no cache corruption).
+
+- [ ] **T009** [US1] Run integration tests: `make docker-up && make integration-test`. Verify the new test passes AND the rest of `test/sql/` still passes (no regressions on non-partitioned tables).
+
+**Checkpoint**: Issue #85 is resolved. All existing integration tests still pass. New regression test is now in CI.
+
+---
+
+## Phase 4b: Cross-cutting smoke tests (Priority: P2, US4)
+
+**Goal**: Verify the catalog fix does not silently regress filter pushdown, DML, or COPY against partitioned tables.
+
+**Independent Test**: Each `[P]` task below adds an isolated assertion block to a new test file. None require code changes beyond the fixtures in T001-T002.
+
+- [ ] **T009a** [P] [US4] Add `test/sql/catalog/partitioned_filter_pushdown.test`:
+   - ATTACH the test DB.
+   - `query I SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog WHERE id < 100;` → expect 10 (partition 1 only).
+   - `query I SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog WHERE id >= 100 AND id < 200;` → expect 20 (partition 2 only).
+   - `query I SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog WHERE id >= 300;` → expect 40 (partition 4 only).
+   - Optional: `EXPLAIN SELECT ... WHERE id < 100;` → assert the pushed-down T-SQL contains the predicate (via `query II` and a `LIKE '%WHERE%id%<%100%'` check on the explain output).
+   - DETACH.
+
+- [ ] **T009b** [P] [US4] Add `test/sql/insert/insert_partitioned.test` (or extend `insert_basic.test`):
+   - ATTACH the test DB.
+   - `statement ok INSERT INTO testdb_part.dbo.PartitionedLog (id, log_ts, message) VALUES (250, '2026-05-19T12:00:00', 'inserted');`
+   - `query I SELECT COUNT(*) FROM testdb_part.dbo.PartitionedLog WHERE id = 250;` → expect 1.
+   - `statement ok SELECT mssql_refresh_cache('testdb_part');`
+   - `query I SELECT estimated_size FROM duckdb_tables() WHERE database_name = 'testdb_part' AND table_name = 'PartitionedLog';` → expect 101 (post-refresh).
+   - Cleanup: `statement ok DELETE FROM testdb_part.dbo.PartitionedLog WHERE id = 250;` and re-refresh.
+   - DETACH.
+
+- [ ] **T009c** [P] [US4] Add `test/sql/dml/dml_partitioned.test`:
+   - ATTACH the test DB.
+   - `statement ok UPDATE testdb_part.dbo.PartitionedWithPK SET message = 'updated' WHERE id = 50;`
+   - `query T SELECT message FROM testdb_part.dbo.PartitionedWithPK WHERE id = 50;` → expect 'updated'.
+   - `statement ok DELETE FROM testdb_part.dbo.PartitionedWithPK WHERE id = 60;`
+   - `query I SELECT COUNT(*) FROM testdb_part.dbo.PartitionedWithPK WHERE id = 60;` → expect 0.
+   - Cleanup (restore deleted row + revert message) for test isolation.
+   - DETACH.
+
+- [ ] **T009d** [P] [US4] Add `test/sql/copy/copy_partitioned.test`:
+   - ATTACH the test DB.
+   - `statement ok CREATE TABLE local_src AS SELECT 999 AS id, 'copied' AS message;`
+   - `statement ok COPY local_src TO 'mssql:testdb_part.dbo.PartitionedLog' (FORMAT MSSQL, COLUMN_MAPPING 'id,message');` — or equivalent COPY syntax per `test/sql/copy/copy_basic.test` patterns.
+   - `query T SELECT message FROM testdb_part.dbo.PartitionedLog WHERE id = 999;` → expect 'copied'.
+   - Cleanup: `statement ok DELETE FROM testdb_part.dbo.PartitionedLog WHERE id = 999;`
+   - DETACH.
+
+**Checkpoint**: All four cross-cutting smoke tests pass. The catalog fix is verified to not regress filter pushdown, INSERT, UPDATE/DELETE, or COPY against partitioned tables.
+
+---
+
+## Phase 5: Unit-Test Guard (Priority: P3, optional)
+
+**Goal**: Catch a future refactor that drops the `GROUP BY` aggregation without needing to spin up SQL Server.
+
+- [ ] **T010** [P3] Create `test/cpp/test_metadata_cache_queries.cpp`. For each of the three template strings (`TABLE_DISCOVERY_SQL_TEMPLATE`, `SINGLE_TABLE_METADATA_SQL_TEMPLATE`, `BULK_METADATA_SCHEMA_SQL_TEMPLATE`), assert the literal contains the substrings `"GROUP BY object_id"`, `"SUM(rows)"`, and `"index_id IN (0, 1)"`. Use Catch2's `REQUIRE` macros. The templates are `static` (file-local) so the test will need them exposed — either via a small helper accessor in `mssql_metadata_cache.cpp` or by moving the templates into the header file as `inline constexpr const char *` (C++17) — since the project is C++11-compatible, prefer the accessor approach (free function `const char *GetSingleTableMetadataSql();` etc., declared in the existing header).
+
+- [ ] **T011** [P3] Add `test/cpp/test_metadata_cache_queries.cpp` to the unit-test target in `test/cpp/CMakeLists.txt`. Verify with `GEN=ninja make && ./build/release/test/unittest`.
+
+**Checkpoint**: Unit-test guard runs in <1s as part of every CI build. A future refactor that drops aggregation fails at unit-test time.
+
+---
+
+## Phase 6: Polish & Documentation
+
+- [ ] **T012** [Shared] Add a "Recent Changes" entry to `CLAUDE.md`:
+
+   ```text
+   - 049-fix-partitioned-table-catalog: Fix issue #85 — querying tables with partitioned clustered indexes
+     failed with "Column with name X already exists!" because `LEFT JOIN sys.partitions` in three catalog
+     metadata queries multiplied rows by partition count. Pre-aggregate via a derived table. Also fixes a
+     silent miscount of cardinality estimates (was: arbitrary single-partition count; now: SUM across all
+     partitions). New integration test: test/sql/catalog/partitioned_table.test.
+   ```
+
+- [ ] **T013** [Shared] Full integration suite: `make docker-down && make docker-up && make integration-test`. Final clean run end-to-end.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: N/A.
+- **Phase 2 (Foundational)**: T001 → T002 (sequential within phase). Both must complete before T008-T009 in Phase 4.
+- **Phase 3 (US1 fix)**: T003-T005 can run in parallel (independent string literals). T006-T007 after all three.
+- **Phase 4 (Integration test)**: T008 depends on T001-T005. T009 depends on T008 + T002 (docker fixture loaded).
+- **Phase 5 (Unit test, optional)**: T010-T011 depend only on T003-T005 (the templates being changed).
+- **Phase 6 (Polish)**: T012-T013 after everything else.
+
+### User Story Dependencies
+
+- **US1 (P1)**: T003 is the core fix. T006-T009 validate it. MVP path is T003 → T006 → T007 → T008 (US1 portions) → T009.
+- **US2 (P2)**: T005 fixes the row-count miscount; T008 (US2 portions) validates it.
+- **US3 (P2)**: T004 fixes the bulk preload path; T008 (US3 portions) validates it.
+
+### Parallel Opportunities
+
+- T003, T004, T005 — independent string-literal edits in one file (do in one editor pass).
+- T010 (unit-test guard) is independent of all integration test work — can be developed in parallel with T008.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. T001 + T002: Stand up the partitioned-table fixture (the only blocker for proof of fix).
+2. T003: One-line SQL fix to `SINGLE_TABLE_METADATA_SQL_TEMPLATE`.
+3. T006: Build.
+4. T007: Unit tests still pass.
+5. T008 (US1 portions only) + T009: Integration test confirms issue #85 resolved.
+6. **STOP and VALIDATE**: Issue #85 closed.
+
+### Full Delivery (recommended)
+
+1. **MVP**: T001 → T002 → T003 → T006 → T007 (US1 fix in place).
+2. **Cardinality fix**: T005 → re-run T009 with US2 assertions enabled in T008.
+3. **Preload fix**: T004 → re-run T009 with US3 assertions enabled in T008.
+4. **Guard rail**: T010 → T011 (optional but cheap).
+5. **Polish**: T012 → T013.
+
+---
+
+## Notes
+
+- All three SQL template fixes (T003-T005) are mechanical string replacements following the exact pattern in `contracts/metadata-query-contract.md`. Total edited LOC ≈ 12 (3 templates × 1 line replaced with 4 lines).
+- T001's `dbo.PartitionedLog` uses `INT` partition key rather than `DATETIME2` for fixture simplicity; the fix is partition-key-type-agnostic so this doesn't reduce coverage of the reported bug.
+- T010 requires either exposing the static templates via an accessor or moving them to a header. Prefer the accessor (preserves the templates' internal-linkage benefits).
+- T012's CLAUDE.md entry should be added under the existing `## Recent Changes` section, above the spec 044 entry, in reverse-chronological order.
+- The fix touches no Windows-specific code and no platform abstraction. No CI matrix changes needed beyond the existing one.


### PR DESCRIPTION
## Summary

Adds the design bundle for spec **049-fix-partitioned-table-catalog**, the planned fix for [issue #85](https://github.com/hugr-lab/mssql-extension/issues/85) — querying a SQL Server table with a partitioned clustered index fails with `Catalog Error: Column with name <col> already exists!`.

This PR is **spec/docs only**. No source code changes. Implementation will land in a follow-up PR per the tasks in `specs/049-fix-partitioned-table-catalog/tasks.md`.

## Root cause (investigated)

Three SQL templates in `src/catalog/mssql_metadata_cache.cpp`:

- `TABLE_DISCOVERY_SQL_TEMPLATE` (L44)
- `SINGLE_TABLE_METADATA_SQL_TEMPLATE` (L57)
- `BULK_METADATA_SCHEMA_SQL_TEMPLATE` (L79)

each do

```sql
LEFT JOIN sys.partitions p ON o.object_id = p.object_id AND p.index_id IN (0, 1)
```

`sys.partitions` has one row per partition. For an N-partition clustered table the join multiplies every column row N times. `MakeTableInfo()` in `src/catalog/mssql_table_entry.cpp:45-48` then calls `info.columns.AddColumn(...)` on each row → DuckDB rejects the second copy. The `TABLE_DISCOVERY` template doesn't crash (map dedupes by name) but silently reports the row count of an arbitrary single partition.

## Planned fix

Replace each `LEFT JOIN sys.partitions ...` with a pre-aggregated derived table:

```sql
LEFT JOIN (
    SELECT object_id, SUM(rows) AS rows
    FROM sys.partitions
    WHERE index_id IN (0, 1)
    GROUP BY object_id
) p ON p.object_id = o.object_id
```

Same shape as `src/catalog/mssql_statistics.cpp:14-22` which already aggregates correctly (this PR brings the metadata cache into alignment with code that already exists).

## User stories

| ID | Priority | Summary |
| -- | :------: | ------- |
| US1 | P1 | Query a partitioned table without the duplicate-column crash |
| US2 | P2 | `duckdb_tables().estimated_size` = SUM across partitions |
| US3 | P2 | `mssql_preload_catalog` succeeds on schemas with partitioned tables |
| US4 | P2 | Cross-cutting smoke tests: filter pushdown, INSERT, UPDATE/DELETE on PartitionedWithPK, COPY TO |
| US5 | P3 | (Out of scope, deferred) — pre-existing SQL-injection finding in identifier substitution |

## Review findings folded into the spec

1. `mssql_statistics.cpp` already uses the correct `ISNULL(SUM(p.rows), 0)` shape — fix is *converging*, not net-new SQL.
2. **Pre-existing SQL-injection surface** found in `MSSQLMetadataCache` identifier substitution (`'` not escaped, unlike `mssql_statistics.cpp::FetchRowCount`). Documented as US5 and explicitly deferred to a hardening PR so the crash fix isn't blocked.
3. **Cross-cutting gap** — issue #85 reports a read failure, but catalog metadata is the foundation of every DML/COPY path. US4 added smoke tests across filter pushdown, INSERT, UPDATE/DELETE (with a new `PartitionedWithPK` fixture), and COPY TO.

## Files

```
specs/049-fix-partitioned-table-catalog/
├── spec.md                                   (21.5K, 5 user stories, 17 FRs, 7 SCs, security notes)
├── plan.md                                   (12.9K, constitution check, structure decision)
├── research.md                               (7.4K, 5 decisions inc. alternatives matrix)
├── data-model.md                             (7.1K, before/after SQL + worked example using issue #85's table)
├── quickstart.md                             (3.1K, drop-in fix + repro/cleanup)
├── checklists/requirements.md                (3.9K)
├── contracts/metadata-query-contract.md      (5.3K, output-row shape + canonical SQL)
└── tasks.md                                  (15.2K, T001-T013 incl. T009a-d cross-cutting)
```

## Test plan

For *this* PR (spec-only):

- [x] All eight artifacts present and internally consistent (spec ↔ plan ↔ research ↔ tasks).
- [x] Spec checklist passes (`specs/049-fix-partitioned-table-catalog/checklists/requirements.md`).
- [x] Contract pins the canonical SQL shape so future refactors can be caught at unit-test time.

For the *follow-up implementation PR* (tracked in tasks.md):

- [ ] T001-T002 — partitioned-table fixture loads in dockerized SQL Server.
- [ ] T003-T005 — three SQL template fixes (single-line change each).
- [ ] T006-T007 — build + existing unit tests stay green.
- [ ] T008-T009 — regression test (`test/sql/catalog/partitioned_table.test`) passes; full integration suite stays green.
- [ ] T009a-d — cross-cutting smoke tests pass (filter pushdown, INSERT, UPDATE/DELETE, COPY).
- [ ] T010-T011 (optional) — C++ unit-test guard on the aggregation marker.
- [ ] T012 — `CLAUDE.md` "Recent Changes" entry.

Refs #85.