### PR TITLE
security: wipe bearer credentials on destruction (password, access_token, FEDAUTH token)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Wipe bearer credentials on destruction.** `MSSQLConnectionInfo` gains a
+  user-declared destructor that `OPENSSL_cleanse`s `password` and
+  `access_token`; `~MSSQLCatalog` wipes the cached `fedauth_token_utf16le_`
+  byte vector. `OPENSSL_cleanse` defeats dead-store elimination, so secrets
+  do not linger in heap-recycled memory after the owning
+  `shared_ptr<MSSQLConnectionInfo>` or `MSSQLCatalog` is destroyed.
+  Rule-of-five compliance: copy/move ctors and assigns on
+  `MSSQLConnectionInfo` are explicitly `= default`-ed so that user-declaring
+  the destructor doesn't silently disable move generation.
+
 ## [0.2.0] - 2026-05-20
 
 Major release: integrated authentication (Kerberos + Windows SSPI),

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -1,4 +1,6 @@
 #include "catalog/mssql_catalog.hpp"
+#include <openssl/crypto.h>
+
 #include "azure/azure_token.hpp"
 #include "catalog/mssql_ddl_translator.hpp"
 #include "catalog/mssql_schema_entry.hpp"
@@ -75,7 +77,15 @@ MSSQLCatalog::MSSQLCatalog(AttachedDatabase &db, const string &context_name,
 	statistics_provider_ = make_uniq<MSSQLStatisticsProvider>();
 }
 
-MSSQLCatalog::~MSSQLCatalog() noexcept = default;
+MSSQLCatalog::~MSSQLCatalog() noexcept {
+	// Wipe the cached FEDAUTH token (UTF-16LE bytes) on catalog teardown so
+	// the bearer credential does not linger in heap-recycled memory. Same
+	// rationale as MSSQLConnectionInfo::~MSSQLConnectionInfo — use
+	// OPENSSL_cleanse to defeat dead-store elimination.
+	if (!fedauth_token_utf16le_.empty()) {
+		OPENSSL_cleanse(fedauth_token_utf16le_.data(), fedauth_token_utf16le_.size());
+	}
+}
 
 //===----------------------------------------------------------------------===//
 // Result Stream Registry (spec 047 / US3)

--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -142,6 +142,28 @@ struct MSSQLConnectionInfo {
 
 	// Check if string is a connection string (contains key=value pairs)
 	static bool IsConnectionString(const string &str);
+
+	//===----------------------------------------------------------------------===//
+	// Credential lifetime
+	//
+	// User-declared destructor OPENSSL_cleanse's `password` and `access_token`
+	// (and any other bearer-token storage added later) so secrets are not
+	// left behind in heap-recycled memory after this struct is freed. The
+	// implementation lives in mssql_storage.cpp to keep OpenSSL out of this
+	// header. shared_ptr<MSSQLConnectionInfo> is the canonical owner shape,
+	// so the wipe runs exactly when the last reference drops.
+	//
+	// The other four special members are explicitly defaulted because
+	// user-declaring the destructor would otherwise disable implicit move
+	// generation (and silently fall back to copy).
+	//===----------------------------------------------------------------------===//
+	MSSQLConnectionInfo() = default;
+	~MSSQLConnectionInfo();
+
+	MSSQLConnectionInfo(const MSSQLConnectionInfo &) = default;
+	MSSQLConnectionInfo &operator=(const MSSQLConnectionInfo &) = default;
+	MSSQLConnectionInfo(MSSQLConnectionInfo &&) = default;
+	MSSQLConnectionInfo &operator=(MSSQLConnectionInfo &&) = default;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -16,6 +16,8 @@
 #include "tds/auth/auth_strategy_factory.hpp"
 #include "tds/tds_connection.hpp"
 
+#include <openssl/crypto.h>
+
 #include <cstdlib>
 
 // Debug logging (same pattern as tds_socket.cpp)
@@ -35,6 +37,29 @@ static int GetMssqlStorageDebugLevel() {
 	} while (0)
 
 namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// MSSQLConnectionInfo destructor — wipe bearer credentials
+//
+// SQL `password` and Azure AD `access_token` are bearer credentials that
+// should not linger in heap-recycled memory after the struct dies. Use
+// OPENSSL_cleanse rather than std::fill / memset so dead-store elimination
+// can't optimise the wipe away. Cheap (microseconds) and OpenSSL is
+// already linked extension-wide via vcpkg.
+//
+// `password.data()` returns a pointer to the storage in use (whether SSO
+// inline buffer or heap allocation). Wiping `size()` bytes covers the
+// live characters; subsequent `string` destruction releases the heap
+// allocation (if any) — by then it holds zeros.
+//===----------------------------------------------------------------------===//
+MSSQLConnectionInfo::~MSSQLConnectionInfo() {
+	if (!password.empty()) {
+		OPENSSL_cleanse(&password[0], password.size());
+	}
+	if (!access_token.empty()) {
+		OPENSSL_cleanse(&access_token[0], access_token.size());
+	}
+}
 
 //===----------------------------------------------------------------------===//
 // ResolveAppName (Spec 047 US-AN / FR-014 / T065) — see header doc-comment


### PR DESCRIPTION
## Summary

Add user-declared destructors that `OPENSSL_cleanse` sensitive credential storage so bearer secrets are not left in heap-recycled memory after the owning struct dies.

- **`MSSQLConnectionInfo::~MSSQLConnectionInfo()`** wipes `password` (SQL auth) and `access_token` (pre-provided Azure AD JWT — spec 032). Both are bearer credentials parsed from connection strings or DuckDB secrets.
- **`~MSSQLCatalog()`** wipes `fedauth_token_utf16le_` — the UTF-16LE Azure FEDAUTH token vector held on the catalog after `AcquireToken` returns (spec 047).
- **`OPENSSL_cleanse`** rather than `std::fill` / `memset`: defeats dead-store elimination so the wipe is not optimised away. OpenSSL is already linked extension-wide via vcpkg; the call is microsecond-cheap.
- **Rule-of-five compliance**: copy/move ctors and assigns on `MSSQLConnectionInfo` are explicitly `= default`-ed. User-declaring the destructor would otherwise silently disable move generation and fall back to copy.
- **`<openssl/crypto.h>` stays out of public headers** — destructor implementations live in `mssql_storage.cpp` and `mssql_catalog.cpp`.

## Threat model

Defence in depth against post-mortem memory inspection: process core dumps, container restart races, OOM-kill survivors, swap-file scrapes. Doesn't change the in-use threat surface — while a `MSSQLConnectionInfo` lives, its `password` is plaintext in memory exactly as before, but a leaked allocator slab after teardown contains zeros instead of the secret.

## Files

| File | Change |
|---|---|
| `src/include/mssql_storage.hpp` | Declare `~MSSQLConnectionInfo()` + explicit rule-of-five defaults |
| `src/mssql_storage.cpp` | Implement destructor, `#include <openssl/crypto.h>` |
| `src/catalog/mssql_catalog.cpp` | Replace `~MSSQLCatalog() = default` with body wiping `fedauth_token_utf16le_` |
| `CHANGELOG.md` | `[Unreleased]` Security entry |

## Test plan

- [ ] CI green on all platforms (Linux GCC + Clang, macOS Clang, Windows MSVC + MinGW). `<openssl/crypto.h>` is already a transitive include in TDS/TLS code, so no new vcpkg deps.
- [ ] No behaviour change at runtime — wipe only runs at destruction. Existing integration suite suffices to confirm no regression.
- [ ] Optional: ASan run on `make integration-test` to confirm no use-after-free introduced by the explicit destructor (the rule-of-five defaults guard against this, but worth a check).

## Notes

- `MSSQLConnectionInfo` is held via `shared_ptr<MSSQLConnectionInfo>` throughout (`FromSecret`, `FromConnectionString`, `MSSQLCatalog::connection_info_`), so wipes run exactly once per logical credential, on the last reference drop.
- This does NOT wipe transient copies the OS / vcpkg / TDS layer may make of these strings during LOGIN7 encoding or TLS handshakes. Those are out of scope for a single-PR change; widening that surface would require codec-level audit (spec-class work). The struct-destructor wipe handles the long-lived references that matter for forensic exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)