### PR TITLE
chore(release): v0.2.1 — integrated-auth LOGIN7 fragmentation + fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 # Extension version - update this when creating a new release tag
-set(MSSQL_EXTENSION_VERSION "0.2.0")
+set(MSSQL_EXTENSION_VERSION "0.2.1")
 
 # Project configuration
 project(${TARGET_NAME})

--- a/description.yml
+++ b/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: mssql
   description: "Connect DuckDB to Microsoft SQL Server via native TDS (including TLS)."
-  version: "0.1.18"
+  version: "0.2.1"
   language: "C++"
   build: "cmake"
   licence: "MIT"
@@ -17,8 +17,7 @@ extension:
 
 repo:
   github: "hugr-lab/mssql-extension"
-  ref: "v0.1.18"
-  ref_next: 65fc3592940086ddb078b2efc3396f04b50605b4
+  ref: "v0.2.1"
 
 docs:
   hello_world: |
@@ -35,15 +34,20 @@ docs:
     Features:
     - Native TDS protocol (no ODBC/JDBC required)
     - Azure Entra ID authentication (Service Principal, CLI, Device Code, Environment Variables)
+    - Kerberos integrated authentication on POSIX (kinit / keytab / raw credentials) and Windows SSPI (current logon session via secur32.dll)
     - Azure SQL Database and Microsoft Fabric support
     - Lazy metadata loading for fast connections
     - Schema, table, and view catalog integration
-    - Projection and filter pushdown
+    - Projection, filter, and ORDER BY pushdown
     - TLS/SSL encrypted connections (encrypt parameter)
     - INSERT support with RETURNING clause
     - UPDATE and DELETE support (requires primary key)
-    - Connection pooling with configurable limits
+    - Per-catalog connection pooling with configurable limits
+    - Eager ATTACH-time credential validation (opt-out via lazy_validation true)
+    - Custom Application Name propagated to LOGIN7 program_name
     - DuckDB secret management for credentials
     - ANSI-compliant connections for DDL commands
-    - COPY TO for bulk data transfer via BCP protocol
+    - COPY TO for bulk data transfer via BCP protocol (SIMD-accelerated UTF-16 transcoding via simdutf)
     - CREATE TABLE AS SELECT (CTAS) support
+    - Named SQL Server instance resolution via SQL Server Browser (UDP 1434)
+    - XML data type read/write support

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mssql-extension",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DuckDB extension for Microsoft SQL Server using native TDS protocol",
   "dependencies": [
     "openssl",


### PR DESCRIPTION
## Release v0.2.1

Patch bump of `MSSQL_EXTENSION_VERSION` (CMakeLists.txt) and `version` (vcpkg.json) from **0.2.0 → 0.2.1**, plus the community-extensions descriptor (`description.yml`). Bug fixes / hardening / internal refactors only — no new user-facing surface.

### What's in 0.2.1 (vs 0.2.0)

**Authentication (contributor fix)**
- `fix(auth)`: fragment integrated-auth LOGIN7 across TDS packets so an AD-sized Kerberos PAC no longer overflows a single TDS packet (#138, merged via #139).
- Adds the **test-only** `mssql_login7_max_packet` setting (replaces the `MSSQL_LOGIN7_MAX_PACKET` env var) to exercise the multi-packet send path without a real AD PAC.
- End-to-end forced-fragmentation kerberos e2e + build fix qualifying TDS constants in `Login7FragmentPacketSize`.

**Bug fixes / hardening**
- Fix **dbt segfault with `threads >= 2`** — spec 052 thread-safe catalog entry lifetime (#127).
- `security`: wipe bearer credentials on destruction (#128).

**Internal / docs / CI**
- Spec 051: DuckDB API migration via `src/include/mssql_compat.hpp` — FlatVector header relocation, single-arg `bind_scalar_function_t`, `IsInterrupted` / `SetNullHandling` (#124).
- `docs`: add DATAMODEL.md (#130).
- `ci(deps)`: bump GitHub Actions (checkout, github-script, codeql, build-push, setup-buildx, action-gh-release).

### Files changed
- `CMakeLists.txt` — `MSSQL_EXTENSION_VERSION` 0.2.0 → 0.2.1
- `vcpkg.json` — `version` 0.2.0 → 0.2.1
- `description.yml` — community descriptor 0.1.18 → 0.2.1 (`ref` v0.1.18 → v0.2.1) + refreshed feature list (was a release behind)

### Release steps
- [x] Bump `CMakeLists.txt` + `vcpkg.json` + `description.yml` to 0.2.1
- [ ] Merge this PR
- [ ] Tag `v0.2.1` on the merge commit (triggers the Release workflow: lint + multi-platform build + publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)