### PR TITLE
fix(query): honor mssql_query_timeout in mssql_exec(); don't drop long-running queries (#90, #145)

### DIFF
--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -1,8 +1,10 @@
 #include "mssql_functions.hpp"
 #include <chrono>
+#include <climits>
 #include <cstdlib>
 #include "catalog/mssql_catalog.hpp"
 #include "connection/mssql_connection_provider.hpp"
+#include "connection/mssql_settings.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -376,9 +378,20 @@ static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &re
 			throw IOException("mssql_exec: Failed to acquire connection from pool for '%s'", context_name);
 		}
 
-		// Execute the SQL
+		// Execute the SQL.
+		// Honor the mssql_query_timeout setting (in seconds) the same way mssql_scan
+		// does — previously mssql_exec used MSSQLSimpleQuery's hardcoded 30s default and
+		// dropped long-running server-side queries regardless of the setting (#90/#145).
+		// 0 (or negative / absurdly large) means no timeout.
+		int query_timeout_s = LoadQueryTimeout(client_context);
+		int timeout_ms;
+		if (query_timeout_s <= 0 || query_timeout_s > INT_MAX / 1000) {
+			timeout_ms = 0;	 // no timeout (wait indefinitely)
+		} else {
+			timeout_ms = query_timeout_s * 1000;
+		}
 		try {
-			auto query_result = MSSQLSimpleQuery::Execute(*connection, sql);
+			auto query_result = MSSQLSimpleQuery::Execute(*connection, sql, timeout_ms);
 
 			// Release connection via ConnectionProvider (no-op if in transaction)
 			ConnectionProvider::ReleaseConnection(client_context, catalog, std::move(connection));

--- a/src/query/mssql_simple_query.cpp
+++ b/src/query/mssql_simple_query.cpp
@@ -1,5 +1,6 @@
 #include "query/mssql_simple_query.hpp"
 #include <chrono>
+#include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -191,12 +192,38 @@ SimpleQueryResult MSSQLSimpleQuery::ExecuteWithCallback(tds::TdsConnection &conn
 			auto remaining_ms = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
 			recv_timeout = static_cast<int>(std::min<long long>(remaining_ms, timeout_ms));
 		} else {
-			recv_timeout = 30000;  // No timeout: use 30s chunks for SO_RCVTIMEO (allows interrupt)
+			// No timeout configured (mssql_query_timeout = 0): wait effectively forever
+			// for each packet, matching mssql_scan's result-stream behavior
+			// (read_timeout_ms_ = INT_MAX). Previously this used a 30s value and then
+			// aborted on the first recv timeout below, which dropped long-running
+			// server-side queries issued via mssql_exec (#90/#145).
+			recv_timeout = INT_MAX;
 		}
 
 		// Read TDS packet (properly framed with 8-byte header)
 		tds::TdsPacket packet;
 		if (!socket->ReceivePacket(packet, recv_timeout)) {
+			// ReceivePacket() returns false on either a read timeout (Receive() == 0,
+			// socket stays connected) or a hard error (Receive() == -1, socket marked
+			// disconnected). A finite mssql_query_timeout that elapses surfaces here
+			// rather than in the deadline check above, because recv_timeout == the
+			// remaining budget, so the socket read times out right at the deadline.
+			// When the socket is still alive, treat it as a clean query timeout: cancel
+			// the server-side statement with ATTENTION and keep the connection reusable,
+			// instead of reporting a hard "Failed to receive TDS packet" and dropping the
+			// connection (#90/#145).
+			if (has_timeout && socket->IsConnected()) {
+				result.success = false;
+				result.error_message = "Query timeout";
+				SIMPLE_QUERY_DEBUG(1, "ExecuteWithCallback: query TIMEOUT after %dms", timeout_ms);
+				connection.SendAttention();
+				connection.WaitForAttentionAck(5000);
+				// State is reset by WaitForAttentionAck on success, else mark disconnected
+				if (connection.GetState() == tds::ConnectionState::Executing) {
+					connection.TransitionState(tds::ConnectionState::Executing, tds::ConnectionState::Disconnected);
+				}
+				return result;
+			}
 			result.success = false;
 			result.error_message = "Failed to receive TDS packet: " + socket->GetLastError();
 			// Mark connection as disconnected since we can't trust it after a receive error

--- a/test/sql/query/exec_query_timeout.test
+++ b/test/sql/query/exec_query_timeout.test
@@ -1,0 +1,68 @@
+# name: test/sql/query/exec_query_timeout.test
+# description: mssql_exec() must honor the mssql_query_timeout setting for long-running server-side queries (regression for issues #90 and #145)
+# group: [mssql]
+#
+# Before the fix, mssql_exec() ignored mssql_query_timeout and used a hardcoded 30s
+# ceiling inside MSSQLSimpleQuery. A server-side statement that ran longer than ~30s
+# without sending TDS packets (e.g. a big INSERT...SELECT, or WAITFOR DELAY) was dropped
+# with "Failed to receive TDS packet: Socket timeout waiting for data", regardless of
+# SET mssql_query_timeout. mssql_scan() honored the setting; mssql_exec() did not.
+#
+# NOTE: this test deliberately runs queries that sleep server-side (WAITFOR DELAY),
+# including one >30s case that directly reproduces #90/#145, so it is slow (~45s total).
+#
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#   Example: Server=localhost,1433;Database=testdb;User Id=sa;Password=YourPassword123
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+
+# --- mssql_query_timeout is honored (was previously ignored) -----------------
+# A 2s timeout must abort a 5s server-side WAITFOR. Before the fix, mssql_exec used a
+# hardcoded 30s timeout, so this 5s query would have (incorrectly) succeeded.
+statement ok
+SET mssql_query_timeout=2;
+
+statement error
+SELECT mssql_exec('mssql', 'WAITFOR DELAY ''00:00:05''');
+----
+Query timeout
+
+# A timeout comfortably larger than the query lets it complete (returns 0 affected rows).
+statement ok
+SET mssql_query_timeout=30;
+
+query I
+SELECT mssql_exec('mssql', 'WAITFOR DELAY ''00:00:03''');
+----
+0
+
+# --- core repro for #90 / #145 ----------------------------------------------
+# Issue #90: "the cutoff is consistently right at 30 seconds of server-side execution
+# (WAITFOR DELAY '00:00:25' passes, '00:00:35' fails)". With mssql_query_timeout=0
+# (documented as "infinite"), the >30s case must NOT be dropped with
+# "Failed to receive TDS packet: Socket timeout waiting for data".
+statement ok
+SET mssql_query_timeout=0;
+
+query I
+SELECT mssql_exec('mssql', 'WAITFOR DELAY ''00:00:35''');
+----
+0
+
+# Issue #90 documented workaround: the same long-running statement wrapped with a
+# trailing SELECT via mssql_scan() already succeeded (mssql_scan honored the timeout;
+# mssql_exec did not). Assert that asymmetry is gone — both paths now respect the
+# setting and complete past the old 30s ceiling.
+query I
+SELECT done FROM mssql_scan('mssql', 'WAITFOR DELAY ''00:00:35''; SELECT 1 AS done');
+----
+1
+
+statement ok
+DETACH mssql;


### PR DESCRIPTION
## Summary

`mssql_exec()` ignored the `mssql_query_timeout` setting and used `MSSQLSimpleQuery`'s hardcoded **30s** default. A server-side statement that ran longer than ~30s without sending TDS packets (a big `INSERT ... SELECT`, an `EXEC` proc, or `WAITFOR`) was dropped with:

```
Invalid Input Error: MSSQL execution error: SQL Server error 0:
Failed to receive TDS packet: Socket timeout waiting for data
```

…regardless of `SET mssql_query_timeout` (including `0`, documented as infinite). `mssql_scan()` honored the setting; `mssql_exec()` did not — which is why the documented workaround (`mssql_scan` with a trailing `SELECT`) worked.

Fixes #90 and its duplicate #145.

## Root cause

- `mssql_exec()` called `MSSQLSimpleQuery::Execute(*connection, sql)` — the 2-arg form, so `timeout_ms` was always the `30000` default; the setting was never read.
- Even the `timeout_ms <= 0` ("no timeout") branch in `MSSQLSimpleQuery` set `recv_timeout = 30000` and then **aborted** on the first socket-recv timeout, so `mssql_query_timeout=0` still died at 30s.
- On timeout it reported a hard `Failed to receive TDS packet` and marked the connection disconnected (the "drops the connection" symptom in the issue).

## Fix

1. **Plumb the setting**: `mssql_exec()` reads `mssql_query_timeout` via `LoadQueryTimeout()` and passes it (seconds → ms; `0`/negative/overflow → no timeout) to `MSSQLSimpleQuery::Execute()`.
2. **Make `0` mean infinite**: the no-timeout branch now waits with `INT_MAX`, matching `mssql_scan`'s result-stream behaviour (`read_timeout_ms_ = INT_MAX`).
3. **Clean finite-timeout handling**: on a recv failure with a finite timeout and a *still-connected* socket, treat it as a query timeout — cancel server-side via `ATTENTION` and keep the connection reusable, instead of a hard error + disconnect. Timeout vs. hard error is distinguished via `TdsSocket::IsConnected()` (`Receive()` returns `0` on timeout, keeping the socket connected; `-1` on a real error, which drops it). This is robust across the plain-TCP and TLS read paths, where the timeout error string is empty.

## Test

Adds `test/sql/query/exec_query_timeout.test` (group `[mssql]`), mirroring issue #90's documented scenarios:

| Scenario | Expectation |
|---|---|
| `mssql_query_timeout=2`, 5s `WAITFOR` | clean `Query timeout` (setting honored; previously waited 30s) |
| `mssql_query_timeout=30`, 3s `WAITFOR` | succeeds |
| `mssql_query_timeout=0`, **35s** `WAITFOR` via `mssql_exec` | succeeds (the #90/#145 repro — previously dropped at 30s) |
| `mssql_query_timeout=0`, 35s `WAITFOR` + trailing `SELECT` via `mssql_scan` | returns row (documented workaround / parity) |

> Note: the test deliberately runs >30s server-side sleeps, so it is slow (~45s).

## Verification

Built `make release` against current `main` and ran the new test against a live SQL Server 2022 container (TLS enabled): **9/9 assertions pass**. `test/sql/catalog/filter_pushdown.test` and the `test/sql/query/*` suite remain green (the `MSSQLSimpleQuery` recv-path change only affects the error/timeout branch).

Closes #90
Closes #145