### PR TITLE
refactor(051-fu): DuckDB API migration M5–M12 (GetDataMutable, Legacy filter API, expression accessors)

### DIFF
--- a/src/azure/azure_test_function.cpp
+++ b/src/azure/azure_test_function.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "mssql_compat.hpp"
 
 namespace duckdb {
 namespace mssql {

--- a/src/catalog/mssql_preload_catalog.cpp
+++ b/src/catalog/mssql_preload_catalog.cpp
@@ -163,7 +163,7 @@ void RegisterMSSQLPreloadCatalogFunction(ExtensionLoader &loader) {
 	// M9 (spec 051 follow-up): varargs moved from a public ScalarFunction
 	// field to a private FunctionSignature member with a SetVarArgs setter.
 #ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
-	func.SetVarArgs(LogicalType::VARCHAR);  // Optional schema_name
+	func.SetVarArgs(LogicalType::VARCHAR);	// Optional schema_name
 #else
 	func.varargs = LogicalType::VARCHAR;  // Optional schema_name
 #endif

--- a/src/catalog/mssql_preload_catalog.cpp
+++ b/src/catalog/mssql_preload_catalog.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -159,7 +160,13 @@ void RegisterMSSQLPreloadCatalogFunction(ExtensionLoader &loader) {
 	// mssql_preload_catalog(catalog_name VARCHAR [, schema_name VARCHAR]) -> VARCHAR
 	ScalarFunction func("mssql_preload_catalog", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 						MSSQLPreloadCatalogExecute, MSSQLPreloadCatalogBind);
+	// M9 (spec 051 follow-up): varargs moved from a public ScalarFunction
+	// field to a private FunctionSignature member with a SetVarArgs setter.
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	func.SetVarArgs(LogicalType::VARCHAR);  // Optional schema_name
+#else
 	func.varargs = LogicalType::VARCHAR;  // Optional schema_name
+#endif
 	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	loader.RegisterFunction(func);
 }

--- a/src/catalog/mssql_refresh_function.cpp
+++ b/src/catalog/mssql_refresh_function.cpp
@@ -8,6 +8,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"

--- a/src/codec/binary_codec.cpp
+++ b/src/codec/binary_codec.cpp
@@ -67,7 +67,7 @@ std::string HexRender(const uint8_t *data, size_t length) {
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata & /*col*/, Vector &out, idx_t row) {
 	// AddStringOrBlob copies the raw bytes into the vector's string heap.
 	// Works for BLOB, GEOMETRY, and the VARCHAR fallback case (issue #89).
-	FlatVector::GetData<string_t>(out)[row] =
+	mssql_compat::GetDataMutable<string_t>(out)[row] =
 		StringVector::AddStringOrBlob(out, reinterpret_cast<const char *>(bytes.data()), bytes.size());
 }
 

--- a/src/codec/boolean_codec.cpp
+++ b/src/codec/boolean_codec.cpp
@@ -33,7 +33,7 @@ namespace {
 
 bool GetVectorBool(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto data = UnifiedVectorFormat::GetData<bool>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -43,7 +43,7 @@ bool GetVectorBool(Vector &vec, idx_t row_idx) {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata & /*col*/, Vector &out, idx_t row) {
 	bool b = !bytes.empty() && bytes[0] != 0;
-	FlatVector::GetData<bool>(out)[row] = b;
+	mssql_compat::GetDataMutable<bool>(out)[row] = b;
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/datetime_codec.cpp
+++ b/src/codec/datetime_codec.cpp
@@ -86,7 +86,7 @@ using duckdb::tds::TDS_TYPE_TIME;
 template <typename T>
 T GetVectorValue(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto data = UnifiedVectorFormat::GetData<T>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -261,23 +261,23 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	switch (col.type_id) {
 	case TDS_TYPE_DATE: {
 		date_t d = tds::encoding::DateTimeEncoding::ConvertDate(bytes.data());
-		FlatVector::GetData<date_t>(out)[row] = d;
+		mssql_compat::GetDataMutable<date_t>(out)[row] = d;
 		return;
 	}
 	case TDS_TYPE_TIME: {
 		dtime_t t = tds::encoding::DateTimeEncoding::ConvertTime(bytes.data(), col.scale);
-		FlatVector::GetData<dtime_t>(out)[row] = t;
+		mssql_compat::GetDataMutable<dtime_t>(out)[row] = t;
 		return;
 	}
 	case TDS_TYPE_DATETIME: {
 		// DATETIME wire (~3 ms precision) always decodes to TIMESTAMP (µs).
 		timestamp_t ts = tds::encoding::DateTimeEncoding::ConvertDatetime(bytes.data());
-		FlatVector::GetData<timestamp_t>(out)[row] = ts;
+		mssql_compat::GetDataMutable<timestamp_t>(out)[row] = ts;
 		return;
 	}
 	case TDS_TYPE_SMALLDATETIME: {
 		timestamp_t ts = tds::encoding::DateTimeEncoding::ConvertSmallDatetime(bytes.data());
-		FlatVector::GetData<timestamp_t>(out)[row] = ts;
+		mssql_compat::GetDataMutable<timestamp_t>(out)[row] = ts;
 		return;
 	}
 	case TDS_TYPE_DATETIME2: {
@@ -286,7 +286,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		// drop precision on DATETIME2(7) → TIMESTAMP_NS round-trips.
 		size_t time_len = Datetime2TimeByteLen(col.scale);
 		int64_t native = Datetime2WireToNativeUnit(bytes.data(), time_len, col.scale, out.GetType().id());
-		FlatVector::GetData<timestamp_t>(out)[row] = timestamp_t(native);
+		mssql_compat::GetDataMutable<timestamp_t>(out)[row] = timestamp_t(native);
 		return;
 	}
 	case TDS_TYPE_DATETIMEN: {
@@ -300,14 +300,14 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		} else {
 			throw InvalidInputException("Invalid DATETIMEN length: %d", bytes.size());
 		}
-		FlatVector::GetData<timestamp_t>(out)[row] = ts;
+		mssql_compat::GetDataMutable<timestamp_t>(out)[row] = ts;
 		return;
 	}
 	case TDS_TYPE_DATETIMEOFFSET: {
 		// DuckDB has no nanosecond TZ type; catalog always maps DATETIMEOFFSET
 		// to TIMESTAMP_TZ (µs). Existing decoder returns UTC µs which fits.
 		timestamp_t ts = tds::encoding::DateTimeEncoding::ConvertDatetimeOffset(bytes.data(), col.scale);
-		FlatVector::GetData<timestamp_t>(out)[row] = ts;
+		mssql_compat::GetDataMutable<timestamp_t>(out)[row] = ts;
 		return;
 	}
 	default:

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -56,7 +56,7 @@ namespace {
 template <typename T>
 T GetVectorValue(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto data = UnifiedVectorFormat::GetData<T>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -87,13 +87,13 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	// DuckDB DECIMAL uses different storage based on precision.
 	// Mirrors the dispatch in TypeConverter::ConvertDecimal.
 	if (col.precision <= 4) {
-		FlatVector::GetData<int16_t>(out)[row] = static_cast<int16_t>(int_value.lower);
+		mssql_compat::GetDataMutable<int16_t>(out)[row] = static_cast<int16_t>(int_value.lower);
 	} else if (col.precision <= 9) {
-		FlatVector::GetData<int32_t>(out)[row] = static_cast<int32_t>(int_value.lower);
+		mssql_compat::GetDataMutable<int32_t>(out)[row] = static_cast<int32_t>(int_value.lower);
 	} else if (col.precision <= 18) {
-		FlatVector::GetData<int64_t>(out)[row] = static_cast<int64_t>(int_value.lower);
+		mssql_compat::GetDataMutable<int64_t>(out)[row] = static_cast<int64_t>(int_value.lower);
 	} else {
-		FlatVector::GetData<hugeint_t>(out)[row] = int_value;
+		mssql_compat::GetDataMutable<hugeint_t>(out)[row] = int_value;
 	}
 }
 

--- a/src/codec/float_codec.cpp
+++ b/src/codec/float_codec.cpp
@@ -43,7 +43,7 @@ namespace {
 template <typename T>
 T GetVectorValue(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto data = UnifiedVectorFormat::GetData<T>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -108,11 +108,11 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	if (bytes.size() == 4) {
 		float f = 0;
 		std::memcpy(&f, bytes.data(), 4);
-		FlatVector::GetData<float>(out)[row] = f;
+		mssql_compat::GetDataMutable<float>(out)[row] = f;
 	} else if (bytes.size() == 8) {
 		double d = 0;
 		std::memcpy(&d, bytes.data(), 8);
-		FlatVector::GetData<double>(out)[row] = d;
+		mssql_compat::GetDataMutable<double>(out)[row] = d;
 	}
 	// Other sizes silently skip (mirror legacy ConvertFloat — defensive only).
 }

--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -48,7 +48,7 @@ namespace {
 template <typename T>
 T GetVectorValue(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto data = UnifiedVectorFormat::GetData<T>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -91,24 +91,24 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	switch (bytes.size()) {
 	case 1:
 		// SQL Server TINYINT is unsigned (0-255).
-		FlatVector::GetData<uint8_t>(out)[row] = bytes[0];
+		mssql_compat::GetDataMutable<uint8_t>(out)[row] = bytes[0];
 		return;
 	case 2: {
 		int16_t v = 0;
 		std::memcpy(&v, bytes.data(), 2);
-		FlatVector::GetData<int16_t>(out)[row] = v;
+		mssql_compat::GetDataMutable<int16_t>(out)[row] = v;
 		return;
 	}
 	case 4: {
 		int32_t v = 0;
 		std::memcpy(&v, bytes.data(), 4);
-		FlatVector::GetData<int32_t>(out)[row] = v;
+		mssql_compat::GetDataMutable<int32_t>(out)[row] = v;
 		return;
 	}
 	case 8: {
 		int64_t v = 0;
 		std::memcpy(&v, bytes.data(), 8);
-		FlatVector::GetData<int64_t>(out)[row] = v;
+		mssql_compat::GetDataMutable<int64_t>(out)[row] = v;
 		return;
 	}
 	default:

--- a/src/codec/money_codec.cpp
+++ b/src/codec/money_codec.cpp
@@ -40,12 +40,12 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	if (bytes.size() == 8) {
 		// MONEY → DECIMAL(19,4), hugeint storage (precision > 18).
 		hugeint_t int_value = tds::encoding::DecimalEncoding::ConvertMoney(bytes.data());
-		FlatVector::GetData<hugeint_t>(out)[row] = int_value;
+		mssql_compat::GetDataMutable<hugeint_t>(out)[row] = int_value;
 	} else if (bytes.size() == 4) {
 		// SMALLMONEY → DECIMAL(10,4), int64 storage. ConvertSmallMoney returns a
 		// hugeint_t whose .lower carries the sign-extended int32 in its low 64 bits.
 		hugeint_t int_value = tds::encoding::DecimalEncoding::ConvertSmallMoney(bytes.data());
-		FlatVector::GetData<int64_t>(out)[row] = static_cast<int64_t>(int_value.lower);
+		mssql_compat::GetDataMutable<int64_t>(out)[row] = static_cast<int64_t>(int_value.lower);
 	} else {
 		throw InvalidInputException("Invalid MONEY length: %d", bytes.size());
 	}

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -33,7 +33,7 @@ namespace {
 template <typename T>
 T GetVectorValue(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto data = UnifiedVectorFormat::GetData<T>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -175,7 +175,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		}
 	}
 
-	FlatVector::GetData<string_t>(out)[row] = StringVector::AddString(out, str);
+	mssql_compat::GetDataMutable<string_t>(out)[row] = StringVector::AddString(out, str);
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/uuid_codec.cpp
+++ b/src/codec/uuid_codec.cpp
@@ -90,7 +90,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		throw InvalidInputException("codec::uuid::DecodeFromTds: expected 16 wire bytes, got %zu", bytes.size());
 	}
 	auto guid = tds::encoding::GuidEncoding::ConvertGuid(bytes.data());
-	FlatVector::GetData<hugeint_t>(out)[row] = guid;
+	mssql_compat::GetDataMutable<hugeint_t>(out)[row] = guid;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/include/mssql_compat.hpp
+++ b/src/include/mssql_compat.hpp
@@ -127,7 +127,6 @@ struct TFT {
 #endif
 };
 
-
 // M5 — write-site adapter for FlatVector data pointers. On the new SHA this
 // routes to GetDataMutable<T>; on the legacy SHA the single-overload
 // GetData<T>(Vector&) already returns T*, so we forward to it.

--- a/src/include/mssql_compat.hpp
+++ b/src/include/mssql_compat.hpp
@@ -17,6 +17,37 @@
 // M1 (ClientContext::IsInterrupted) and M3 (ScalarFunction::SetNullHandling)
 // exist on both currently-supported SHAs and are renamed in-place at call
 // sites, not via this header.
+//
+// Spec 051 follow-up (M5–M7), added after a downstream DuckLake build against
+// SHA 997c2427 surfaced three more shape changes:
+//   M5 — FlatVector::GetData<T>(Vector&) now returns const T*; write sites
+//        must call FlatVector::GetDataMutable<T>(Vector&). Use the
+//        mssql_compat::GetDataMutable<T> helper, which routes to
+//        GetDataMutable on the new SHA and GetData on the legacy SHA (where
+//        GetData<T>(Vector&) still returns T*).
+//   M6 — StringVector moved out of <duckdb/common/types/vector.hpp> into a
+//        dedicated <duckdb/common/vector/string_vector.hpp>. Including this
+//        header conditionally below picks it up on the new SHA; the legacy
+//        SHA continues to expose StringVector transitively via vector.hpp.
+//   M7 — Vector::ToUnifiedFormat(idx_t, UnifiedVectorFormat&) is deprecated
+//        in favour of the single-arg form. Use mssql_compat::ToUnifiedFormat.
+//   M8 — ExpressionExecutor only forward-declared from <function.hpp> on the
+//        new SHA. Callers of ExpressionExecutor::EvaluateScalar must include
+//        <duckdb/execution/expression_executor.hpp> directly. Header exists
+//        on both SHAs so the include is unconditional at the call site.
+//   M9 — ScalarFunction::varargs moved from a public field on ScalarFunction
+//        to a private FunctionSignature member with a SetVarArgs setter.
+//        Guarded inline at the single call site with
+//        MSSQL_DUCKDB_HAS_NEW_BIND_INPUT.
+//   M10 — TableFilter API rewrite. Old class names (ConstantFilter, InFilter,
+//        ConjunctionAndFilter, ConjunctionOrFilter) are now `Legacy*`-prefixed
+//        on the new SHA; TableFilterType enum values are `LEGACY_*`-prefixed.
+//        TableFilterSet moved to <duckdb/planner/table_filter_set.hpp>.
+//        BoundBetweenExpression became a static-helper struct over a
+//        BoundFunctionExpression (function name "__between"). Use
+//        mssql_compat::{ConstantFilter,InFilter,ConjunctionAndFilter,
+//        ConjunctionOrFilter} typedefs and mssql_compat::TFT::* enum aliases.
+//        BETWEEN dispatch is gated with MSSQL_DUCKDB_HAS_NEW_BIND_INPUT.
 //===----------------------------------------------------------------------===//
 
 #pragma once
@@ -27,6 +58,125 @@
 #else
 #include <duckdb/common/types/vector.hpp>
 #endif
+
+#if __has_include(<duckdb/common/vector/string_vector.hpp>)
+#include <duckdb/common/vector/string_vector.hpp>
+#endif
+#if __has_include(<duckdb/common/vector/struct_vector.hpp>)
+#include <duckdb/common/vector/struct_vector.hpp>
+#endif
+
+// M10 — TableFilter API rewrite. The Legacy*-prefixed classes (new SHA) and
+// their un-prefixed peers (legacy SHA) live at the same header paths, so
+// these includes are unconditional. table_filter_set.hpp is new-SHA-only
+// (the type was inline in table_filter.hpp on the legacy SHA, brought in
+// transitively via the constant/in/conjunction headers).
+#include <duckdb/planner/filter/conjunction_filter.hpp>
+#include <duckdb/planner/filter/constant_filter.hpp>
+#include <duckdb/planner/filter/in_filter.hpp>
+#include <duckdb/planner/filter/null_filter.hpp>
+#if __has_include(<duckdb/planner/filter/optional_filter.hpp>)
+#include <duckdb/planner/filter/optional_filter.hpp>
+#endif
+#if __has_include(<duckdb/planner/table_filter_set.hpp>)
+#include <duckdb/planner/table_filter_set.hpp>
+#endif
+// M11 — BoundComparisonExpression and BoundFunctionExpression headers.
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+
+namespace duckdb {
+namespace mssql_compat {
+
+// M10 — typedefs that resolve to the Legacy*-prefixed classes on the new SHA
+// and to the un-prefixed originals on the legacy SHA.
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+using ConstantFilter = duckdb::LegacyConstantFilter;
+using InFilter = duckdb::LegacyInFilter;
+using ConjunctionAndFilter = duckdb::LegacyConjunctionAndFilter;
+using ConjunctionOrFilter = duckdb::LegacyConjunctionOrFilter;
+#else
+using ConstantFilter = duckdb::ConstantFilter;
+using InFilter = duckdb::InFilter;
+using ConjunctionAndFilter = duckdb::ConjunctionAndFilter;
+using ConjunctionOrFilter = duckdb::ConjunctionOrFilter;
+#endif
+
+// M10 — TableFilterType enum-value aliases (named after the legacy values).
+struct TFT {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	static constexpr auto CONSTANT_COMPARISON = duckdb::TableFilterType::LEGACY_CONSTANT_COMPARISON;
+	static constexpr auto IS_NULL = duckdb::TableFilterType::LEGACY_IS_NULL;
+	static constexpr auto IS_NOT_NULL = duckdb::TableFilterType::LEGACY_IS_NOT_NULL;
+	static constexpr auto IN_FILTER = duckdb::TableFilterType::LEGACY_IN_FILTER;
+	static constexpr auto CONJUNCTION_OR = duckdb::TableFilterType::LEGACY_CONJUNCTION_OR;
+	static constexpr auto CONJUNCTION_AND = duckdb::TableFilterType::LEGACY_CONJUNCTION_AND;
+	static constexpr auto OPTIONAL_FILTER = duckdb::TableFilterType::LEGACY_OPTIONAL_FILTER;
+	static constexpr auto STRUCT_EXTRACT = duckdb::TableFilterType::LEGACY_STRUCT_EXTRACT;
+	static constexpr auto DYNAMIC_FILTER = duckdb::TableFilterType::LEGACY_DYNAMIC_FILTER;
+#else
+	static constexpr auto CONSTANT_COMPARISON = duckdb::TableFilterType::CONSTANT_COMPARISON;
+	static constexpr auto IS_NULL = duckdb::TableFilterType::IS_NULL;
+	static constexpr auto IS_NOT_NULL = duckdb::TableFilterType::IS_NOT_NULL;
+	static constexpr auto IN_FILTER = duckdb::TableFilterType::IN_FILTER;
+	static constexpr auto CONJUNCTION_OR = duckdb::TableFilterType::CONJUNCTION_OR;
+	static constexpr auto CONJUNCTION_AND = duckdb::TableFilterType::CONJUNCTION_AND;
+	static constexpr auto OPTIONAL_FILTER = duckdb::TableFilterType::OPTIONAL_FILTER;
+	static constexpr auto STRUCT_EXTRACT = duckdb::TableFilterType::STRUCT_EXTRACT;
+	static constexpr auto DYNAMIC_FILTER = duckdb::TableFilterType::DYNAMIC_FILTER;
+#endif
+};
+
+
+// M5 — write-site adapter for FlatVector data pointers. On the new SHA this
+// routes to GetDataMutable<T>; on the legacy SHA the single-overload
+// GetData<T>(Vector&) already returns T*, so we forward to it.
+template <class T>
+inline T *GetDataMutable(duckdb::Vector &vec) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	return duckdb::FlatVector::GetDataMutable<T>(vec);
+#else
+	return duckdb::FlatVector::GetData<T>(vec);
+#endif
+}
+
+// M5b — same const-overload story for FlatVector::Validity. The new SHA has
+// a `ValidityMutable` peer that returns the non-const reference suitable for
+// SetAllValid / write-through; the legacy SHA's `Validity` already returns
+// the non-const reference.
+inline duckdb::ValidityMask &ValidityMutable(duckdb::Vector &vec) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	return duckdb::FlatVector::ValidityMutable(vec);
+#else
+	return duckdb::FlatVector::Validity(vec);
+#endif
+}
+
+// M7 — count-less ToUnifiedFormat on the new SHA; legacy SHA keeps the count.
+// We only need format info, not count, at every current call site, so we
+// always pass `count` and let the new-SHA branch discard it.
+inline void ToUnifiedFormat(duckdb::Vector &vec, duckdb::idx_t count, duckdb::UnifiedVectorFormat &fmt) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	(void)count;
+	vec.ToUnifiedFormat(fmt);
+#else
+	vec.ToUnifiedFormat(count, fmt);
+#endif
+}
+
+// M11 — BoundFunctionExpression.function.name moved from a public Function
+// field to a protected BoundSimpleFunction field with a GetName() getter on
+// the new SHA. Single forwarding helper covers both shapes.
+inline const std::string &GetFunctionName(const duckdb::BoundFunctionExpression &expr) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	return expr.function.GetName();
+#else
+	return expr.function.name;
+#endif
+}
+
+}  // namespace mssql_compat
+}  // namespace duckdb
 
 #ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
 

--- a/src/include/table_scan/filter_encoder.hpp
+++ b/src/include/table_scan/filter_encoder.hpp
@@ -10,8 +10,10 @@
 #include <string>
 #include <vector>
 #include "duckdb.hpp"
+#include "duckdb/planner/expression/bound_between_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/in_filter.hpp"
+#include "mssql_compat.hpp"
 
 namespace duckdb {
 namespace mssql {
@@ -173,7 +175,8 @@ private:
 	/**
 	 * Encode CONSTANT_COMPARISON filter (col OP value).
 	 */
-	static ExpressionEncodeResult EncodeConstantComparison(const ConstantFilter &filter, const std::string &column_name,
+	static ExpressionEncodeResult EncodeConstantComparison(const mssql_compat::ConstantFilter &filter,
+														   const std::string &column_name,
 														   const LogicalType &column_type);
 
 	/**
@@ -189,14 +192,14 @@ private:
 	/**
 	 * Encode IN_FILTER (col IN (values)).
 	 */
-	static ExpressionEncodeResult EncodeInFilter(const InFilter &filter, const std::string &column_name,
+	static ExpressionEncodeResult EncodeInFilter(const mssql_compat::InFilter &filter, const std::string &column_name,
 												 const LogicalType &column_type);
 
 	/**
 	 * Encode CONJUNCTION_AND filter.
 	 * Partial pushdown allowed: unsupported children are skipped.
 	 */
-	static ExpressionEncodeResult EncodeConjunctionAnd(const ConjunctionAndFilter &filter,
+	static ExpressionEncodeResult EncodeConjunctionAnd(const mssql_compat::ConjunctionAndFilter &filter,
 													   const std::string &column_name, const LogicalType &column_type,
 													   const ExpressionEncodeContext &ctx);
 
@@ -204,8 +207,8 @@ private:
 	 * Encode CONJUNCTION_OR filter.
 	 * All-or-nothing: if any child unsupported, entire OR is skipped.
 	 */
-	static ExpressionEncodeResult EncodeConjunctionOr(const ConjunctionOrFilter &filter, const std::string &column_name,
-													  const LogicalType &column_type,
+	static ExpressionEncodeResult EncodeConjunctionOr(const mssql_compat::ConjunctionOrFilter &filter,
+													  const std::string &column_name, const LogicalType &column_type,
 													  const ExpressionEncodeContext &ctx);
 
 	/**
@@ -226,9 +229,17 @@ private:
 
 	/**
 	 * Encode a comparison expression (left OP right).
+	 * On the new DuckDB SHA, comparison is a BoundFunctionExpression and
+	 * BoundComparisonExpression is a static-helper struct; on the legacy SHA
+	 * it is a class. The signature differs accordingly.
 	 */
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	static ExpressionEncodeResult EncodeComparisonExpression(const BoundFunctionExpression &expr,
+															 const ExpressionEncodeContext &ctx);
+#else
 	static ExpressionEncodeResult EncodeComparisonExpression(const BoundComparisonExpression &expr,
 															 const ExpressionEncodeContext &ctx);
+#endif
 
 	/**
 	 * Encode an operator expression (+, -, *, /, etc.).
@@ -244,9 +255,17 @@ private:
 
 	/**
 	 * Encode a BETWEEN expression (input BETWEEN lower AND upper).
+	 * On the new DuckDB SHA, BETWEEN is a BoundFunctionExpression (function
+	 * name "__between") and BoundBetweenExpression is a static-helper struct;
+	 * on the legacy SHA it is a class. The signature differs accordingly.
 	 */
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	static ExpressionEncodeResult EncodeBetweenExpression(const BoundFunctionExpression &expr,
+														  const ExpressionEncodeContext &ctx);
+#else
 	static ExpressionEncodeResult EncodeBetweenExpression(const BoundBetweenExpression &expr,
 														  const ExpressionEncodeContext &ctx);
+#endif
 
 	/**
 	 * Encode a column reference.

--- a/src/table_scan/filter_encoder.cpp
+++ b/src/table_scan/filter_encoder.cpp
@@ -298,8 +298,8 @@ ExpressionEncodeResult FilterEncoder::EncodeIsNotNull(const std::string &column_
 	return {column_name + " IS NOT NULL", true};
 }
 
-ExpressionEncodeResult FilterEncoder::EncodeInFilter(const mssql_compat::InFilter &filter, const std::string &column_name,
-													 const LogicalType &column_type) {
+ExpressionEncodeResult FilterEncoder::EncodeInFilter(const mssql_compat::InFilter &filter,
+													 const std::string &column_name, const LogicalType &column_type) {
 	std::string sql = column_name + " IN (";
 	for (idx_t i = 0; i < filter.values.size(); i++) {
 		if (i > 0) {
@@ -389,7 +389,8 @@ ExpressionEncodeResult FilterEncoder::EncodeConjunctionOr(const mssql_compat::Co
 ExpressionEncodeResult FilterEncoder::EncodeExpressionFilter(const ExpressionFilter &filter,
 															 const ExpressionEncodeContext &ctx) {
 	// Expression filters contain arbitrary expressions
-	MSSQL_FILTER_DEBUG_LOG(1, "EncodeExpressionFilter: encoding expression type %d", (int)filter.expr->GetExpressionType());
+	MSSQL_FILTER_DEBUG_LOG(1, "EncodeExpressionFilter: encoding expression type %d",
+						   (int)filter.expr->GetExpressionType());
 	return EncodeExpression(*filter.expr, ctx);
 }
 
@@ -404,7 +405,8 @@ ExpressionEncodeResult FilterEncoder::EncodeExpression(const Expression &expr, c
 		return {"", false};
 	}
 
-	MSSQL_FILTER_DEBUG_LOG(2, "EncodeExpression: type=%d class=%d", (int)expr.GetExpressionType(), (int)expr.GetExpressionClass());
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeExpression: type=%d class=%d", (int)expr.GetExpressionType(),
+						   (int)expr.GetExpressionClass());
 
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::BOUND_COLUMN_REF:
@@ -584,7 +586,8 @@ ExpressionEncodeResult FilterEncoder::EncodeComparisonExpression(const BoundComp
 	// Get the comparison operator
 	std::string op;
 	if (!GetComparisonOperator(expr.GetExpressionType(), op)) {
-		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: unsupported comparison type %d", (int)expr.GetExpressionType());
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: unsupported comparison type %d",
+							   (int)expr.GetExpressionType());
 		return {"", false};
 	}
 
@@ -610,7 +613,8 @@ ExpressionEncodeResult FilterEncoder::EncodeComparisonExpression(const BoundComp
 
 ExpressionEncodeResult FilterEncoder::EncodeOperatorExpression(const BoundOperatorExpression &expr,
 															   const ExpressionEncodeContext &ctx) {
-	MSSQL_FILTER_DEBUG_LOG(2, "EncodeOperatorExpression: type=%d, children=%zu", (int)expr.GetExpressionType(), expr.children.size());
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeOperatorExpression: type=%d, children=%zu", (int)expr.GetExpressionType(),
+						   expr.children.size());
 
 	// Handle NOT operator
 	if (expr.GetExpressionType() == ExpressionType::OPERATOR_NOT) {

--- a/src/table_scan/filter_encoder.cpp
+++ b/src/table_scan/filter_encoder.cpp
@@ -142,12 +142,21 @@ FilterEncoderResult FilterEncoder::Encode(const TableFilterSet *filters, const s
 	FilterEncoderResult result;
 	result.needs_duckdb_filter = false;
 
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	if (!filters || !filters->HasFilters()) {
+		MSSQL_FILTER_DEBUG_LOG(1, "Encode: no filters to encode");
+		return result;
+	}
+
+	MSSQL_FILTER_DEBUG_LOG(1, "Encode: encoding %zu filter(s)", (size_t)filters->FilterCount());
+#else
 	if (!filters || filters->filters.empty()) {
 		MSSQL_FILTER_DEBUG_LOG(1, "Encode: no filters to encode");
 		return result;
 	}
 
 	MSSQL_FILTER_DEBUG_LOG(1, "Encode: encoding %zu filter(s)", filters->filters.size());
+#endif
 
 	ExpressionEncodeContext ctx(column_ids, column_names, column_types);
 	std::vector<std::string> where_conditions;
@@ -155,8 +164,13 @@ FilterEncoderResult FilterEncoder::Encode(const TableFilterSet *filters, const s
 	// Virtual/special column identifiers start at 2^63
 	constexpr column_t VIRTUAL_COL_START = UINT64_C(9223372036854775808);
 
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	for (const auto &filter_entry : *filters) {
+		idx_t projected_col_idx = filter_entry.GetIndex();
+#else
 	for (const auto &filter_entry : filters->filters) {
 		idx_t projected_col_idx = filter_entry.first;
+#endif
 
 		// Map from projected column index to actual table column index
 		idx_t table_col_idx;
@@ -195,7 +209,11 @@ FilterEncoderResult FilterEncoder::Encode(const TableFilterSet *filters, const s
 							   (unsigned long long)projected_col_idx, (unsigned long long)table_col_idx,
 							   col_name.c_str());
 
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+		auto encode_result = EncodeFilter(filter_entry.Filter(), escaped_col, col_type, ctx);
+#else
 		auto encode_result = EncodeFilter(*filter_entry.second, escaped_col, col_type, ctx);
+#endif
 
 		if (encode_result.supported && !encode_result.sql.empty()) {
 			where_conditions.push_back(encode_result.sql);
@@ -230,32 +248,29 @@ FilterEncoderResult FilterEncoder::Encode(const TableFilterSet *filters, const s
 ExpressionEncodeResult FilterEncoder::EncodeFilter(const TableFilter &filter, const std::string &column_name,
 												   const LogicalType &column_type, const ExpressionEncodeContext &ctx) {
 	switch (filter.filter_type) {
-	case TableFilterType::CONSTANT_COMPARISON:
-		return EncodeConstantComparison(filter.Cast<ConstantFilter>(), column_name, column_type);
+	case mssql_compat::TFT::CONSTANT_COMPARISON:
+		return EncodeConstantComparison(filter.Cast<mssql_compat::ConstantFilter>(), column_name, column_type);
 
-	case TableFilterType::IS_NULL:
+	case mssql_compat::TFT::IS_NULL:
 		return EncodeIsNull(column_name);
 
-	case TableFilterType::IS_NOT_NULL:
+	case mssql_compat::TFT::IS_NOT_NULL:
 		return EncodeIsNotNull(column_name);
 
-	case TableFilterType::IN_FILTER:
-		return EncodeInFilter(filter.Cast<InFilter>(), column_name, column_type);
+	case mssql_compat::TFT::IN_FILTER:
+		return EncodeInFilter(filter.Cast<mssql_compat::InFilter>(), column_name, column_type);
 
-	case TableFilterType::CONJUNCTION_OR:
-		return EncodeConjunctionOr(filter.Cast<ConjunctionOrFilter>(), column_name, column_type, ctx);
+	case mssql_compat::TFT::CONJUNCTION_OR:
+		return EncodeConjunctionOr(filter.Cast<mssql_compat::ConjunctionOrFilter>(), column_name, column_type, ctx);
 
-	case TableFilterType::CONJUNCTION_AND:
-		return EncodeConjunctionAnd(filter.Cast<ConjunctionAndFilter>(), column_name, column_type, ctx);
+	case mssql_compat::TFT::CONJUNCTION_AND:
+		return EncodeConjunctionAnd(filter.Cast<mssql_compat::ConjunctionAndFilter>(), column_name, column_type, ctx);
 
 	case TableFilterType::EXPRESSION_FILTER:
 		// Expression filters (for complex expressions) - not yet fully supported
 		// Will be enhanced in later phases
 		return EncodeExpressionFilter(filter.Cast<ExpressionFilter>(), ctx);
 
-	case TableFilterType::OPTIONAL_FILTER:
-	case TableFilterType::STRUCT_EXTRACT:
-	case TableFilterType::DYNAMIC_FILTER:
 	default:
 		// These filter types cannot be pushed down to SQL Server
 		MSSQL_FILTER_DEBUG_LOG(1, "Filter type %d cannot be pushed down", (int)filter.filter_type);
@@ -263,7 +278,7 @@ ExpressionEncodeResult FilterEncoder::EncodeFilter(const TableFilter &filter, co
 	}
 }
 
-ExpressionEncodeResult FilterEncoder::EncodeConstantComparison(const ConstantFilter &filter,
+ExpressionEncodeResult FilterEncoder::EncodeConstantComparison(const mssql_compat::ConstantFilter &filter,
 															   const std::string &column_name,
 															   const LogicalType &column_type) {
 	std::string op;
@@ -283,7 +298,7 @@ ExpressionEncodeResult FilterEncoder::EncodeIsNotNull(const std::string &column_
 	return {column_name + " IS NOT NULL", true};
 }
 
-ExpressionEncodeResult FilterEncoder::EncodeInFilter(const InFilter &filter, const std::string &column_name,
+ExpressionEncodeResult FilterEncoder::EncodeInFilter(const mssql_compat::InFilter &filter, const std::string &column_name,
 													 const LogicalType &column_type) {
 	std::string sql = column_name + " IN (";
 	for (idx_t i = 0; i < filter.values.size(); i++) {
@@ -296,7 +311,7 @@ ExpressionEncodeResult FilterEncoder::EncodeInFilter(const InFilter &filter, con
 	return {sql, true};
 }
 
-ExpressionEncodeResult FilterEncoder::EncodeConjunctionAnd(const ConjunctionAndFilter &filter,
+ExpressionEncodeResult FilterEncoder::EncodeConjunctionAnd(const mssql_compat::ConjunctionAndFilter &filter,
 														   const std::string &column_name,
 														   const LogicalType &column_type,
 														   const ExpressionEncodeContext &ctx) {
@@ -336,7 +351,7 @@ ExpressionEncodeResult FilterEncoder::EncodeConjunctionAnd(const ConjunctionAndF
 	return {sql, all_supported};
 }
 
-ExpressionEncodeResult FilterEncoder::EncodeConjunctionOr(const ConjunctionOrFilter &filter,
+ExpressionEncodeResult FilterEncoder::EncodeConjunctionOr(const mssql_compat::ConjunctionOrFilter &filter,
 														  const std::string &column_name,
 														  const LogicalType &column_type,
 														  const ExpressionEncodeContext &ctx) {
@@ -374,7 +389,7 @@ ExpressionEncodeResult FilterEncoder::EncodeConjunctionOr(const ConjunctionOrFil
 ExpressionEncodeResult FilterEncoder::EncodeExpressionFilter(const ExpressionFilter &filter,
 															 const ExpressionEncodeContext &ctx) {
 	// Expression filters contain arbitrary expressions
-	MSSQL_FILTER_DEBUG_LOG(1, "EncodeExpressionFilter: encoding expression type %d", (int)filter.expr->type);
+	MSSQL_FILTER_DEBUG_LOG(1, "EncodeExpressionFilter: encoding expression type %d", (int)filter.expr->GetExpressionType());
 	return EncodeExpression(*filter.expr, ctx);
 }
 
@@ -389,7 +404,7 @@ ExpressionEncodeResult FilterEncoder::EncodeExpression(const Expression &expr, c
 		return {"", false};
 	}
 
-	MSSQL_FILTER_DEBUG_LOG(2, "EncodeExpression: type=%d class=%d", (int)expr.type, (int)expr.GetExpressionClass());
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeExpression: type=%d class=%d", (int)expr.GetExpressionType(), (int)expr.GetExpressionClass());
 
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::BOUND_COLUMN_REF:
@@ -401,8 +416,14 @@ ExpressionEncodeResult FilterEncoder::EncodeExpression(const Expression &expr, c
 	case ExpressionClass::BOUND_FUNCTION:
 		return EncodeFunctionExpression(expr.Cast<BoundFunctionExpression>(), ctx);
 
+#ifndef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	// On the legacy SHA, comparison is its own ExpressionClass (BOUND_COMPARISON)
+	// with a typed BoundComparisonExpression. On the new SHA, comparison arrives
+	// as a BoundFunctionExpression and is dispatched via the IsComparison check
+	// inside EncodeFunctionExpression.
 	case ExpressionClass::BOUND_COMPARISON:
 		return EncodeComparisonExpression(expr.Cast<BoundComparisonExpression>(), ctx);
+#endif
 
 	case ExpressionClass::BOUND_CONJUNCTION:
 		return EncodeConjunctionExpression(expr.Cast<BoundConjunctionExpression>(), ctx);
@@ -413,8 +434,14 @@ ExpressionEncodeResult FilterEncoder::EncodeExpression(const Expression &expr, c
 	case ExpressionClass::BOUND_CASE:
 		return EncodeCaseExpression(expr.Cast<BoundCaseExpression>(), ctx);
 
+#ifndef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	// On the legacy SHA, BETWEEN is its own ExpressionClass (BOUND_BETWEEN)
+	// with a typed BoundBetweenExpression. On the new SHA, BETWEEN arrives as
+	// a BoundFunctionExpression with function.name "__between"; the dispatch
+	// for that case is in EncodeFunctionExpression below.
 	case ExpressionClass::BOUND_BETWEEN:
 		return EncodeBetweenExpression(expr.Cast<BoundBetweenExpression>(), ctx);
+#endif
 
 	default:
 		MSSQL_FILTER_DEBUG_LOG(1, "EncodeExpression: unsupported expression class %d", (int)expr.GetExpressionClass());
@@ -424,9 +451,24 @@ ExpressionEncodeResult FilterEncoder::EncodeExpression(const Expression &expr, c
 
 ExpressionEncodeResult FilterEncoder::EncodeFunctionExpression(const BoundFunctionExpression &expr,
 															   const ExpressionEncodeContext &ctx) {
-	const std::string &func_name = expr.function.name;
+	const std::string &func_name = mssql_compat::GetFunctionName(expr);
 	MSSQL_FILTER_DEBUG_LOG(2, "EncodeFunctionExpression: function=%s, args=%zu", func_name.c_str(),
 						   expr.children.size());
+
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	// On the new DuckDB SHA, BETWEEN is emitted as a BoundFunctionExpression
+	// wrapping the internal "__between" function. Dispatch to the BETWEEN
+	// encoder via the BoundBetweenExpression static helpers.
+	if (func_name == "__between") {
+		return EncodeBetweenExpression(expr, ctx);
+	}
+	// Likewise, every comparison (=, <>, <, <=, >, >=) is now a
+	// BoundFunctionExpression. BoundComparisonExpression::IsComparison
+	// recognises the comparison ExpressionType.
+	if (BoundComparisonExpression::IsComparison(expr)) {
+		return EncodeComparisonExpression(expr, ctx);
+	}
+#endif
 
 	// Check for LIKE pattern functions (prefix, suffix, contains, iprefix, isuffix, icontains)
 	if (IsLikePatternFunction(func_name)) {
@@ -479,12 +521,54 @@ ExpressionEncodeResult FilterEncoder::EncodeFunctionExpression(const BoundFuncti
 	return {sql, true};
 }
 
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+ExpressionEncodeResult FilterEncoder::EncodeComparisonExpression(const BoundFunctionExpression &expr,
+																 const ExpressionEncodeContext &ctx) {
+	const Expression &left = BoundComparisonExpression::Left(expr);
+	const Expression &right = BoundComparisonExpression::Right(expr);
+	const auto comparison_type = expr.GetExpressionType();
+
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: type=%d", (int)comparison_type);
+
+	if (comparison_type == ExpressionType::COMPARE_EQUAL && ctx.HasPKInfo()) {
+		if (IsRowidColumn(left, ctx)) {
+			MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: detected rowid = value");
+			return EncodeRowidEquality(right, ctx);
+		}
+		if (IsRowidColumn(right, ctx)) {
+			MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: detected value = rowid");
+			return EncodeRowidEquality(left, ctx);
+		}
+	}
+
+	std::string op;
+	if (!GetComparisonOperator(comparison_type, op)) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: unsupported comparison type %d", (int)comparison_type);
+		return {"", false};
+	}
+
+	auto child_ctx = ctx.child();
+	auto left_result = EncodeExpression(left, child_ctx);
+	if (!left_result.supported) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: left side encoding failed");
+		return {"", false};
+	}
+	auto right_result = EncodeExpression(right, child_ctx);
+	if (!right_result.supported) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: right side encoding failed");
+		return {"", false};
+	}
+	std::string sql = "(" + left_result.sql + op + right_result.sql + ")";
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: encoded -> %s", sql.c_str());
+	return {sql, true};
+}
+#else
 ExpressionEncodeResult FilterEncoder::EncodeComparisonExpression(const BoundComparisonExpression &expr,
 																 const ExpressionEncodeContext &ctx) {
-	MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: type=%d", (int)expr.type);
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: type=%d", (int)expr.GetExpressionType());
 
 	// Check for rowid equality: rowid = value (Spec 001-pk-rowid-semantics)
-	if (expr.type == ExpressionType::COMPARE_EQUAL && ctx.HasPKInfo()) {
+	if (expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL && ctx.HasPKInfo()) {
 		// Check if left is rowid and right is constant
 		if (IsRowidColumn(*expr.left, ctx)) {
 			MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: detected rowid = value");
@@ -499,8 +583,8 @@ ExpressionEncodeResult FilterEncoder::EncodeComparisonExpression(const BoundComp
 
 	// Get the comparison operator
 	std::string op;
-	if (!GetComparisonOperator(expr.type, op)) {
-		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: unsupported comparison type %d", (int)expr.type);
+	if (!GetComparisonOperator(expr.GetExpressionType(), op)) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeComparisonExpression: unsupported comparison type %d", (int)expr.GetExpressionType());
 		return {"", false};
 	}
 
@@ -522,13 +606,14 @@ ExpressionEncodeResult FilterEncoder::EncodeComparisonExpression(const BoundComp
 	MSSQL_FILTER_DEBUG_LOG(2, "EncodeComparisonExpression: encoded -> %s", sql.c_str());
 	return {sql, true};
 }
+#endif
 
 ExpressionEncodeResult FilterEncoder::EncodeOperatorExpression(const BoundOperatorExpression &expr,
 															   const ExpressionEncodeContext &ctx) {
-	MSSQL_FILTER_DEBUG_LOG(2, "EncodeOperatorExpression: type=%d, children=%zu", (int)expr.type, expr.children.size());
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeOperatorExpression: type=%d, children=%zu", (int)expr.GetExpressionType(), expr.children.size());
 
 	// Handle NOT operator
-	if (expr.type == ExpressionType::OPERATOR_NOT) {
+	if (expr.GetExpressionType() == ExpressionType::OPERATOR_NOT) {
 		if (expr.children.size() != 1) {
 			return {"", false};
 		}
@@ -541,7 +626,7 @@ ExpressionEncodeResult FilterEncoder::EncodeOperatorExpression(const BoundOperat
 	}
 
 	// Handle IS NULL / IS NOT NULL operators
-	if (expr.type == ExpressionType::OPERATOR_IS_NULL) {
+	if (expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NULL) {
 		if (expr.children.size() != 1) {
 			return {"", false};
 		}
@@ -553,7 +638,7 @@ ExpressionEncodeResult FilterEncoder::EncodeOperatorExpression(const BoundOperat
 		return {"(" + child_result.sql + " IS NULL)", true};
 	}
 
-	if (expr.type == ExpressionType::OPERATOR_IS_NOT_NULL) {
+	if (expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
 		if (expr.children.size() != 1) {
 			return {"", false};
 		}
@@ -567,7 +652,7 @@ ExpressionEncodeResult FilterEncoder::EncodeOperatorExpression(const BoundOperat
 
 	// For other operators, we don't support them yet
 	// Arithmetic is handled via BoundFunctionExpression in DuckDB stable
-	MSSQL_FILTER_DEBUG_LOG(1, "EncodeOperatorExpression: unsupported operator type %d", (int)expr.type);
+	MSSQL_FILTER_DEBUG_LOG(1, "EncodeOperatorExpression: unsupported operator type %d", (int)expr.GetExpressionType());
 	return {"", false};
 }
 
@@ -607,6 +692,47 @@ ExpressionEncodeResult FilterEncoder::EncodeCaseExpression(const BoundCaseExpres
 	return {sql, true};
 }
 
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+ExpressionEncodeResult FilterEncoder::EncodeBetweenExpression(const BoundFunctionExpression &expr,
+															  const ExpressionEncodeContext &ctx) {
+	bool lower_inclusive = BoundBetweenExpression::LowerInclusive(expr);
+	bool upper_inclusive = BoundBetweenExpression::UpperInclusive(expr);
+	const Expression &input = BoundBetweenExpression::Input(expr);
+	const Expression &lower = BoundBetweenExpression::LowerBound(expr);
+	const Expression &upper = BoundBetweenExpression::UpperBound(expr);
+
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeBetweenExpression: lower_inclusive=%s, upper_inclusive=%s",
+						   lower_inclusive ? "true" : "false", upper_inclusive ? "true" : "false");
+
+	auto child_ctx = ctx.child();
+	auto input_result = EncodeExpression(input, child_ctx);
+	if (!input_result.supported) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeBetweenExpression: input encoding failed");
+		return {"", false};
+	}
+	auto lower_result = EncodeExpression(lower, child_ctx);
+	if (!lower_result.supported) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeBetweenExpression: lower bound encoding failed");
+		return {"", false};
+	}
+	auto upper_result = EncodeExpression(upper, child_ctx);
+	if (!upper_result.supported) {
+		MSSQL_FILTER_DEBUG_LOG(1, "EncodeBetweenExpression: upper bound encoding failed");
+		return {"", false};
+	}
+	if (lower_inclusive && upper_inclusive) {
+		std::string sql = "(" + input_result.sql + " BETWEEN " + lower_result.sql + " AND " + upper_result.sql + ")";
+		MSSQL_FILTER_DEBUG_LOG(2, "EncodeBetweenExpression: encoded -> %s", sql.c_str());
+		return {sql, true};
+	}
+	std::string lower_op = lower_inclusive ? " >= " : " > ";
+	std::string upper_op = upper_inclusive ? " <= " : " < ";
+	std::string sql = "((" + input_result.sql + lower_op + lower_result.sql + ") AND (" + input_result.sql + upper_op +
+					  upper_result.sql + "))";
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeBetweenExpression: encoded -> %s", sql.c_str());
+	return {sql, true};
+}
+#else
 ExpressionEncodeResult FilterEncoder::EncodeBetweenExpression(const BoundBetweenExpression &expr,
 															  const ExpressionEncodeContext &ctx) {
 	MSSQL_FILTER_DEBUG_LOG(2, "EncodeBetweenExpression: lower_inclusive=%s, upper_inclusive=%s",
@@ -651,13 +777,19 @@ ExpressionEncodeResult FilterEncoder::EncodeBetweenExpression(const BoundBetween
 	MSSQL_FILTER_DEBUG_LOG(2, "EncodeBetweenExpression: encoded -> %s", sql.c_str());
 	return {sql, true};
 }
+#endif
 
 ExpressionEncodeResult FilterEncoder::EncodeColumnRef(const BoundColumnRefExpression &expr,
 													  const ExpressionEncodeContext &ctx) {
 	// Get the column binding - this contains the table index and column index
 	const auto &binding = expr.binding;
 	MSSQL_FILTER_DEBUG_LOG(2, "EncodeColumnRef: table_idx=%llu, column_idx=%llu",
-						   (unsigned long long)binding.table_index, (unsigned long long)binding.column_index);
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+						   (unsigned long long)binding.table_index.index,
+#else
+						   (unsigned long long)binding.table_index,
+#endif
+						   (unsigned long long)binding.column_index);
 
 	// Virtual/special column identifiers start at 2^63
 	constexpr column_t VIRTUAL_COL_START = UINT64_C(9223372036854775808);
@@ -712,22 +844,27 @@ ExpressionEncodeResult FilterEncoder::EncodeColumnRef(const BoundColumnRefExpres
 }
 
 ExpressionEncodeResult FilterEncoder::EncodeConstant(const BoundConstantExpression &expr) {
-	std::string sql = ValueToSQLLiteral(expr.value, expr.return_type);
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	const auto &return_type = expr.GetReturnType();
+#else
+	const auto &return_type = expr.return_type;
+#endif
+	std::string sql = ValueToSQLLiteral(expr.value, return_type);
 	MSSQL_FILTER_DEBUG_LOG(2, "EncodeConstant: value=%s, type=%s -> %s", expr.value.ToString().c_str(),
-						   expr.return_type.ToString().c_str(), sql.c_str());
+						   return_type.ToString().c_str(), sql.c_str());
 	return {sql, true};
 }
 
 ExpressionEncodeResult FilterEncoder::EncodeConjunctionExpression(const BoundConjunctionExpression &expr,
 																  const ExpressionEncodeContext &ctx) {
-	MSSQL_FILTER_DEBUG_LOG(2, "EncodeConjunctionExpression: type=%d, children=%zu", (int)expr.type,
+	MSSQL_FILTER_DEBUG_LOG(2, "EncodeConjunctionExpression: type=%d, children=%zu", (int)expr.GetExpressionType(),
 						   expr.children.size());
 
 	if (expr.children.empty()) {
 		return {"", false};
 	}
 
-	bool is_and = (expr.type == ExpressionType::CONJUNCTION_AND);
+	bool is_and = (expr.GetExpressionType() == ExpressionType::CONJUNCTION_AND);
 	std::string conj_op = is_and ? " AND " : " OR ";
 
 	auto child_ctx = ctx.child();

--- a/src/table_scan/mssql_optimizer.cpp
+++ b/src/table_scan/mssql_optimizer.cpp
@@ -13,7 +13,6 @@
 #include <cstdlib>
 #include <unordered_set>
 #include "catalog/mssql_catalog.hpp"
-#include "mssql_compat.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
@@ -24,6 +23,7 @@
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
+#include "mssql_compat.hpp"
 #include "mssql_functions.hpp"
 #include "mssql_storage.hpp"
 #include "table_scan/filter_encoder.hpp"
@@ -140,8 +140,7 @@ static bool ResolveColumnIndex(const Expression &expr, const LogicalGet &get, id
 							(unsigned long long)get.table_index.index);
 #else
 			MSSQL_OPT_DEBUG(2, "  BOUND_COLUMN_REF table_index %llu != get.table_index %llu",
-							(unsigned long long)col_ref.binding.table_index,
-							(unsigned long long)get.table_index);
+							(unsigned long long)col_ref.binding.table_index, (unsigned long long)get.table_index);
 #endif
 			return false;
 		}
@@ -245,14 +244,15 @@ static bool ResolveOrderExpression(const Expression &expr, const LogicalGet &get
 		}
 
 		if (mapping->expected_args != 1 || func_expr.children.size() != 1) {
-			MSSQL_OPT_DEBUG(2, "  Function %s: expected 1 arg, got %zu", mssql_compat::GetFunctionName(func_expr).c_str(),
-							func_expr.children.size());
+			MSSQL_OPT_DEBUG(2, "  Function %s: expected 1 arg, got %zu",
+							mssql_compat::GetFunctionName(func_expr).c_str(), func_expr.children.size());
 			return false;
 		}
 
 		idx_t inner_col_ids_index;
 		if (!ResolveColumnIndex(*func_expr.children[0], get, inner_col_ids_index)) {
-			MSSQL_OPT_DEBUG(2, "  Function %s: arg is not a resolvable column ref", mssql_compat::GetFunctionName(func_expr).c_str());
+			MSSQL_OPT_DEBUG(2, "  Function %s: arg is not a resolvable column ref",
+							mssql_compat::GetFunctionName(func_expr).c_str());
 			return false;
 		}
 

--- a/src/table_scan/mssql_optimizer.cpp
+++ b/src/table_scan/mssql_optimizer.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <unordered_set>
 #include "catalog/mssql_catalog.hpp"
+#include "mssql_compat.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
@@ -133,8 +134,15 @@ static bool ResolveColumnIndex(const Expression &expr, const LogicalGet &get, id
 		auto &col_ref = expr.Cast<BoundColumnRefExpression>();
 		// Match against the Get's table_index and find column in GetColumnIds
 		if (col_ref.binding.table_index != get.table_index) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
 			MSSQL_OPT_DEBUG(2, "  BOUND_COLUMN_REF table_index %llu != get.table_index %llu",
-							(unsigned long long)col_ref.binding.table_index, (unsigned long long)get.table_index);
+							(unsigned long long)col_ref.binding.table_index.index,
+							(unsigned long long)get.table_index.index);
+#else
+			MSSQL_OPT_DEBUG(2, "  BOUND_COLUMN_REF table_index %llu != get.table_index %llu",
+							(unsigned long long)col_ref.binding.table_index,
+							(unsigned long long)get.table_index);
+#endif
 			return false;
 		}
 		// column_index maps to position in GetColumnIds
@@ -185,16 +193,29 @@ static bool ResolveOrderExpression(const Expression &expr, const LogicalGet &get
 			if (col_ref.binding.table_index == projection->table_index &&
 				col_ref.binding.column_index < projection->expressions.size()) {
 				resolve_expr = projection->expressions[col_ref.binding.column_index].get();
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+				MSSQL_OPT_DEBUG(2, "  Resolved BOUND_COLUMN_REF[%llu.%llu] through projection -> class=%d",
+								(unsigned long long)col_ref.binding.table_index.index,
+								(unsigned long long)col_ref.binding.column_index,
+								(int)resolve_expr->GetExpressionClass());
+#else
 				MSSQL_OPT_DEBUG(2, "  Resolved BOUND_COLUMN_REF[%llu.%llu] through projection -> class=%d",
 								(unsigned long long)col_ref.binding.table_index,
 								(unsigned long long)col_ref.binding.column_index,
 								(int)resolve_expr->GetExpressionClass());
+#endif
 			}
 			// If binding matches Get's table_index, resolve directly against Get (skip projection)
 			else if (col_ref.binding.table_index == get.table_index) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+				MSSQL_OPT_DEBUG(2, "  BOUND_COLUMN_REF[%llu.%llu] references Get directly",
+								(unsigned long long)col_ref.binding.table_index.index,
+								(unsigned long long)col_ref.binding.column_index);
+#else
 				MSSQL_OPT_DEBUG(2, "  BOUND_COLUMN_REF[%llu.%llu] references Get directly",
 								(unsigned long long)col_ref.binding.table_index,
 								(unsigned long long)col_ref.binding.column_index);
+#endif
 				// resolve_expr stays as &expr, handled below
 			}
 		}
@@ -217,21 +238,21 @@ static bool ResolveOrderExpression(const Expression &expr, const LogicalGet &get
 	// Case 2: Function expression (e.g., YEAR(col))
 	if (resolve_expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
 		auto &func_expr = resolve_expr->Cast<BoundFunctionExpression>();
-		auto *mapping = mssql::GetFunctionMapping(func_expr.function.name);
+		auto *mapping = mssql::GetFunctionMapping(mssql_compat::GetFunctionName(func_expr));
 		if (!mapping) {
-			MSSQL_OPT_DEBUG(2, "  Unsupported function: %s", func_expr.function.name.c_str());
+			MSSQL_OPT_DEBUG(2, "  Unsupported function: %s", mssql_compat::GetFunctionName(func_expr).c_str());
 			return false;
 		}
 
 		if (mapping->expected_args != 1 || func_expr.children.size() != 1) {
-			MSSQL_OPT_DEBUG(2, "  Function %s: expected 1 arg, got %zu", func_expr.function.name.c_str(),
+			MSSQL_OPT_DEBUG(2, "  Function %s: expected 1 arg, got %zu", mssql_compat::GetFunctionName(func_expr).c_str(),
 							func_expr.children.size());
 			return false;
 		}
 
 		idx_t inner_col_ids_index;
 		if (!ResolveColumnIndex(*func_expr.children[0], get, inner_col_ids_index)) {
-			MSSQL_OPT_DEBUG(2, "  Function %s: arg is not a resolvable column ref", func_expr.function.name.c_str());
+			MSSQL_OPT_DEBUG(2, "  Function %s: arg is not a resolvable column ref", mssql_compat::GetFunctionName(func_expr).c_str());
 			return false;
 		}
 
@@ -500,8 +521,15 @@ static void TryPushOrderBy(ClientContext &context, unique_ptr<LogicalOperator> &
 
 	// Full pushdown: remove LogicalOrder from plan, keep Projection if present
 	if (pushed == order.orders.size()) {
-		// Capture projection_map BEFORE destroying LogicalOrder
-		vector<idx_t> projection_map = order.projection_map;
+		// Capture projection_map BEFORE destroying LogicalOrder. On the new
+		// DuckDB SHA the LogicalOrder field is vector<ProjectionIndex>, which
+		// implicitly converts to vector<idx_t> elementwise but not as a vector
+		// type, so we copy through a manual loop.
+		vector<idx_t> projection_map;
+		projection_map.reserve(order.projection_map.size());
+		for (auto &p : order.projection_map) {
+			projection_map.push_back((idx_t)p);
+		}
 
 		MSSQL_OPT_DEBUG(1, "Full ORDER BY pushdown - removing LogicalOrder from plan");
 		plan = std::move(plan->children[0]);

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -764,8 +764,8 @@ static void ComplexFilterPushdown(ClientContext &context, LogicalGet &get, Funct
 
 	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &filter = filters[i];
-		MSSQL_SCAN_DEBUG_LOG(2, "  filter[%llu]: type=%d class=%d", (unsigned long long)i, (int)filter->GetExpressionType(),
-							 (int)filter->GetExpressionClass());
+		MSSQL_SCAN_DEBUG_LOG(2, "  filter[%llu]: type=%d class=%d", (unsigned long long)i,
+							 (int)filter->GetExpressionType(), (int)filter->GetExpressionClass());
 
 		// Try to encode this expression
 		auto result = FilterEncoder::EncodeExpression(*filter, ctx);

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -338,9 +338,18 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 	bool needs_duckdb_filter = false;
 
 	// 1. Encode simple filters (TableFilterSet from filter_pushdown)
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+	if (input.filters && input.filters->HasFilters()) {
+#else
 	if (input.filters && !input.filters->filters.empty()) {
+#endif
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+		MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: simple filter pushdown with %zu filter(s)",
+							 (size_t)input.filters->FilterCount());
+#else
 		MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: simple filter pushdown with %zu filter(s)",
 							 input.filters->filters.size());
+#endif
 
 		auto encode_result =
 			FilterEncoder::Encode(input.filters.get(), column_ids, bind_data.all_column_names, bind_data.all_types);
@@ -547,7 +556,11 @@ static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, 
 				if (output_idx != UINT64_MAX) {
 					// This PK column is in the projection - copy to STRUCT child
 					auto &src_vector = output.data[output_idx];
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+					auto &dst_vector = entries[pk_idx];
+#else
 					auto &dst_vector = *entries[pk_idx];
+#endif
 					VectorOperations::Copy(src_vector, dst_vector, row_count, 0, 0);
 					MSSQL_SCAN_DEBUG_LOG(2, "Execute: copied PK column %llu from output[%llu] to STRUCT child",
 										 (unsigned long long)pk_idx, (unsigned long long)output_idx);
@@ -555,7 +568,7 @@ static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, 
 			}
 		}
 
-		auto &validity = FlatVector::Validity(rowid_vector);
+		auto &validity = mssql_compat::ValidityMutable(rowid_vector);
 		validity.SetAllValid(row_count);
 		MSSQL_SCAN_DEBUG_LOG(2, "Execute: composite_pk_direct_to_struct mode - STRUCT validity set for %llu rows",
 							 (unsigned long long)row_count);
@@ -571,14 +584,18 @@ static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, 
 		for (idx_t pk_idx = 0; pk_idx < state.pk_result_indices.size(); pk_idx++) {
 			idx_t src_col_idx = state.pk_result_indices[pk_idx];
 			auto &src_vector = output.data[src_col_idx];
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+			auto &dst_vector = entries[pk_idx];
+#else
 			auto &dst_vector = *entries[pk_idx];
+#endif
 
 			// Copy the PK column data to the struct child
 			VectorOperations::Copy(src_vector, dst_vector, row_count, 0, 0);
 		}
 
 		// Set validity for the struct itself (valid if any child is valid)
-		auto &validity = FlatVector::Validity(rowid_vector);
+		auto &validity = mssql_compat::ValidityMutable(rowid_vector);
 		validity.SetAllValid(row_count);
 
 		MSSQL_SCAN_DEBUG_LOG(2, "Execute: populated composite rowid with %zu fields for %llu rows",
@@ -634,7 +651,11 @@ static void TableScanExecute(ClientContext &context, TableFunctionInput &data, D
 				for (idx_t pk_idx = 0; pk_idx < global_state.pk_result_indices.size(); pk_idx++) {
 					if (global_state.pk_result_indices[pk_idx] == UINT64_MAX) {
 						// This PK column was added - SQL will write to STRUCT child
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+						target_vectors.push_back(&entries[pk_idx]);
+#else
 						target_vectors.push_back(entries[pk_idx].get());
+#endif
 						added_pk_count++;
 					}
 					// PK columns already in projection will be copied after FillChunk
@@ -651,7 +672,11 @@ static void TableScanExecute(ClientContext &context, TableFunctionInput &data, D
 				// Composite PK rowid-only: write directly to STRUCT children
 				vector<Vector *> target_vectors;
 				for (auto &entry : entries) {
+#ifdef MSSQL_DUCKDB_HAS_NEW_BIND_INPUT
+					target_vectors.push_back(&entry);
+#else
 					target_vectors.push_back(entry.get());
+#endif
 				}
 				global_state.result_stream->SetTargetVectors(std::move(target_vectors));
 				global_state.result_stream->SetColumnsToFill(entries.size());
@@ -739,7 +764,7 @@ static void ComplexFilterPushdown(ClientContext &context, LogicalGet &get, Funct
 
 	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &filter = filters[i];
-		MSSQL_SCAN_DEBUG_LOG(2, "  filter[%llu]: type=%d class=%d", (unsigned long long)i, (int)filter->type,
+		MSSQL_SCAN_DEBUG_LOG(2, "  filter[%llu]: type=%d class=%d", (unsigned long long)i, (int)filter->GetExpressionType(),
 							 (int)filter->GetExpressionClass());
 
 		// Try to encode this expression

--- a/src/tds/auth/krb5_test_function.cpp
+++ b/src/tds/auth/krb5_test_function.cpp
@@ -13,9 +13,9 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
-#include "mssql_compat.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "mssql_compat.hpp"
 #include "mssql_storage.hpp"
 
 #include <string>

--- a/src/tds/auth/krb5_test_function.cpp
+++ b/src/tds/auth/krb5_test_function.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "mssql_compat.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "mssql_storage.hpp"

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "mssql_compat.hpp"
 
 #include <string>
 

--- a/src/tds/encoding/bcp_row_encoder.cpp
+++ b/src/tds/encoding/bcp_row_encoder.cpp
@@ -12,6 +12,7 @@
 #include "copy/target_resolver.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "mssql_compat.hpp"
 #include "tds/encoding/utf16.hpp"
 
 #include <cstring>
@@ -33,7 +34,7 @@ constexpr int64_t MICROS_PER_DAY = 86400000000LL;
 template <typename T>
 static T GetVectorValue(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);	 // We only need format info, not count
+	mssql_compat::ToUnifiedFormat(vec, 1, format);	// We only need format info, not count
 	auto data = UnifiedVectorFormat::GetData<T>(format);
 	auto idx = format.sel->get_index(row_idx);
 	return data[idx];
@@ -53,7 +54,7 @@ static T GetVectorValue(Vector &vec, idx_t row_idx) {
 
 static bool IsVectorNull(Vector &vec, idx_t row_idx) {
 	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
+	mssql_compat::ToUnifiedFormat(vec, 1, format);
 	auto idx = format.sel->get_index(row_idx);
 	return !format.validity.RowIsValid(idx);
 }

--- a/src/tds/encoding/type_converter.cpp
+++ b/src/tds/encoding/type_converter.cpp
@@ -459,7 +459,7 @@ void TypeConverter::WriteAsStringFallback(const std::vector<uint8_t> &value, con
 			"with an explicit CAST in the query.",
 			column.type_id);
 	}
-	FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddString(vector, rendered);
+	mssql_compat::GetDataMutable<string_t>(vector)[row_idx] = StringVector::AddString(vector, rendered);
 }
 
 }  // namespace encoding


### PR DESCRIPTION
## Summary

Source-only migration so a single tree still compiles against both the currently pinned DuckDB SHA `f480e781694b03105c9281d2564f08adb9a8d4a8` and the target SHA `997c2427680e7c0981e312743d27a6c61785ac9e` (DuckLake's [oluies/ducklake#1](https://github.com/oluies/ducklake/pull/1) target). Follow-up to PR #124 (spec 051 M1–M4) — DuckLake's earlier build only flagged three classes of breakage; building the full extension against 997c2427 surfaced eight more API-shape changes.

No submodule bump, no new deps, no behaviour change.

## Migrations (M5–M12)

| # | DuckDB error on 997c2427 | Fix | Compat |
|---|---|---|---|
| **M5** | `FlatVector::GetData<T>(Vector&)` now returns `const T*` — write sites fail with `assignment of read-only location` | `FlatVector::GetDataMutable<T>` for writes | `mssql_compat::GetDataMutable` (forwards to GetData on legacy SHA) |
| **M5b** | `FlatVector::Validity` returns `const ValidityMask&` — `SetAllValid` fails as non-const | `FlatVector::ValidityMutable` | `mssql_compat::ValidityMutable` |
| **M6** | `StringVector` / `StructVector` moved to dedicated headers | `#include <duckdb/common/vector/{string,struct}_vector.hpp>` | `__has_include` guard in `mssql_compat.hpp` |
| **M7** | `Vector::ToUnifiedFormat(idx_t, …)` deprecated in favour of single-arg form | `mssql_compat::ToUnifiedFormat(vec, count, fmt)` discards `count` on new SHA |
| **M8** | `ExpressionExecutor` only forward-declared from `function.hpp` | Explicit `#include <duckdb/execution/expression_executor.hpp>` (unconditional — header exists on both SHAs) |
| **M9** | `ScalarFunction::varargs` field gone (moved to private `FunctionSignature::varargs` with `SetVarArgs(LogicalType)` setter) | `func.SetVarArgs(…)` on new SHA, `func.varargs = …` on legacy | `#ifdef` at the single call site |
| **M10** | `ConstantFilter` / `InFilter` / `ConjunctionAndFilter` / `ConjunctionOrFilter` renamed `Legacy*`; `TableFilterType` enum values renamed `LEGACY_*`; `TableFilterSet` split to its own header; `TableFilterSet::filters` private | `mssql_compat::{ConstantFilter,InFilter,…}` typedefs + `mssql_compat::TFT::*` enum aliases + `HasFilters()` / `FilterCount()` / range-`for` via `*filters` on new SHA |
| **M11** | `BoundComparisonExpression` and `BoundBetweenExpression` became static-helper structs over `BoundFunctionExpression` (function names `"__between"` and the comparison-type expressions); `ExpressionClass::BOUND_COMPARISON`/`BOUND_BETWEEN` gone; `BoundSimpleFunction::name`, `BaseExpression::type`, `Expression::return_type` protected | `BoundComparisonExpression::IsComparison(expr)` + `Left(funcexpr)` / `Right(funcexpr)` / `BoundBetweenExpression::{Input,LowerBound,UpperBound,LowerInclusive,UpperInclusive}(funcexpr)` on new SHA. `expr.GetExpressionType()` / `expr.GetReturnType()` / `mssql_compat::GetFunctionName(expr)` for the accessor swaps. BETWEEN/comparison dispatch lives inside `EncodeFunctionExpression` on the new SHA |
| **M12** | `ColumnBinding::table_index` is now a strongly-typed `TableIndex` struct (no implicit `idx_t` cast); `LogicalOrder::projection_map` is `vector<ProjectionIndex>` (no implicit conversion to `vector<idx_t>`); `StructVector::GetEntries` returns `vector<Vector>&` instead of `vector<unique_ptr<Vector>>&` | `.index` field access for `TableIndex`; element-wise copy for ProjectionIndex; `entries[i]` / `&entries[i]` (no `.get()` / `*`) for StructVector | All under `MSSQL_DUCKDB_HAS_NEW_BIND_INPUT` guards |

Per-M rationale also lives inline at the top of `src/include/mssql_compat.hpp` so future migrations have one canonical reference.

## What's in this PR

- `chore(051-fu): extend mssql_compat.hpp with M5–M11 DuckDB shims` — +150 lines to the spec 051 compat header, no call-site changes.
- `refactor(051-fu): migrate call sites for M5–M12 against DuckDB 997c2427` — 20 files, mechanical accessor swaps, ~300 lines net.

Files changed (21 total):

```
src/codec/{boolean,integer,float,decimal,money,string,binary,datetime,uuid}_codec.cpp
src/tds/encoding/{type_converter,bcp_row_encoder}.cpp
src/azure/azure_test_function.cpp
src/tds/auth/{krb5,winsspi}_test_function.cpp
src/catalog/{mssql_preload_catalog,mssql_refresh_function}.cpp
src/include/table_scan/filter_encoder.hpp
src/table_scan/{filter_encoder,mssql_optimizer,table_scan}.cpp
src/include/mssql_compat.hpp
```

## Verification (local mac)

```bash
# Currently pinned submodule SHA (no regression)
git -C duckdb checkout f480e781694b03105c9281d2564f08adb9a8d4a8
make clean && make release    # exit 0 ✓ (33.5 MB extension, 50.6 MB unittest)

# Target SHA (the point of this PR)
git -C duckdb checkout 997c2427680e7c0981e312743d27a6c61785ac9e
make clean && make release    # exit 0 ✓ (34.9 MB extension, 1.6 MB unittest)
```

Submodule pin **NOT** bumped — that's a separate decision.

## What's NOT in this PR

- Submodule gitlink bump.
- New dependencies.
- Behaviour change. No SQLLogicTest is added or modified.
- DuckLake-side changes — that's a separate PR after we tag (e.g. v0.2.2).

## Test plan

- [ ] CI green against the pinned SHA `f480e781` (extension's submodule default)
- [ ] Manual verification: `git -C duckdb checkout 997c2427 && make release` green on a fresh runner
- [ ] `make test` (C++ unit tests) green
- [ ] `make integration-test` green against SQL Server
- [ ] Reviewer confirms each migration is a pure API-shape change (no semantic drift)

## Downstream

After this merges and the next release tags (e.g. v0.2.2), oluies/ducklake#1 bumps `mssql-extension.version` and that PR's MSSQL build job goes green end-to-end.