### PR TITLE
fix(copy): BCP COPY omits unmapped target columns (IDENTITY/DEFAULT) (#125)

### DIFF
--- a/src/copy/copy_function.cpp
+++ b/src/copy/copy_function.cpp
@@ -330,6 +330,39 @@ unique_ptr<GlobalFunctionData> BCPCopyInitGlobal(ClientContext &context, Functio
 				// Build column mapping from source to target
 				gstate->column_mapping = TargetResolver::BuildColumnMapping(bdata.source_names, gstate->columns);
 
+				// Issue #125: Drop target columns that have no matching source column (by name).
+				// These are columns the server fills itself — IDENTITY, DEFAULT-valued, or
+				// computed columns the source intentionally omits. INSERT BULK only needs the
+				// columns actually being loaded; SQL Server auto-generates the rest. Previously
+				// every target column was declared, so an unmapped IDENTITY column had NULL
+				// streamed into it and the load failed ("Cannot insert the value NULL into
+				// column ..." / "Incorrect syntax near the keyword 'with'").
+				{
+					vector<BCPColumnMetadata> mapped_columns;
+					vector<int32_t> mapped_mapping;
+					mapped_columns.reserve(gstate->columns.size());
+					mapped_mapping.reserve(gstate->column_mapping.size());
+					for (idx_t i = 0; i < gstate->columns.size(); i++) {
+						if (gstate->column_mapping[i] >= 0) {
+							mapped_columns.push_back(gstate->columns[i]);
+							mapped_mapping.push_back(gstate->column_mapping[i]);
+						} else {
+							CopyDebugLog(1,
+										 "BCPCopyInitGlobal: omitting target column '%s' from INSERT BULK "
+										 "(no matching source column; server-generated, e.g. IDENTITY/DEFAULT)",
+										 gstate->columns[i].name.c_str());
+						}
+					}
+					if (mapped_columns.empty()) {
+						throw InvalidInputException(
+							"MSSQL COPY: no source columns match target table '%s' by name; "
+							"nothing to load. Ensure source column names match the target's columns.",
+							bdata.target.GetFullyQualifiedName());
+					}
+					gstate->columns = std::move(mapped_columns);
+					gstate->column_mapping = std::move(mapped_mapping);
+				}
+
 				// Check if we need to use column mapping (i.e., not a 1:1 positional match)
 				// Mapping is needed if: column counts differ, or any mapping != position
 				need_column_mapping = (bdata.source_names.size() != gstate->columns.size());

--- a/src/copy/copy_function.cpp
+++ b/src/copy/copy_function.cpp
@@ -343,6 +343,10 @@ unique_ptr<GlobalFunctionData> BCPCopyInitGlobal(ClientContext &context, Functio
 					mapped_columns.reserve(gstate->columns.size());
 					mapped_mapping.reserve(gstate->column_mapping.size());
 					for (idx_t i = 0; i < gstate->columns.size(); i++) {
+						// column_mapping[i] is the source-column index feeding target column i,
+						// or -1 when no source column matches it by name. Keep only the mapped
+						// (>= 0) target columns; the -1 entries are server-generated (IDENTITY,
+						// DEFAULT, computed) and must be left out of INSERT BULK entirely.
 						if (gstate->column_mapping[i] >= 0) {
 							mapped_columns.push_back(gstate->columns[i]);
 							mapped_mapping.push_back(gstate->column_mapping[i]);

--- a/test/sql/catalog/ddl_if_not_exists.test
+++ b/test/sql/catalog/ddl_if_not_exists.test
@@ -12,7 +12,7 @@ ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # Clean up any existing test tables
 statement ok
-CALL mssql_exec('mssql', 'IF OBJECT_ID(''dbo.DDLIfNotExists'', ''U'') IS NOT NULL DROP TABLE dbo.DDLIfNotExists');
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.DDLIfNotExists'', ''U'') IS NOT NULL DROP TABLE dbo.DDLIfNotExists');
 
 # =============================================================================
 # Test 1: CREATE TABLE IF NOT EXISTS - table does not exist
@@ -59,7 +59,7 @@ CREATE TABLE mssql.dbo.DDLIfNotExists (
     id INTEGER
 );
 ----
-already exists
+already an object named
 
 # =============================================================================
 # Test 4: CREATE OR REPLACE TABLE - replaces existing

--- a/test/sql/copy/bcp_identity_column.test
+++ b/test/sql/copy/bcp_identity_column.test
@@ -1,0 +1,84 @@
+# name: test/sql/copy/bcp_identity_column.test
+# description: COPY ... TO (FORMAT 'bcp') against a table with an IDENTITY column, with and without the identity column in the source (regression for issue #125)
+# group: [mssql]
+#
+# Before the fix, the BCP COPY path declared ALL target columns (including an unmapped
+# IDENTITY column) in the INSERT BULK statement and streamed NULL for the identity, failing
+# with "Cannot insert the value NULL into column 'ID'" / "Incorrect syntax near 'with'".
+# The fix declares only the columns the source actually maps to:
+#   - source WITHOUT the identity column -> column omitted, SQL Server auto-generates it
+#   - source WITH the identity column    -> column loaded, explicit values preserved
+#
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#   Example: Server=localhost,1433;Database=testdb;User Id=sa;Password=YourPassword123
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+
+# =============================================================================
+# Scenario A: source OMITS the identity column -> server auto-generates it
+# =============================================================================
+
+statement ok
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.BcpIdentityAuto'',''U'') IS NOT NULL DROP TABLE dbo.BcpIdentityAuto');
+
+statement ok
+SELECT mssql_exec('mssql', 'CREATE TABLE dbo.BcpIdentityAuto (ID BIGINT NOT NULL IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100), val INT)');
+
+statement ok
+CREATE TEMP TABLE bcp_src_auto (name VARCHAR, val INTEGER);
+
+statement ok
+INSERT INTO bcp_src_auto VALUES ('alpha', 10), ('beta', 20), ('gamma', 30);
+
+statement ok
+COPY bcp_src_auto TO 'mssql.dbo.BcpIdentityAuto' (FORMAT 'bcp', CREATE_TABLE false);
+
+# Identity auto-assigned 1..3 in insertion order
+query ITI
+SELECT ID, name, val FROM mssql.dbo.BcpIdentityAuto ORDER BY ID;
+----
+1	alpha	10
+2	beta	20
+3	gamma	30
+
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.BcpIdentityAuto');
+
+# =============================================================================
+# Scenario B: source INCLUDES the identity column -> explicit values preserved
+# =============================================================================
+
+statement ok
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.BcpIdentityKeep'',''U'') IS NOT NULL DROP TABLE dbo.BcpIdentityKeep');
+
+statement ok
+SELECT mssql_exec('mssql', 'CREATE TABLE dbo.BcpIdentityKeep (ID BIGINT NOT NULL IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100), val INT)');
+
+statement ok
+CREATE TEMP TABLE bcp_src_keep (ID BIGINT, name VARCHAR, val INTEGER);
+
+statement ok
+INSERT INTO bcp_src_keep VALUES (100, 'alpha', 10), (200, 'beta', 20), (300, 'gamma', 30);
+
+statement ok
+COPY bcp_src_keep TO 'mssql.dbo.BcpIdentityKeep' (FORMAT 'bcp', CREATE_TABLE false);
+
+# Explicit identity values preserved (BCP keeps identity)
+query ITI
+SELECT ID, name, val FROM mssql.dbo.BcpIdentityKeep ORDER BY ID;
+----
+100	alpha	10
+200	beta	20
+300	gamma	30
+
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.BcpIdentityKeep');
+
+statement ok
+DETACH mssql;

--- a/test/sql/copy/copy_auto_tablock.test
+++ b/test/sql/copy/copy_auto_tablock.test
@@ -12,7 +12,7 @@ ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # Clean up any existing test tables
 statement ok
-CALL mssql_exec('mssql', 'IF OBJECT_ID(''dbo.CopyAutoTablockTest'', ''U'') IS NOT NULL DROP TABLE dbo.CopyAutoTablockTest');
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.CopyAutoTablockTest'', ''U'') IS NOT NULL DROP TABLE dbo.CopyAutoTablockTest');
 
 # Create source data
 statement ok
@@ -60,7 +60,7 @@ SELECT COUNT(*) FROM mssql.dbo.CopyAutoTablockTest;
 # When user explicitly sets tablock=false, auto-TABLOCK should NOT override
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
 
 statement ok
 COPY source_data TO 'mssql.dbo.CopyAutoTablockTest' (FORMAT bcp, TABLOCK false);
@@ -74,7 +74,7 @@ SELECT COUNT(*) FROM mssql.dbo.CopyAutoTablockTest;
 # Test 5: Explicit TABLOCK enabled via COPY option
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
 
 statement ok
 COPY source_data TO 'mssql.dbo.CopyAutoTablockTest' (FORMAT bcp, TABLOCK true);
@@ -88,7 +88,7 @@ SELECT COUNT(*) FROM mssql.dbo.CopyAutoTablockTest;
 # Test 6: Explicit TABLOCK via setting (should override auto behavior)
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
 
 statement ok
 SET mssql_copy_tablock = true;
@@ -108,7 +108,7 @@ RESET mssql_copy_tablock;
 # Cleanup
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.CopyAutoTablockTest');
 
 statement ok
 DROP TABLE source_data;


### PR DESCRIPTION
## Summary

`COPY … TO (FORMAT 'bcp')` into a table with an **IDENTITY** column failed:

```
Invalid Input Error: MSSQL COPY: Failed to ... Cannot insert the value NULL into column 'ID' ...
```
(or, on some SQL Server builds, `Incorrect syntax near the keyword 'with'`).

Fixes #125.

## Root cause (reproduced)

The BCP path declared **all** target-table columns in the `INSERT BULK` statement. `BuildColumnMapping` correctly leaves a source-omitted IDENTITY column **unmapped** (`-1`), but `gstate->columns` still held every target column, so the identity column ended up in the `INSERT BULK` list + COLMETADATA and the writer streamed **NULL** into it:

```
BuildColumnMapping: mapped 2 source columns to 3 target columns
INSERT BULK [dbo].[T] ([ID] bigint, [name] nvarchar(100), [val] int) WITH (TABLOCK, ROWS_PER_BATCH = 100000)
-> Cannot insert the value NULL into column 'ID' ...
```

There is **no `SET IDENTITY_INSERT`** in the code and the generated statement is well-formed — the bug is purely the column set. (The reporter's "syntax near `WITH`" is the same mismatch surfacing differently per server/version.)

## Fix

`INSERT BULK` with an explicit column list only needs the columns being loaded; SQL Server auto-generates the rest. After `BuildColumnMapping`, drop target columns with no matching source column from both `gstate->columns` and `gstate->column_mapping`, so the `INSERT BULK` list, COLMETADATA, and row stream agree on the loaded subset. (`src/copy/copy_function.cpp`)

Verified against a live SQL Server 2022 (TLS):

| Source | Result |
|---|---|
| **omits** identity column | column omitted → server auto-generates `1,2,3` |
| **includes** identity column | column loaded → explicit values `100,200,300` preserved |
| no source column matches by name | clear error instead of a NULL failure |

## Tests

- `test/sql/copy/bcp_identity_column.test` (new) — both the auto-generate and keep-identity scenarios. **32 assertions, all pass.**

### Test-suite maintenance (second commit)

While verifying the COPY suite I found several integration tests using `CALL mssql_exec(...)`. `mssql_exec` is a **scalar** function, so `CALL` (table-function syntax) fails with `Catalog Error: Table Function with name mssql_exec does not exist` — these tests never ran green. This PR corrects the two where the fix fully restores them:

- `test/sql/copy/copy_auto_tablock.test`: `CALL` → `SELECT` → **22 assertions pass**.
- `test/sql/catalog/ddl_if_not_exists.test`: `CALL` → `SELECT`, plus the expected duplicate-table error substring updated `already exists` → `already an object named` (SQL Server error 2714 wording) → **15 assertions pass**.

### Pre-existing issues left for separate follow-up (NOT touched here)

Correcting the `CALL` syntax in four other tests unmasked **deeper, unrelated drift** — some of it possible real bugs that shouldn't be papered over by editing assertions. Left as-is and flagged:

1. **Catalog-cache incoherence** (`ctas_if_not_exists`, `ctas_auto_tablock`): `mssql_exec('DROP TABLE …')` runs raw T-SQL that does **not** invalidate the catalog metadata cache. A following `CREATE TABLE IF NOT EXISTS … AS` then sees a stale "exists" and skips creation, so a later read fails with `Invalid object name`. The CTAS-with-`mssql_copy_tablock=false` data load itself is fine (verified: 100 rows land both client- and server-side) — the `COUNT(*) = 0` in the test is this cache artifact, not data loss. Either the tests should DROP via the catalog (`DROP TABLE db.dbo.X`) or raw-exec DDL should invalidate the cache.
2. **`mssql_pool_stats` schema drift** (`copy_connection_leak`): references removed columns (`pool_size`, `total_connections_created`); the current schema is `total_connections, idle_connections, active_connections, connections_created, connections_closed, acquire_count, acquire_timeout_count, pinned_count`. Expected values are also stale and pool-state-dependent.
3. **BIGINT→INT coercion** (`copy_type_mismatch`): the test expects a BIGINT source to coerce into an INT column, but the COPY validator now rejects any type difference with `… type mismatch … Use REPLACE=true …`. Needs a decision on whether narrowing coercion should be allowed (note `copy_connection_leak` only ever expected the *incompatible* VARCHAR→INT case to fail).

## Regression check

`copy_column_mapping` (69 assertions), `copy_basic`, `copy_temp`, `copy_types`, `copy_overwrite`, `copy_auto_tablock`, `ddl_if_not_exists` all pass. The #125 code change is isolated to `src/copy/copy_function.cpp` (+33 lines); the column-type validation path is untouched.

Closes #125