### PR TITLE
fix(dml): clean error for DELETE on tables without a primary key (#141)

### DIFF
--- a/src/catalog/mssql_table_entry.cpp
+++ b/src/catalog/mssql_table_entry.cpp
@@ -390,4 +390,32 @@ virtual_column_map_t MSSQLTableEntry::GetVirtualColumns() const {
 	return result;
 }
 
+vector<column_t> MSSQLTableEntry::GetRowIdColumns() const {
+	// Called by DuckDB's Binder::BindRowIdColumns() on the UPDATE/DELETE/MERGE bind paths.
+	//
+	// rowid is only available for base tables that have a primary key. Without this guard,
+	// DELETE binding (which, unlike UPDATE, never calls BindUpdateConstraints()) reaches
+	// BindRowIdColumns(), fails to find the rowid in GetVirtualColumns(), and raises an
+	// INTERNAL assertion failure (issue #141). Surface the same clean, user-facing error
+	// that UPDATE produces via BindUpdateConstraints() (issue #140) so both DML paths behave
+	// consistently.
+	//
+	// PK info is lazy-loaded in GetScanFunction(), which runs while the table reference is
+	// bound — before any rowid binding — so pk_info_ is published (pk_loaded_) by the time
+	// we get here. Read pk_loaded_ with acquire ordering, matching GetVirtualColumns().
+	if (object_type_ == MSSQLObjectType::VIEW) {
+		throw BinderException("MSSQL: UPDATE/DELETE is not supported on views. '%s.%s' is a view.", schema.name.c_str(),
+							  name.c_str());
+	}
+
+	if (!pk_loaded_.load(std::memory_order_acquire) || !pk_info_.exists) {
+		throw BinderException(
+			"MSSQL: UPDATE/DELETE requires a table with a primary key. "
+			"Table '%s.%s' has no primary key.",
+			schema.name.c_str(), name.c_str());
+	}
+
+	return TableCatalogEntry::GetRowIdColumns();
+}
+
 }  // namespace duckdb

--- a/src/include/catalog/mssql_table_entry.hpp
+++ b/src/include/catalog/mssql_table_entry.hpp
@@ -56,6 +56,11 @@ public:
 	// Note: PK info is lazy-loaded in GetScanFunction(), which is called before this
 	virtual_column_map_t GetVirtualColumns() const override;
 
+	// Override to gate the rowid column required by UPDATE/DELETE binding.
+	// For tables without a primary key (or views) this throws a clean BinderException
+	// instead of letting DuckDB's BindRowIdColumns() hit an internal assertion (issue #141).
+	vector<column_t> GetRowIdColumns() const override;
+
 	//===----------------------------------------------------------------------===//
 	// MSSQL-specific Accessors
 	//===----------------------------------------------------------------------===//

--- a/test/sql/dml/no_pk_update_delete.test
+++ b/test/sql/dml/no_pk_update_delete.test
@@ -1,0 +1,62 @@
+# name: test/sql/dml/no_pk_update_delete.test
+# description: UPDATE/DELETE on tables without a primary key must fail with a clean, consistent BinderException (regression for issues #140 and #141)
+# group: [mssql]
+#
+# Issue #140: UPDATE on a no-PK table fails with a Binder Error (working as designed).
+# Issue #141: DELETE on a no-PK table fails with an INTERNAL assertion failure
+#             ("BindRowIdColumns could not find the row id column ...") instead of the
+#             same clean Binder Error that UPDATE produces. DELETE must surface the
+#             same user-facing error as UPDATE, never an internal assertion.
+#
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#   Example: Server=localhost,1433;Database=testdb;User Id=sa;Password=YourPassword123
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+
+# Create a table WITHOUT a primary key
+statement ok
+DROP TABLE IF EXISTS mssql.dbo.no_pk_dml_test;
+
+statement ok
+CREATE TABLE mssql.dbo.no_pk_dml_test (id INTEGER);
+
+statement ok
+INSERT INTO mssql.dbo.no_pk_dml_test VALUES (1), (2), (3);
+
+# Sanity: SELECT and INSERT work regardless of PK
+query I
+SELECT COUNT(*) FROM mssql.dbo.no_pk_dml_test;
+----
+3
+
+# Issue #140: UPDATE on no-PK table must fail with a clean Binder Error
+statement error
+UPDATE mssql.dbo.no_pk_dml_test SET id = 3 WHERE id = 1;
+----
+requires a table with a primary key
+
+# Issue #141: DELETE on no-PK table must fail with the SAME clean Binder Error,
+# NOT an INTERNAL assertion failure (BindRowIdColumns ...).
+statement error
+DELETE FROM mssql.dbo.no_pk_dml_test WHERE id = 3;
+----
+requires a table with a primary key
+
+# The failed DML must not have mutated any rows
+query I
+SELECT COUNT(*) FROM mssql.dbo.no_pk_dml_test;
+----
+3
+
+# Cleanup
+statement ok
+DROP TABLE mssql.dbo.no_pk_dml_test;
+
+statement ok
+DETACH mssql;


### PR DESCRIPTION
## Summary

DELETE on a SQL Server table **without a primary key** raised an internal assertion failure instead of a clean error:

```
INTERNAL Error: BindRowIdColumns could not find the row id column in the
virtual columns list of the table
```

UPDATE on the same table already produced a clean `BinderException` (issue #140). This PR makes DELETE consistent.

## Root cause

DuckDB's **UPDATE** bind path calls `TableCatalogEntry::BindUpdateConstraints()` — the MSSQL no-PK guard that throws the clean error — *before* `BindRowIdColumns()`. The **DELETE** bind path (`bind_delete.cpp`) calls `BindRowIdColumns()` **directly, with no equivalent hook**. For a no-PK table, `GetVirtualColumns()` exposes no rowid, so `BindRowIdColumns()` throws the internal assertion.

## Fix

Override `MSSQLTableEntry::GetRowIdColumns()` — the first method `BindRowIdColumns()` calls — to throw the same user-facing `BinderException` UPDATE produces when the table has no primary key (or is a view):

```
MSSQL: UPDATE/DELETE requires a table with a primary key. Table '<schema>.<name>' has no primary key.
```

PK info is already lazy-loaded by `GetScanFunction()` (which runs while the table reference is bound, before any rowid binding), so `pk_info_` is populated. `GetRowIdColumns()` is only invoked on the UPDATE/DELETE/MERGE bind paths, so SELECT/INSERT on no-PK tables are unaffected.

## Test

Adds `test/sql/dml/no_pk_update_delete.test` asserting that both UPDATE and DELETE on a no-PK table fail with the consistent message and mutate nothing.

## Verification

Built `make release` against a live SQL Server 2022 container and ran:

| Test | Result |
|---|---|
| `no_pk_update_delete.test` (new) | ✅ 10 assertions |
| `no_pk_rowid.test` | ✅ 9 |
| `delete_scalar_pk` / `update_scalar_pk` | ✅ 30 / 48 |
| `delete_composite_pk` / `update_composite_pk` | ✅ 32 / 76 |

No regressions.

Closes #141