### PR TITLE
refactor(051): DuckDB API migration — IsInterrupted, FlatVector header, SetNullHandling, BindScalarFunctionInput

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ duckdb --unsigned -c "INSTALL mssql FROM local_build_debug; LOAD mssql;"
 - **DML**: INSERT uses batched VALUES; UPDATE/DELETE use rowid-based VALUES JOIN pattern with deferred execution in transactions.
 - **DDL**: `CREATE TABLE IF NOT EXISTS` silently succeeds when table exists; `CREATE OR REPLACE TABLE` drops and recreates. Auto-TABLOCK enabled for new table creation (CTAS/COPY TO).
 - **Filter pushdown**: DuckDB filter expressions translated to T-SQL WHERE clauses. Function mapping for common string/date/arithmetic operations.
-- **DuckDB API compat**: Auto-detected at CMake time. `MSSQL_GETDATA_METHOD` macro handles GetData vs GetDataInternal.
+- **DuckDB API compat**: `src/include/mssql_compat.hpp` adapts API-shape differences between DuckDB SHAs so a single source tree compiles against both the pinned submodule SHA and rolling main. Detection uses `__has_include` on a target-SHA-only header (no CMake autodetect). Currently shims (spec 051): FlatVector header relocation to `<duckdb/common/vector/flat_vector.hpp>`, and the single-arg `bind_scalar_function_t` signature via `MSSQL_BIND_SCALAR_SIG` / `MSSQL_BIND_SCALAR_PROLOGUE` macros. Unconditional renames (`IsInterrupted`, `SetNullHandling`) live at call sites, not in the header.
 
 ## Windows Build Support
 

--- a/specs/051-duckdb-api-migration/pr_description.md
+++ b/specs/051-duckdb-api-migration/pr_description.md
@@ -1,0 +1,96 @@
+# refactor(051): DuckDB API migration — IsInterrupted, FlatVector header, SetNullHandling, BindScalarFunctionInput
+
+## Summary
+
+Source-only migration so a single tree compiles against **both** the currently
+pinned DuckDB SHA `f480e781694b03105c9281d2564f08adb9a8d4a8` (2026-02-13) and
+target SHA `997c2427680e7c0981e312743d27a6c61785ac9e` (2026-05-13, "Clustered
+Aggregation #22230"). Spec was merged separately as #123.
+
+Unblocks downstream **oluies/ducklake#1**'s MSSQL build job.
+
+## Four API migrations
+
+| # | DuckDB error on 997c2427 | Fix | Compat |
+|---|---|---|---|
+| **M1** | `'ClientContext' has no member 'interrupted'; did you mean 'Interrupt'?` | Rename → `IsInterrupted()` | Unconditional (exists on both SHAs) |
+| **M2** | `'FlatVector' has not been declared` | New header `<duckdb/common/vector/flat_vector.hpp>` | `__has_include` guard in `mssql_compat.hpp` |
+| **M3** | `'ScalarFunction' has no member 'null_handling'; did you mean 'GetNullHandling'?` | Setter `SetNullHandling()` | Unconditional (exists on both SHAs) |
+| **M4** | `invalid conversion ... bind_scalar_function_t {aka (*)(BindScalarFunctionInput&)}` | Single-arg struct signature | Macro guard in `mssql_compat.hpp` |
+
+Header-grep evidence on both SHAs is recorded in
+[`specs/051-duckdb-api-migration/plan.md`](../specs/051-duckdb-api-migration/plan.md).
+
+## Commits
+
+One commit per concern, in order:
+
+1. `chore(051): add src/include/mssql_compat.hpp for DuckDB API shims` —
+   New header with the M2 `__has_include` + M4 `MSSQL_BIND_SCALAR_SIG` /
+   `MSSQL_BIND_SCALAR_PROLOGUE` macros.
+2. `docs(051): reconcile CLAUDE.md DuckDB-compat description` —
+   CLAUDE.md long advertised this header in two places but the file did not
+   exist. Replaces the stale `MSSQL_GETDATA_METHOD` paragraph.
+3. `refactor(051): migrate context.interrupted to IsInterrupted() (M1)` —
+   7 sites, 4 files.
+4. `refactor(051): use SetNullHandling() setter (M3)` — 3 sites.
+5. `refactor(051): route FlatVector through mssql_compat.hpp (M2)` — 11 files.
+6. `refactor(051): bind_scalar_function_t single-arg signature (M4)` — 3 callbacks.
+
+## Discrepancy with spec.md (M2 file list)
+
+Spec.md listed 10 files for M2; the actual file count is 11 — spec missed
+`src/tds/encoding/type_converter.cpp` (2 `FlatVector::` sites at lines 266
+and 461). The impl PR adds the compat include there too. Spec.md's
+"~25 sites total" estimate is unchanged.
+
+## Verification
+
+Header-grep evidence (both SHAs verified — recorded in plan.md):
+
+| New symbol | Exists on f480e781? | Exists on 997c2427? |
+|---|---|---|
+| `ClientContext::IsInterrupted()` | yes | yes |
+| `<duckdb/common/vector/flat_vector.hpp>` | **no** (needs guard) | yes |
+| `ScalarFunction::SetNullHandling()` | yes (inherited) | yes (direct) |
+| `BindScalarFunctionInput` | **no** (needs guard) | yes |
+
+Build verification:
+
+```bash
+# pinned SHA (must still build — no regression)
+git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8
+make clean && make release    # exit 0   ← attach build log
+
+# target SHA (must now build — the point of this PR)
+git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e
+make clean && make release    # exit 0   ← attach build log
+```
+
+## What's NOT in this PR
+
+- Submodule gitlink bump — separate decision.
+- Patches against DuckDB — extension adapts to DuckDB, not vice versa.
+- New dependencies.
+- Behavior change of any kind. No SQLLogicTest is modified or added.
+
+## Test plan
+
+Local build verification was deferred to CI: the maintainer's macOS dev box
+does not have the project's `vcpkg` bootstrapped locally and falls back to
+homebrew's simdutf, which requires C++17 — conflicting with DuckDB's C++11
+default. CI builds against the project's vcpkg with the C++11-compatible
+simdutf and is the authoritative verification gate.
+
+- [ ] CI green on the pinned SHA `f480e781` (the gitlink isn't bumped, so
+      that's what CI builds against by default)
+- [ ] Manual verification: `git -C duckdb checkout 997c2427 && make release`
+      green on a fresh runner (will run before tag)
+- [ ] `make test` (C++ unit tests) green in CI
+- [ ] `make integration-test` green if Docker container reachable in CI
+- [ ] Reviewer confirms each commit is purely an API-shape change
+
+## Downstream
+
+After this PR merges and the next release tags (e.g. v0.2.1), DuckLake bumps
+`specs/001-mssql-metadata-backend/mssql-extension.version` in oluies/ducklake#1.

--- a/src/catalog/mssql_preload_catalog.cpp
+++ b/src/catalog/mssql_preload_catalog.cpp
@@ -4,6 +4,7 @@
 #include "catalog/mssql_preload_catalog.hpp"
 #include "catalog/mssql_catalog.hpp"
 #include "catalog/mssql_statistics.hpp"
+#include "mssql_compat.hpp"
 #include "mssql_storage.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -19,8 +20,8 @@ namespace duckdb {
 // Bind Function - Validates arguments at compile time
 //===----------------------------------------------------------------------===//
 
-static unique_ptr<FunctionData> MSSQLPreloadCatalogBind(ClientContext &context, ScalarFunction &bound_function,
-														vector<unique_ptr<Expression>> &arguments) {
+MSSQL_BIND_SCALAR_SIG(MSSQLPreloadCatalogBind) {
+	MSSQL_BIND_SCALAR_PROLOGUE
 	// First argument is the catalog name (must be constant)
 	if (arguments[0]->HasParameter()) {
 		throw InvalidInputException("mssql_preload_catalog: catalog_name must be a constant, not a parameter");

--- a/src/catalog/mssql_preload_catalog.cpp
+++ b/src/catalog/mssql_preload_catalog.cpp
@@ -159,7 +159,7 @@ void RegisterMSSQLPreloadCatalogFunction(ExtensionLoader &loader) {
 	ScalarFunction func("mssql_preload_catalog", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 						MSSQLPreloadCatalogExecute, MSSQLPreloadCatalogBind);
 	func.varargs = LogicalType::VARCHAR;  // Optional schema_name
-	func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	loader.RegisterFunction(func);
 }
 

--- a/src/catalog/mssql_refresh_function.cpp
+++ b/src/catalog/mssql_refresh_function.cpp
@@ -3,6 +3,7 @@
 
 #include "catalog/mssql_refresh_function.hpp"
 #include "catalog/mssql_catalog.hpp"
+#include "mssql_compat.hpp"
 #include "mssql_storage.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -17,8 +18,8 @@ namespace duckdb {
 // Bind Function - Validates arguments at compile time
 //===----------------------------------------------------------------------===//
 
-static unique_ptr<FunctionData> MSSQLRefreshCacheBind(ClientContext &context, ScalarFunction &bound_function,
-													  vector<unique_ptr<Expression>> &arguments) {
+MSSQL_BIND_SCALAR_SIG(MSSQLRefreshCacheBind) {
+	MSSQL_BIND_SCALAR_PROLOGUE
 	// First argument is the catalog name (must be constant)
 	if (arguments[0]->HasParameter()) {
 		throw InvalidInputException("mssql_refresh_cache: catalog_name must be a constant, not a parameter");

--- a/src/catalog/mssql_refresh_function.cpp
+++ b/src/catalog/mssql_refresh_function.cpp
@@ -115,7 +115,7 @@ void RegisterMSSQLRefreshCacheFunction(ExtensionLoader &loader) {
 	// mssql_refresh_cache(catalog_name VARCHAR) -> BOOLEAN
 	ScalarFunction func("mssql_refresh_cache", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, MSSQLRefreshCacheExecute,
 						MSSQLRefreshCacheBind);
-	func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	loader.RegisterFunction(func);
 }
 

--- a/src/codec/binary_codec.cpp
+++ b/src/codec/binary_codec.cpp
@@ -31,7 +31,7 @@
 
 #include "copy/target_resolver.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/bcp_row_encoder.hpp"
 
 #include <cstdint>

--- a/src/codec/boolean_codec.cpp
+++ b/src/codec/boolean_codec.cpp
@@ -20,7 +20,7 @@
 #include "codec/boolean_codec.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 
 #include <cstdint>
 

--- a/src/codec/datetime_codec.cpp
+++ b/src/codec/datetime_codec.cpp
@@ -58,7 +58,7 @@
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/bcp_row_encoder.hpp"
 #include "tds/encoding/datetime_encoding.hpp"
 #include "tds/tds_column_metadata.hpp"

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -37,7 +37,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/common/types/hugeint.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/bcp_row_encoder.hpp"
 #include "tds/encoding/decimal_encoding.hpp"
 #include "tds/encoding/type_converter.hpp"

--- a/src/codec/float_codec.cpp
+++ b/src/codec/float_codec.cpp
@@ -24,7 +24,7 @@
 #include "codec/float_codec.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 
 #include <cmath>
 #include <cstdint>

--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -29,7 +29,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/hugeint.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/bcp_row_encoder.hpp"
 #include "tds/encoding/type_converter.hpp"
 

--- a/src/codec/money_codec.cpp
+++ b/src/codec/money_codec.cpp
@@ -26,7 +26,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/hugeint.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/decimal_encoding.hpp"
 
 #include <cstdint>

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -14,7 +14,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/interval.hpp"
-#include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/utf16.hpp"
 #include "tds/tds_column_metadata.hpp"
 #include "tds/tds_types.hpp"

--- a/src/codec/uuid_codec.cpp
+++ b/src/codec/uuid_codec.cpp
@@ -28,6 +28,7 @@
 #include "dml/ctas/mssql_ctas_config.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/guid_encoding.hpp"
 #include "tds/tds_column_metadata.hpp"
 

--- a/src/copy/copy_function.cpp
+++ b/src/copy/copy_function.cpp
@@ -459,7 +459,7 @@ void BCPCopySink(ExecutionContext &context, FunctionData &bind_data, GlobalFunct
 	}
 
 	// Check for interrupt (Ctrl+C) - allows user to cancel long-running COPY
-	if (context.client.interrupted) {
+	if (context.client.IsInterrupted()) {
 		CopyDebugLog(1, "BCPCopySink: INTERRUPT detected at start");
 		throw InterruptException();
 	}
@@ -483,7 +483,7 @@ void BCPCopySink(ExecutionContext &context, FunctionData &bind_data, GlobalFunct
 					 (unsigned long long)rows_written, write_ms);
 
 		// Check for interrupt after encoding
-		if (context.client.interrupted) {
+		if (context.client.IsInterrupted()) {
 			CopyDebugLog(1, "BCPCopySink: INTERRUPT detected after encoding");
 			throw InterruptException();
 		}
@@ -505,7 +505,7 @@ void BCPCopySink(ExecutionContext &context, FunctionData &bind_data, GlobalFunct
 		}
 
 		// Check for interrupt after flush
-		if (context.client.interrupted) {
+		if (context.client.IsInterrupted()) {
 			CopyDebugLog(1, "BCPCopySink: INTERRUPT detected after flush");
 			throw InterruptException();
 		}
@@ -614,7 +614,7 @@ void BCPCopyFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunc
 	auto &gdata = gstate.Cast<MSSQLCopyGlobalState>();
 
 	// Check for interrupt before starting heavy finalize
-	if (context.interrupted) {
+	if (context.IsInterrupted()) {
 		throw InterruptException();
 	}
 

--- a/src/include/mssql_compat.hpp
+++ b/src/include/mssql_compat.hpp
@@ -30,21 +30,21 @@
 
 #ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
 
-#define MSSQL_BIND_SCALAR_SIG(name)                                                                                    \
+#define MSSQL_BIND_SCALAR_SIG(name) \
 	static duckdb::unique_ptr<duckdb::FunctionData> name(duckdb::BindScalarFunctionInput &input)
 
-#define MSSQL_BIND_SCALAR_PROLOGUE                                                                                     \
-	auto &context = input.GetClientContext();                                                                          \
-	auto &arguments = input.GetArguments();                                                                            \
-	(void)context;                                                                                                     \
+#define MSSQL_BIND_SCALAR_PROLOGUE            \
+	auto &context = input.GetClientContext(); \
+	auto &arguments = input.GetArguments();   \
+	(void)context;                            \
 	(void)arguments;
 
 #else
 
-#define MSSQL_BIND_SCALAR_SIG(name)                                                                                    \
-	static duckdb::unique_ptr<duckdb::FunctionData> name(                                                              \
-	    duckdb::ClientContext &context, duckdb::ScalarFunction & /*bound_function*/,                                   \
-	    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &arguments)
+#define MSSQL_BIND_SCALAR_SIG(name)                                                  \
+	static duckdb::unique_ptr<duckdb::FunctionData> name(                            \
+		duckdb::ClientContext &context, duckdb::ScalarFunction & /*bound_function*/, \
+		duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &arguments)
 
 #define MSSQL_BIND_SCALAR_PROLOGUE /* no-op on legacy SHA */
 

--- a/src/include/mssql_compat.hpp
+++ b/src/include/mssql_compat.hpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+// mssql_compat.hpp — DuckDB API shape adapters (spec 051)
+//
+// Lets a single source tree compile against multiple DuckDB SHAs by hiding
+// header relocations and signature shape changes behind preprocessor guards.
+// Detection uses __has_include on a target-SHA-only header
+// (duckdb/common/vector/flat_vector.hpp); features that landed together in
+// DuckDB main share that sentinel.
+//
+// Migrations covered (spec 051):
+//   M2 — FlatVector header moved to <duckdb/common/vector/flat_vector.hpp>.
+//   M4 — bind_scalar_function_t signature changed to single-arg
+//        (BindScalarFunctionInput &). The MSSQL_BIND_SCALAR_SIG macro hides
+//        the per-SHA signature; MSSQL_BIND_SCALAR_PROLOGUE unpacks the new
+//        struct on the new SHA and is a no-op on the legacy SHA.
+//
+// M1 (ClientContext::IsInterrupted) and M3 (ScalarFunction::SetNullHandling)
+// exist on both currently-supported SHAs and are renamed in-place at call
+// sites, not via this header.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#if __has_include(<duckdb/common/vector/flat_vector.hpp>)
+#include <duckdb/common/vector/flat_vector.hpp>
+#define MSSQL_DUCKDB_HAS_NEW_BIND_INPUT 1
+#else
+#include <duckdb/common/types/vector.hpp>
+#endif
+
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+
+#define MSSQL_BIND_SCALAR_SIG(name)                                                                                    \
+	static duckdb::unique_ptr<duckdb::FunctionData> name(duckdb::BindScalarFunctionInput &input)
+
+#define MSSQL_BIND_SCALAR_PROLOGUE                                                                                     \
+	auto &context = input.GetClientContext();                                                                          \
+	auto &arguments = input.GetArguments();                                                                            \
+	(void)context;                                                                                                     \
+	(void)arguments;
+
+#else
+
+#define MSSQL_BIND_SCALAR_SIG(name)                                                                                    \
+	static duckdb::unique_ptr<duckdb::FunctionData> name(                                                              \
+	    duckdb::ClientContext &context, duckdb::ScalarFunction & /*bound_function*/,                                   \
+	    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &arguments)
+
+#define MSSQL_BIND_SCALAR_PROLOGUE /* no-op on legacy SHA */
+
+#endif

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -207,7 +207,7 @@ void MSSQLScanFunction(ClientContext &context, TableFunctionInput &data, DataChu
 	}
 
 	// Check for query cancellation (Ctrl+C)
-	if (context.interrupted) {
+	if (context.IsInterrupted()) {
 		global_state.result_stream->Cancel();
 		global_state.done = true;
 		output.SetCardinality(0);

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "mssql_compat.hpp"
 #include "mssql_storage.hpp"
 #include "query/mssql_query_executor.hpp"
 #include "query/mssql_simple_query.hpp"
@@ -284,8 +285,8 @@ struct MSSQLExecBindData : public FunctionData {
 };
 
 // Bind function for mssql_exec
-static unique_ptr<FunctionData> MSSQLExecBind(ClientContext &context, ScalarFunction &bound_function,
-											  vector<unique_ptr<Expression>> &arguments) {
+MSSQL_BIND_SCALAR_SIG(MSSQLExecBind) {
+	MSSQL_BIND_SCALAR_PROLOGUE
 	// First argument is the context name (attached database name, must be constant)
 	if (arguments[0]->HasParameter()) {
 		throw InvalidInputException("mssql_exec: context_name must be a constant, not a parameter");

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -399,7 +399,7 @@ static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &re
 ScalarFunction MSSQLExecScalarFunction::GetFunction() {
 	ScalarFunction func(NAME, {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BIGINT, MSSQLExecExecute,
 						MSSQLExecBind);
-	func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return func;
 }
 

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/common.hpp"		   // For COLUMN_IDENTIFIER_ROW_ID
 #include "duckdb/common/table_column.hpp"  // For TableColumn, virtual_column_map_t
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "mssql_compat.hpp"		// For FlatVector header relocation (spec 051 M2)
 #include "mssql_functions.hpp"	// For backward compatibility with MSSQLCatalogScanBindData
 #include "query/mssql_query_executor.hpp"
 #include "table_scan/filter_encoder.hpp"

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -671,7 +671,7 @@ static void TableScanExecute(ClientContext &context, TableFunctionInput &data, D
 	}
 
 	// Check for query cancellation (Ctrl+C)
-	if (context.interrupted) {
+	if (context.IsInterrupted()) {
 		global_state.result_stream->Cancel();
 		global_state.done = true;
 		output.SetCardinality(0);

--- a/src/table_scan/table_scan_execute.cpp
+++ b/src/table_scan/table_scan_execute.cpp
@@ -47,7 +47,7 @@ void TableScanExecute(ClientContext &context, TableFunctionInput &data, DataChun
 	}
 
 	// Check for query cancellation (Ctrl+C)
-	if (context.interrupted) {
+	if (context.IsInterrupted()) {
 		global_state.result_stream->Cancel();
 		global_state.done = true;
 		output.SetCardinality(0);

--- a/src/tds/encoding/type_converter.cpp
+++ b/src/tds/encoding/type_converter.cpp
@@ -15,6 +15,7 @@
 #include "codec/uuid_codec.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/decimal.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/datetime_encoding.hpp"
 #include "tds/encoding/decimal_encoding.hpp"
 #include "tds/encoding/utf16.hpp"


### PR DESCRIPTION
# refactor(051): DuckDB API migration — IsInterrupted, FlatVector header, SetNullHandling, BindScalarFunctionInput

## Summary

Source-only migration so a single tree compiles against **both** the currently
pinned DuckDB SHA `f480e781694b03105c9281d2564f08adb9a8d4a8` (2026-02-13) and
target SHA `997c2427680e7c0981e312743d27a6c61785ac9e` (2026-05-13, "Clustered
Aggregation #22230"). Spec was merged separately as #123.

Unblocks downstream **oluies/ducklake#1**'s MSSQL build job.

## Four API migrations

| # | DuckDB error on 997c2427 | Fix | Compat |
|---|---|---|---|
| **M1** | `'ClientContext' has no member 'interrupted'; did you mean 'Interrupt'?` | Rename → `IsInterrupted()` | Unconditional (exists on both SHAs) |
| **M2** | `'FlatVector' has not been declared` | New header `<duckdb/common/vector/flat_vector.hpp>` | `__has_include` guard in `mssql_compat.hpp` |
| **M3** | `'ScalarFunction' has no member 'null_handling'; did you mean 'GetNullHandling'?` | Setter `SetNullHandling()` | Unconditional (exists on both SHAs) |
| **M4** | `invalid conversion ... bind_scalar_function_t {aka (*)(BindScalarFunctionInput&)}` | Single-arg struct signature | Macro guard in `mssql_compat.hpp` |

Header-grep evidence on both SHAs is recorded in
[`specs/051-duckdb-api-migration/plan.md`](../specs/051-duckdb-api-migration/plan.md).

## Commits

One commit per concern, in order:

1. `chore(051): add src/include/mssql_compat.hpp for DuckDB API shims` —
   New header with the M2 `__has_include` + M4 `MSSQL_BIND_SCALAR_SIG` /
   `MSSQL_BIND_SCALAR_PROLOGUE` macros.
2. `docs(051): reconcile CLAUDE.md DuckDB-compat description` —
   CLAUDE.md long advertised this header in two places but the file did not
   exist. Replaces the stale `MSSQL_GETDATA_METHOD` paragraph.
3. `refactor(051): migrate context.interrupted to IsInterrupted() (M1)` —
   7 sites, 4 files.
4. `refactor(051): use SetNullHandling() setter (M3)` — 3 sites.
5. `refactor(051): route FlatVector through mssql_compat.hpp (M2)` — 11 files.
6. `refactor(051): bind_scalar_function_t single-arg signature (M4)` — 3 callbacks.

## Discrepancy with spec.md (M2 file list)

Spec.md listed 10 files for M2; the actual file count is 11 — spec missed
`src/tds/encoding/type_converter.cpp` (2 `FlatVector::` sites at lines 266
and 461). The impl PR adds the compat include there too. Spec.md's
"~25 sites total" estimate is unchanged.

## Verification

Header-grep evidence (both SHAs verified — recorded in plan.md):

| New symbol | Exists on f480e781? | Exists on 997c2427? |
|---|---|---|
| `ClientContext::IsInterrupted()` | yes | yes |
| `<duckdb/common/vector/flat_vector.hpp>` | **no** (needs guard) | yes |
| `ScalarFunction::SetNullHandling()` | yes (inherited) | yes (direct) |
| `BindScalarFunctionInput` | **no** (needs guard) | yes |

Build verification:

```bash
# pinned SHA (must still build — no regression)
git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8
make clean && make release    # exit 0   ← attach build log

# target SHA (must now build — the point of this PR)
git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e
make clean && make release    # exit 0   ← attach build log
```

## What's NOT in this PR

- Submodule gitlink bump — separate decision.
- Patches against DuckDB — extension adapts to DuckDB, not vice versa.
- New dependencies.
- Behavior change of any kind. No SQLLogicTest is modified or added.

## Test plan

Local build verification was deferred to CI: the maintainer's macOS dev box
does not have the project's `vcpkg` bootstrapped locally and falls back to
homebrew's simdutf, which requires C++17 — conflicting with DuckDB's C++11
default. CI builds against the project's vcpkg with the C++11-compatible
simdutf and is the authoritative verification gate.

- [ ] CI green on the pinned SHA `f480e781` (the gitlink isn't bumped, so
      that's what CI builds against by default)
- [ ] Manual verification: `git -C duckdb checkout 997c2427 && make release`
      green on a fresh runner (will run before tag)
- [ ] `make test` (C++ unit tests) green in CI
- [ ] `make integration-test` green if Docker container reachable in CI
- [ ] Reviewer confirms each commit is purely an API-shape change

## Downstream

After this PR merges and the next release tags (e.g. v0.2.1), DuckLake bumps
`specs/001-mssql-metadata-backend/mssql-extension.version` in oluies/ducklake#1.