### PR TITLE
docs(spec): add spec 051 — DuckDB API migration (f480e781 → 997c2427)

### DIFF
--- a/specs/051-duckdb-api-migration/plan.md
+++ b/specs/051-duckdb-api-migration/plan.md
@@ -1,0 +1,189 @@
+# Implementation Plan: DuckDB API Migration
+
+**Branch**: `task/051-duckdb-api-migration-impl` (code PR)
+| **Date**: 2026-05-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from
+`/specs/051-duckdb-api-migration/spec.md`
+
+## Summary
+
+The four migrations in spec.md split cleanly into two compatibility classes:
+
+| Migration | Strategy | Lives in |
+|---|---|---|
+| M1 `IsInterrupted()` | Unconditional rename | call sites |
+| M2 `FlatVector` header | `__has_include` guard | `mssql_compat.hpp` (new) |
+| M3 `SetNullHandling()` | Unconditional rename | call sites |
+| M4 `BindScalarFunctionInput` | `#if` macro adapter | `mssql_compat.hpp` (new) |
+
+Two unconditional renames, two guarded shims. The shims live behind two
+macros that read naturally at call sites; we do not introduce a virtual
+abstraction layer.
+
+## New file: `src/include/mssql_compat.hpp`
+
+CLAUDE.md already advertises this header in two places (Technology line +
+"Key Architecture Concepts" bullet). The file does not currently exist —
+this spec ends that lie.
+
+Sketch:
+
+```cpp
+// src/include/mssql_compat.hpp
+#pragma once
+
+// ----- M2: FlatVector header relocation -----
+#if __has_include(<duckdb/common/vector/flat_vector.hpp>)
+#include <duckdb/common/vector/flat_vector.hpp>
+#define MSSQL_DUCKDB_HAS_NEW_BIND_INPUT 1
+#else
+#include <duckdb/common/types/vector.hpp>
+// FlatVector ships in vector.hpp on pre-997c2427 DuckDB.
+#endif
+
+// ----- M4: bind_scalar_function_t signature -----
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+#define MSSQL_BIND_SCALAR_SIG(name) \
+    static duckdb::unique_ptr<duckdb::FunctionData> name( \
+        duckdb::BindScalarFunctionInput &input)
+#define MSSQL_BIND_SCALAR_PROLOGUE                                  \
+    auto &context = input.GetClientContext();                       \
+    auto &arguments = input.GetArguments();                         \
+    (void)context;                                                  \
+    (void)arguments;
+#else
+#define MSSQL_BIND_SCALAR_SIG(name)                                 \
+    static duckdb::unique_ptr<duckdb::FunctionData> name(           \
+        duckdb::ClientContext &context,                             \
+        duckdb::ScalarFunction & /*bound_function*/,                \
+        duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>      \
+            &arguments)
+#define MSSQL_BIND_SCALAR_PROLOGUE  /* no-op */
+#endif
+```
+
+Notes:
+
+- The `(void)x` no-ops in the new prologue keep the macro safe at use
+  sites that read `arguments` but conditionally branch over `context`.
+- `MSSQL_DUCKDB_HAS_NEW_BIND_INPUT` is gated on the presence of
+  `flat_vector.hpp` because M2 and M4 landed together in DuckDB main. If
+  they later diverge, this header grows a second sentinel.
+
+## Call-site rewrites
+
+### M1 (7 sites): `interrupted` → `IsInterrupted()`
+
+```diff
+- if (context.interrupted) {
++ if (context.IsInterrupted()) {
+```
+
+For the three `context.client.interrupted` sites in
+`src/copy/copy_function.cpp`, the outer `context` is an
+`ExecutionContext` — `context.client` is the `ClientContext` — so the
+rewrite is `context.client.IsInterrupted()`.
+
+### M2 (~25 sites): no source change, only includes
+
+Each `src/codec/*_codec.cpp` and `src/table_scan/table_scan.cpp` adds:
+
+```diff
++ #include "mssql_compat.hpp"
+```
+
+(Replacing or accompanying the existing `vector.hpp` include — TBD per
+file to avoid the unused-include lint.)
+
+### M3 (3 sites): `null_handling = X` → `SetNullHandling(X)`
+
+```diff
+- func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
++ func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+```
+
+### M4 (3 callbacks): signature macro
+
+```diff
+- static unique_ptr<FunctionData> MSSQLExecBind(
+-     ClientContext &context, ScalarFunction &bound_function,
+-     vector<unique_ptr<Expression>> &arguments) {
++ MSSQL_BIND_SCALAR_SIG(MSSQLExecBind) {
++     MSSQL_BIND_SCALAR_PROLOGUE
+      // body unchanged — uses `context` and `arguments`
+  }
+```
+
+The body of each callback is unchanged because all three only read
+`context` and `arguments`.
+
+## CLAUDE.md updates
+
+Two reconciliations in `CLAUDE.md`:
+
+1. The "**DuckDB**: main branch, supports both stable (1.4.x) and nightly
+   APIs via `src/include/mssql_compat.hpp`" line stays — it becomes true.
+2. The "Key Architecture Concepts" bullet "**DuckDB API compat**: Auto-detected
+   at CMake time. `MSSQL_GETDATA_METHOD` macro handles GetData vs
+   GetDataInternal." is replaced/extended with a paragraph noting the four
+   spec-051 shims (M1–M4) and that detection is via `__has_include`, not
+   CMake.
+
+## Forward-compat audit (recorded)
+
+| New symbol | Exists on f480e781? | Exists on 997c2427? |
+|---|---|---|
+| `ClientContext::IsInterrupted()` | yes (`client_context.hpp:100`) | yes (`client_context.hpp:106`) |
+| `<duckdb/common/vector/flat_vector.hpp>` | **no** | yes (`flat_vector.hpp:76`) |
+| `ScalarFunction::SetNullHandling()` | yes (inherited, `function.hpp:199`) | yes (direct, `scalar_function.hpp:233`) |
+| `BindScalarFunctionInput` | **no** | yes (`scalar_function.hpp:514`) |
+
+Verification commands (rerun from the worktree):
+
+```bash
+git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8 -- src/include/
+grep -nE "IsInterrupted|SetNullHandling|BindScalarFunctionInput|FlatVector" \
+  duckdb/src/include/duckdb/main/client_context.hpp \
+  duckdb/src/include/duckdb/function/scalar_function.hpp \
+  duckdb/src/include/duckdb/function/function.hpp \
+  duckdb/src/include/duckdb/common/types/vector.hpp
+git -C duckdb cat-file -e \
+  f480e781:src/include/duckdb/common/vector/flat_vector.hpp || \
+  echo "MISSING on f480e781 — needs __has_include guard"
+
+git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e -- src/include/
+# Same greps; verify each symbol exists.
+```
+
+## Verification (PR #B)
+
+```bash
+# Original pin still builds
+git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8
+make clean && make release          # exits 0
+
+# Target SHA builds
+git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e
+make clean && make release          # exits 0
+
+# Tests pass
+make test                           # unit tests green
+# Optional, if SQL Server container available:
+make docker-up && make integration-test && make docker-down
+```
+
+## Risks (per spec.md §Risks)
+
+- DuckDB may rename more APIs in subsequent SHAs not yet audited; this spec
+  only covers the four currently breaking. Future shims land beside M2/M4
+  in `mssql_compat.hpp`.
+- The macro-based approach for M4 trades a small loss of IDE go-to-symbol
+  fidelity (the function signature is hidden inside a macro) for keeping
+  the body identical on both SHAs. Alternative — write the callback twice
+  with `#if` — is rejected as more invasive.
+
+## Out of Scope (per spec.md)
+
+Submodule gitlink bump, DuckDB patches, other API differences, behavior
+changes, DuckLake changes.

--- a/specs/051-duckdb-api-migration/spec.md
+++ b/specs/051-duckdb-api-migration/spec.md
@@ -1,0 +1,216 @@
+# Feature Specification: DuckDB API Migration (f480e781 → 997c2427)
+
+**Feature Branch**: `task/051-duckdb-api-migration-spec` (docs) → `task/051-duckdb-api-migration-impl` (code)
+
+**Created**: 2026-05-24
+
+**Status**: Draft (docs PR)
+
+**Input**: External request from downstream consumer **oluies/ducklake PR #1**.
+DuckLake needs the MSSQL extension to build against newer DuckDB SHAs than the
+gitlink currently pins. Four DuckDB public APIs used by this extension were
+renamed/relocated/reshaped between SHA `f480e781694b03105c9281d2564f08adb9a8d4a8`
+(2026-02-13, currently pinned) and SHA
+`997c2427680e7c0981e312743d27a6c61785ac9e` (2026-05-13, "Clustered Aggregation
+(#22230)"). The extension compiles cleanly against the former and fails on the
+latter. DuckLake's MSSQL build job is blocked.
+
+## Overview
+
+Adapt the extension's source so a single tree compiles against **both**
+SHAs without changing behavior. This is a pure API-shape adjustment — no new
+features, no new dependencies, no submodule bump, no refactoring beyond what
+the four migrations directly require.
+
+Goal: after this spec ships and a new extension version tags, DuckLake bumps
+its `specs/001-mssql-metadata-backend/mssql-extension.version` and PR #1
+unblocks.
+
+## Scope
+
+**In scope**: the four DuckDB API-shape adjustments enumerated in §Migrations.
+A new compatibility header `src/include/mssql_compat.hpp` (already advertised
+by `CLAUDE.md` but missing from the tree) houses the two `#if`-guarded
+adjustments. `CLAUDE.md` is updated to make its compat-header description
+honest.
+
+**Out of scope**:
+
+- Bumping `duckdb/` submodule gitlink (separate, larger decision).
+- Adding patches against DuckDB itself.
+- Any DuckDB API differences other than the four below.
+- Behavior change of any kind. Existing SQLLogicTests must pass unmodified.
+- Touching DuckLake — that repo bumps the version separately once we tag.
+
+## Migrations
+
+### M1. `ClientContext::interrupted` → `IsInterrupted()`
+
+**DuckDB compiler error** (verbatim) when building against 997c2427:
+
+```
+error: 'class duckdb::ClientContext' has no member named 'interrupted';
+       did you mean 'Interrupt'?
+```
+
+**Header evidence**:
+
+- `duckdb/main/client_context.hpp` on f480e781 — declares
+  `DUCKDB_API bool IsInterrupted() const;` (already public).
+- Same header on 997c2427 — declares the same `IsInterrupted()`.
+
+**Conclusion**: unconditional rename works on both SHAs. No compat guard.
+
+**Call sites** (7 total):
+
+- `src/table_scan/table_scan_execute.cpp:50` — `if (context.interrupted)`
+- `src/table_scan/table_scan.cpp:674` — `if (context.interrupted)`
+- `src/mssql_functions.cpp:210` — `if (context.interrupted)`
+- `src/copy/copy_function.cpp:462,486,508` — `if (context.client.interrupted)`
+- `src/copy/copy_function.cpp:617` — `if (context.interrupted)`
+
+### M2. `FlatVector` header moved → `duckdb/common/vector/flat_vector.hpp`
+
+**DuckDB compiler error** (verbatim) when building against 997c2427:
+
+```
+error: 'FlatVector' has not been declared
+```
+
+**Header evidence**:
+
+- f480e781: `struct FlatVector` declared at
+  `duckdb/common/types/vector.hpp:444`.
+- 997c2427: `struct FlatVector` declared at
+  `duckdb/common/vector/flat_vector.hpp:76`. The legacy
+  `duckdb/common/types/vector.hpp` no longer transitively exposes it.
+- `git cat-file -e f480e781:src/include/duckdb/common/vector/flat_vector.hpp`
+  → "path does not exist". The new header is target-SHA-only.
+
+**Conclusion**: `__has_include` guard required. The compat header includes
+the new path when present, falls back to the legacy path otherwise.
+
+**Call sites** (~25 total across):
+
+- `src/table_scan/table_scan.cpp` (2)
+- `src/codec/{binary,boolean,datetime,decimal,float,integer,money,string,uuid}_codec.cpp`
+
+### M3. `ScalarFunction::null_handling` field write → `SetNullHandling()`
+
+**DuckDB compiler error** (verbatim) when building against 997c2427:
+
+```
+error: 'class duckdb::ScalarFunction' has no member named 'null_handling';
+       did you mean 'GetNullHandling'?
+```
+
+**Header evidence**:
+
+- f480e781: `BaseScalarFunction` (the parent) declares both the public field
+  `null_handling` AND the inherited setter
+  `void SetNullHandling(FunctionNullHandling)` at
+  `duckdb/function/function.hpp:199–201`.
+- 997c2427: `ScalarFunction` declares `SetNullHandling()` as a direct member
+  at `duckdb/function/scalar_function.hpp:233`. The field moved behind
+  `properties.null_handling`.
+
+**Conclusion**: unconditional `SetNullHandling()` works on both SHAs. No compat
+guard.
+
+**Call sites** (3 total, all identical):
+
+- `src/mssql_functions.cpp:402`
+- `src/catalog/mssql_preload_catalog.cpp:162`
+- `src/catalog/mssql_refresh_function.cpp:118`
+
+All three are:
+`func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;`
+
+### M4. `bind_scalar_function_t` signature: 3-arg → single `BindScalarFunctionInput&`
+
+**DuckDB compiler error** (verbatim) when building against 997c2427:
+
+```
+error: invalid conversion from
+  'unique_ptr<FunctionData> (*)(ClientContext&, ScalarFunction&,
+                                vector<unique_ptr<Expression>>&)'
+to
+  'bind_scalar_function_t' {aka 'unique_ptr<FunctionData> (*)(BindScalarFunctionInput&)'}
+```
+
+**Header evidence**:
+
+- f480e781: `bind_scalar_function_t` =
+  `unique_ptr<FunctionData> (*)(ClientContext &, ScalarFunction &,
+  vector<unique_ptr<Expression>> &)`
+  at `duckdb/function/scalar_function.hpp:100`. **No `BindScalarFunctionInput`
+  class exists.**
+- 997c2427: `bind_scalar_function_t` =
+  `unique_ptr<FunctionData> (*)(BindScalarFunctionInput &)`
+  at `duckdb/function/scalar_function.hpp:138`. `BindScalarFunctionInput`
+  class is at line 514 with **private** data members and public accessors
+  `GetClientContext()`, `GetBoundFunction()`, `GetArguments()`,
+  `GetBinder()`, `HasBinder()`.
+
+**Conclusion**: `#if` guard required. The compat header defines two macros:
+`MSSQL_BIND_SCALAR_SIG(name)` for the function signature and
+`MSSQL_BIND_SCALAR_PROLOGUE` for the per-version unpacking of `context` and
+`arguments`. Each bind callback then reads naturally on both SHAs.
+
+**Call sites** (3 callbacks):
+
+- `MSSQLExecBind` — `src/mssql_functions.cpp:287`
+- `MSSQLPreloadCatalogBind` — `src/catalog/mssql_preload_catalog.cpp:22`
+- `MSSQLRefreshCacheBind` — `src/catalog/mssql_refresh_function.cpp:20`
+
+All three callbacks use only `context` and `arguments` — none read
+`bound_function`. The `ScalarFunction` vs `BoundScalarFunction` parameter
+type divergence on 997c2427 therefore does not affect us.
+
+## Acceptance Criteria
+
+1. **Builds clean against `997c2427`**:
+   ```bash
+   git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e
+   make clean && make release    # exit 0
+   ```
+2. **Builds clean against the existing pin `f480e781`** (no regression):
+   ```bash
+   git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8
+   make clean && make release    # exit 0
+   ```
+3. **All existing tests pass unmodified**: `make test` green;
+   `make integration-test` green if a SQL Server container is available.
+4. **No behavior change**: no SQLLogicTest is modified or added by this spec.
+5. **`CLAUDE.md` reconciled**: the "DuckDB" technology line and the "DuckDB
+   API compat" architecture bullet accurately describe the (now-created)
+   `src/include/mssql_compat.hpp`.
+
+## Risks
+
+- Future DuckDB SHAs may rename more APIs; this spec only covers the four
+  that currently break. The compat header is designed so additional shape
+  shims can land beside the existing two.
+- `__has_include` is C++17, which DuckDB extensions support (DuckDB ships
+  C++11-default but `__has_include` is a preprocessor feature available in
+  GCC/Clang/MSVC regardless of `-std=`).
+- `BoundScalarFunction` (the new bound-form type on 997c2427) is not
+  exposed via our bind callbacks because none of them read `bound_function`.
+  If a future bind callback needs to mutate `bound_function`, the abstraction
+  must extend.
+
+## Out of Scope (explicit)
+
+- `bind_scalar_function_extended_t` migration — that already-extended
+  callback shape pre-dated `BindScalarFunctionInput` and is not used by this
+  extension.
+- DuckDB version macro auto-detection — `__has_include` on the new
+  `flat_vector.hpp` is the single sentinel for both M2 and M4 (they
+  landed in DuckDB together; see git log between f480e781 and 997c2427).
+  If they later split, the compat header gains a second sentinel.
+
+## Downstream
+
+- **oluies/ducklake PR #1** is the proximate consumer. After this spec's
+  impl PR merges and we tag (e.g. v0.2.1), DuckLake bumps
+  `specs/001-mssql-metadata-backend/mssql-extension.version`.

--- a/specs/051-duckdb-api-migration/tasks.md
+++ b/specs/051-duckdb-api-migration/tasks.md
@@ -1,0 +1,180 @@
+---
+
+description: "Task list for spec 051 DuckDB API Migration"
+---
+
+# Tasks: DuckDB API Migration (f480e781 → 997c2427)
+
+**Input**: Design documents from `/specs/051-duckdb-api-migration/`
+
+**Prerequisites**: spec.md, plan.md (both present)
+
+**Tests**: No new tests. Spec is a behavior-preserving API-shape adjustment;
+existing SQLLogicTests and C++ unit tests must pass unmodified.
+
+## Phase 0 — Compat header + CLAUDE.md
+
+### T001 — Create `src/include/mssql_compat.hpp`
+
+Per `plan.md` sketch. Two sections:
+
+- M2: `__has_include` guard selecting `flat_vector.hpp` (new) or
+  `vector.hpp` (legacy). Defines sentinel `MSSQL_DUCKDB_HAS_NEW_BIND_INPUT`
+  when on new tree.
+- M4: `MSSQL_BIND_SCALAR_SIG(name)` + `MSSQL_BIND_SCALAR_PROLOGUE` macros,
+  gated on the same sentinel.
+
+No call-site changes in this commit — header lands first so subsequent
+commits can include it.
+
+**Commit message**: `chore(051): add src/include/mssql_compat.hpp for DuckDB API shims`
+
+### T002 — Update `CLAUDE.md` to make compat-header claim true
+
+Two edits:
+
+- "**DuckDB**: main branch, supports both stable (1.4.x) and nightly APIs via
+  `src/include/mssql_compat.hpp`" — stays as-is; it becomes accurate after T001.
+- "Key Architecture Concepts" → **DuckDB API compat** bullet — replace
+  with a paragraph that lists the four M1–M4 shims and notes detection
+  via `__has_include` on `flat_vector.hpp`. Drop the stale
+  `MSSQL_GETDATA_METHOD` line if no such macro actually exists in tree
+  (verify with `grep -rn MSSQL_GETDATA_METHOD src/`).
+
+**Commit message**: `docs(051): reconcile CLAUDE.md compat-header description`
+
+## Phase 1 — Unconditional renames (work on both SHAs)
+
+### T003 [P] — M1: `interrupted` → `IsInterrupted()` (7 sites)
+
+Files:
+
+- `src/table_scan/table_scan_execute.cpp:50`
+- `src/table_scan/table_scan.cpp:674`
+- `src/mssql_functions.cpp:210`
+- `src/copy/copy_function.cpp:462,486,508` — note nested
+  `context.client.interrupted` → `context.client.IsInterrupted()`
+- `src/copy/copy_function.cpp:617`
+
+Verify with: `grep -rnE "\.interrupted\b|->interrupted\b" src/` returns empty.
+
+**Commit message**: `refactor(051): migrate context.interrupted to IsInterrupted() (M1)`
+
+### T004 [P] — M3: `null_handling = X` → `SetNullHandling(X)` (3 sites)
+
+Files:
+
+- `src/mssql_functions.cpp:402`
+- `src/catalog/mssql_preload_catalog.cpp:162`
+- `src/catalog/mssql_refresh_function.cpp:118`
+
+Verify with: `grep -rnE "null_handling\s*=" src/` returns empty.
+
+**Commit message**: `refactor(051): use SetNullHandling() setter (M3)`
+
+## Phase 2 — Guarded shims via mssql_compat.hpp
+
+### T005 — M2: add `mssql_compat.hpp` include to FlatVector users
+
+Files (each gets `#include "mssql_compat.hpp"` near the existing duckdb
+includes; remove direct `vector.hpp` include if it becomes unused):
+
+- `src/codec/binary_codec.cpp`
+- `src/codec/boolean_codec.cpp`
+- `src/codec/datetime_codec.cpp`
+- `src/codec/decimal_codec.cpp`
+- `src/codec/float_codec.cpp`
+- `src/codec/integer_codec.cpp`
+- `src/codec/money_codec.cpp`
+- `src/codec/string_codec.cpp`
+- `src/codec/uuid_codec.cpp`
+- `src/table_scan/table_scan.cpp`
+
+Verify with: `make clean && make release` succeeds against both SHAs (T007).
+
+**Commit message**: `refactor(051): route FlatVector through mssql_compat.hpp (M2)`
+
+### T006 — M4: migrate three bind callbacks via macros
+
+Each callback rewritten as:
+
+```cpp
+MSSQL_BIND_SCALAR_SIG(MyBind) {
+    MSSQL_BIND_SCALAR_PROLOGUE
+    // body unchanged
+}
+```
+
+Files:
+
+- `src/mssql_functions.cpp:287` — `MSSQLExecBind`
+- `src/catalog/mssql_preload_catalog.cpp:22` — `MSSQLPreloadCatalogBind`
+- `src/catalog/mssql_refresh_function.cpp:20` — `MSSQLRefreshCacheBind`
+
+Each file gets `#include "mssql_compat.hpp"`.
+
+Verify each callback body uses only `context` and `arguments` — confirmed
+during spec audit (none use `bound_function`).
+
+**Commit message**: `refactor(051): bind_scalar_function_t single-arg signature (M4)`
+
+## Phase 3 — Verification
+
+### T007 — Build against both SHAs
+
+```bash
+git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8
+make clean && make release    # exit 0
+git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e
+make clean && make release    # exit 0
+```
+
+Capture stderr from both runs; both must end with the extension shared
+library produced. After verification, restore the working tree:
+`git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8` (the
+pin we ship with).
+
+### T008 — Run test suites
+
+```bash
+make test                     # C++ unit tests
+make docker-up
+make integration-test         # SQLLogicTest against SQL Server container
+make docker-down
+```
+
+All must pass unmodified (no SQLLogicTest is edited or added by this spec).
+
+### T009 — Write `pr_description.md`
+
+References each M1–M4 by name, the SHA range tested (f480e781 ↔
+997c2427), the two compile logs from T007, and oluies/ducklake#1 as the
+downstream consumer.
+
+## Phase 4 — Ship
+
+### T010 — Open PR #B
+
+`gh pr create --base main --head task/051-duckdb-api-migration-impl`
+with title:
+
+```
+refactor(051): DuckDB API migration — IsInterrupted, FlatVector header,
+               SetNullHandling, BindScalarFunctionInput
+```
+
+Body from `pr_description.md`.
+
+## Dependencies
+
+- T001 blocks T005, T006 (compat header must exist before includes work).
+- T002 has no code dependency (docs).
+- T003 / T004 are independent of each other and of T001 (work on both SHAs
+  already).
+- T005, T006 require T001.
+- T007 requires T001–T006 complete.
+- T008 requires T007 (no point running tests if build fails).
+- T009, T010 require T008.
+
+Parallel markers: `[P]` on T003, T004 — independent files, can land in
+either order.


### PR DESCRIPTION
## Summary

Docs-only spec PR. Adds `specs/051-duckdb-api-migration/{spec,plan,tasks}.md`
for adapting the extension source so a single tree compiles against both
the currently-pinned DuckDB SHA `f480e781` (2026-02-13) and target SHA
`997c2427` (2026-05-13, "Clustered Aggregation #22230").

## Four DuckDB API migrations needed

When built against `997c2427`, the extension fails with these errors:

| # | Error | Fix |
|---|---|---|
| **M1** | `'ClientContext' has no member named 'interrupted'; did you mean 'Interrupt'?` | Unconditional rename → `IsInterrupted()` (exists on both SHAs) |
| **M2** | `'FlatVector' has not been declared` | `__has_include` guard for `<duckdb/common/vector/flat_vector.hpp>` (new) vs `<duckdb/common/types/vector.hpp>` (legacy) |
| **M3** | `'ScalarFunction' has no member named 'null_handling'; did you mean 'GetNullHandling'?` | Unconditional rename → `SetNullHandling()` (exists on both SHAs) |
| **M4** | `invalid conversion ... bind_scalar_function_t {aka unique_ptr<FunctionData> (*)(BindScalarFunctionInput&)}` | Macro-guarded signature via new `mssql_compat.hpp` |

Header-grep evidence on both SHAs is recorded in `plan.md`. Each migration's
exact call sites are enumerated in `spec.md`.

## Compat header

`CLAUDE.md` already advertises `src/include/mssql_compat.hpp` in two places
(the "DuckDB" technology line and the "Key Architecture Concepts" compat
bullet) — but the file does not currently exist. The impl PR creates the
header (houses M2 + M4 guards) and updates `CLAUDE.md` to match.

## Why this matters

Downstream consumer **oluies/ducklake#1**'s MSSQL build job is blocked. After
this spec's impl PR merges and we tag (e.g. v0.2.1), DuckLake bumps its
`specs/001-mssql-metadata-backend/mssql-extension.version` and #1 unblocks.

## What's NOT in this PR

- Source code changes — those land in the follow-up impl PR against
  `task/051-duckdb-api-migration-impl`.
- Submodule gitlink bump — separate, larger decision.
- DuckDB patches — extension adapts to DuckDB, not vice versa.

## Test plan

- [ ] Spec docs render correctly on GitHub
- [ ] Reviewers confirm scope (four migrations, no behavior change, no new deps)
- [ ] Reviewers confirm the two-PR split (spec → impl) is the right pattern