### PR TITLE
fix(catalog): invalidate catalog cache after DDL run via mssql_exec() (#151)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,12 @@ duckdb --unsigned -c "INSTALL mssql FROM local_build_debug; LOAD mssql;"
 - SQL test context names: unique per file, prefixed by operation (e.g., `txtest`, `mssql_upd_scalar`)
 - Test tables: PascalCase (`TestSimplePK`, `TxTestOrders`) or snake_case for simple ones (`tx_test`)
 
+## Documentation
+
+- **`DATAMODEL.md`** is the layered-architecture reference (TDS → connection pool → catalog → cache → codec) with Mermaid diagrams. **On every PR, consider whether `DATAMODEL.md` needs updating** — if the change adds/removes a layer component, alters an invariant (lifetime, cache invalidation, threading, ownership), or changes an end-to-end flow, update the relevant layer section (and its diagram) in the same PR.
+- Keep architecture/internals diagrams in `DATAMODEL.md`; keep `README.md` user-facing (link into `DATAMODEL.md` rather than duplicating internals).
+- Use GitHub-rendered ```mermaid``` fenced blocks for diagrams.
+
 ## Key Architecture Concepts
 
 - **Custom TDS implementation**: No external TDS/ODBC library. TDS v7.4 protocol with PRELOGIN, LOGIN7, SQL_BATCH, ATTENTION packet types.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ duckdb --unsigned -c "INSTALL mssql FROM local_build_debug; LOAD mssql;"
 | `mssql_metadata_timeout` | 300 | Metadata query timeout in seconds (0 = no timeout) |
 | `mssql_attach_validation_timeout` | 0 | ATTACH-time eager credential validation timeout in seconds (0 = inherit `mssql_connection_timeout`). Spec 047 FR-011. |
 | `mssql_catalog_cache_ttl` | 0 | Metadata cache TTL (0 = manual via `mssql_refresh_cache()`) |
+| `mssql_exec_invalidate_cache` | true | Auto-invalidate the catalog cache after DDL run via `mssql_exec()` (CREATE/DROP/ALTER/TRUNCATE/RENAME/EXEC). Set false to preserve a large preloaded cache and invalidate manually with `mssql_invalidate_cache()`. Issue #151. |
 | `mssql_insert_batch_size` | 1000 | Rows per INSERT statement |
 | `mssql_insert_max_rows_per_statement` | 1000 | Hard cap per INSERT |
 | `mssql_insert_max_sql_bytes` | 8MB (8388608) | INSERT SQL size limit |
@@ -215,7 +216,8 @@ Available in: ATTACH options, ADO.NET connection strings (`SchemaFilter`/`TableF
 | `mssql_scan(context, query)` | Table | Execute raw T-SQL, stream results |
 | `mssql_exec(context, sql)` | Scalar | Execute T-SQL, return affected row count |
 | `mssql_pool_stats([context])` | Table | View connection pool statistics |
-| `mssql_refresh_cache(context)` | Scalar | Refresh metadata cache |
+| `mssql_refresh_cache(context)` | Scalar | Refresh metadata cache (eager full reload) |
+| `mssql_invalidate_cache(context [, schema [, table]])` | Scalar | Lazy point invalidation — whole catalog / one schema / one table (keeps other tables' cached columns) |
 | `mssql_preload_catalog(context [, schema])` | Scalar | Bulk-load all metadata in one round trip |
 | `mssql_open(conn_string)` | Scalar | [DEPRECATED] Open standalone diagnostic connection (spec 047 FR-010 — prefer ATTACH + catalog-bound functions) |
 | `mssql_close(handle)` | Scalar | [DEPRECATED] Close diagnostic connection (spec 047 FR-010) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ duckdb --unsigned -c "INSTALL mssql FROM local_build_debug; LOAD mssql;"
 | `mssql_metadata_timeout` | 300 | Metadata query timeout in seconds (0 = no timeout) |
 | `mssql_attach_validation_timeout` | 0 | ATTACH-time eager credential validation timeout in seconds (0 = inherit `mssql_connection_timeout`). Spec 047 FR-011. |
 | `mssql_catalog_cache_ttl` | 0 | Metadata cache TTL (0 = manual via `mssql_refresh_cache()`) |
-| `mssql_exec_invalidate_cache` | true | Auto-invalidate the catalog cache after DDL run via `mssql_exec()` (CREATE/DROP/ALTER/TRUNCATE/RENAME/EXEC). Set false to preserve a large preloaded cache and invalidate manually with `mssql_invalidate_cache()`. Issue #151. |
+| `mssql_exec_invalidate_cache` | false | Auto-invalidate the catalog cache after DDL run via `mssql_exec()` (CREATE/DROP/ALTER/TRUNCATE/RENAME/EXEC). Default `false` (like Postgres `postgres_execute`): invalidate manually with `mssql_invalidate_cache()`. Set `true` to auto-invalidate. Issue #151. |
 | `mssql_insert_batch_size` | 1000 | Rows per INSERT statement |
 | `mssql_insert_max_rows_per_statement` | 1000 | Hard cap per INSERT |
 | `mssql_insert_max_sql_bytes` | 8MB (8388608) | INSERT SQL size limit |

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -304,7 +304,7 @@ flowchart TD
 
 Statements run through `mssql_exec()` are plain T-SQL — DuckDB never sees them, so it cannot invalidate the cache on its own. Spec/issue **#151**: `mssql_exec()` detects DDL keywords (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) and calls `InvalidateMetadataCache()` after a successful run. `INSERT`/`UPDATE`/`DELETE` do not invalidate anything, so transaction-pinned DML through `mssql_exec()` is unaffected.
 
-The auto-invalidation is gated by the `mssql_exec_invalidate_cache` setting (default `true`). Users with a large `mssql_preload_catalog` cache can set it `false` and invalidate at a chosen granularity with `mssql_invalidate_cache(catalog [, schema [, table]])`:
+The auto-invalidation is gated by the `mssql_exec_invalidate_cache` setting, which **defaults to `false`** (matching the Postgres extension's `postgres_execute`): by default `mssql_exec()` does not touch the cache and the caller invalidates at a chosen granularity with `mssql_invalidate_cache(catalog [, schema [, table]])`. Set the flag `true` to auto-invalidate after `mssql_exec()` DDL.
 
 | Granularity | Catalog call | Metadata cache | Table set |
 |---|---|---|---|

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -304,6 +304,16 @@ flowchart TD
 
 Statements run through `mssql_exec()` are plain T-SQL — DuckDB never sees them, so it cannot invalidate the cache on its own. Spec/issue **#151**: `mssql_exec()` detects DDL keywords (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) and calls `InvalidateMetadataCache()` after a successful run. `INSERT`/`UPDATE`/`DELETE` do not invalidate anything, so transaction-pinned DML through `mssql_exec()` is unaffected.
 
+The auto-invalidation is gated by the `mssql_exec_invalidate_cache` setting (default `true`). Users with a large `mssql_preload_catalog` cache can set it `false` and invalidate at a chosen granularity with `mssql_invalidate_cache(catalog [, schema [, table]])`:
+
+| Granularity | Catalog call | Metadata cache | Table set |
+|---|---|---|---|
+| catalog | `InvalidateMetadataCache()` | all schemas + all columns | every schema's bound entries |
+| schema | `InvalidateSchemaTableSet(schema)` | schema table list + that schema's columns | schema's bound entries |
+| table | `InvalidateTableEntry(schema, table)` | that table's columns + `InvalidateSchemaTableList` (existence only) | `InvalidateEntry(table)` (one entry) |
+
+Per-table is the cheap one: `InvalidateSchemaTableList` re-checks the table list (existence) **without** dropping any other table's column metadata, and `MSSQLTableSet::InvalidateEntry` evicts only the one bound entry — so a single `ALTER`/`DROP`/`CREATE` against a huge preloaded schema re-fetches just that table's columns, not the whole schema's.
+
 ```mermaid
 sequenceDiagram
     participant U as DuckDB

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -281,6 +281,45 @@ classDiagram
 - `TokenCache` is the only remaining process-wide static, but it is **namespaced by `DatabaseInstance*`** (spec 047 FR-012) so two embeddings can use the same Azure secret name without aliasing.
 - Result streams (large `mssql_scan` results) live in `MSSQLCatalog::active_streams_`, keyed by a UUID handle that bridges Bind-time stream creation and InitGlobal-time consumption (spec 047 US3).
 
+### Cache invalidation
+
+Existence and column metadata are cached in **two layers**, both filled lazily on first access:
+
+1. **`MSSQLMetadataCache`** (this layer) — schema list, each schema's table/view list, and per-table column metadata.
+2. **Schema table sets** (Layer 3 — `MSSQLTableSet` on each `MSSQLSchemaEntry`) — the bound `MSSQLTableEntry` objects DuckDB resolves names against; built from layer 1 the first time a table is read.
+
+Both layers must be invalidated together. Invalidating only `MSSQLMetadataCache` is not enough once a table has been read: its bound `MSSQLTableEntry` survives in the schema's table set and would still satisfy a `CREATE TABLE IF NOT EXISTS`. `MSSQLCatalog::InvalidateMetadataCache()` does both (lazy — reload deferred to next access); `RefreshCache()` is the eager variant that reloads in one round-trip.
+
+```mermaid
+flowchart TD
+    A["DuckDB catalog DDL<br/>CREATE / DROP / ALTER TABLE db.dbo.t"] --> X{{"cache marked stale"}}
+    B["mssql_exec('db', 'DROP / CREATE / ALTER ...')<br/>raw T-SQL DDL (#151)"] --> X
+    C["mssql_refresh_cache('db')<br/>eager full reload"] --> X
+    D["TTL expiry<br/>when mssql_catalog_cache_ttl is set"] --> X
+    X --> MC["MSSQLMetadataCache invalidated"]
+    X --> TS["schema table sets invalidated<br/>(bound MSSQLTableEntry evicted via graveyard)"]
+    MC --> N["reload from SQL Server<br/>on next access"]
+    TS --> N
+```
+
+Statements run through `mssql_exec()` are plain T-SQL — DuckDB never sees them, so it cannot invalidate the cache on its own. Spec/issue **#151**: `mssql_exec()` detects DDL keywords (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) and calls `InvalidateMetadataCache()` after a successful run. `INSERT`/`UPDATE`/`DELETE` do not invalidate anything, so transaction-pinned DML through `mssql_exec()` is unaffected.
+
+```mermaid
+sequenceDiagram
+    participant U as DuckDB
+    participant C as Catalog cache
+    participant S as SQL Server
+    U->>C: SELECT ... FROM db.dbo.t
+    C->>S: load metadata (lazy)
+    C-->>U: rows — t now cached and bound
+    U->>S: mssql_exec('db', 'DROP TABLE dbo.t')
+    Note over C: DDL detected → InvalidateMetadataCache()<br/>metadata + table sets marked stale
+    U->>C: CREATE TABLE IF NOT EXISTS db.dbo.t AS ...
+    C->>S: existence re-checked (cache stale) — table gone, so CREATE runs
+    U->>C: SELECT ... FROM db.dbo.t
+    C-->>U: rows ✓ (returned "Invalid object name" before the #151 fix)
+```
+
 ---
 
 ## Layer 5 — Codec (spec 045)

--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ SELECT mssql_exec('sqlserver', 'CREATE UNIQUE INDEX IX_users_username ON dbo.use
 SELECT mssql_exec('sqlserver', 'DROP INDEX IX_users_email ON dbo.users');
 ```
 
-> **Note**: Schema-changing statements run through `mssql_exec()` (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) invalidate the metadata cache automatically, the same as standard DuckDB DDL. To preserve a large manually-preloaded cache, set `mssql_exec_invalidate_cache = false` and invalidate yourself with `mssql_invalidate_cache('sqlserver' [, schema [, table]])` (lazy, point-scoped) or `mssql_refresh_cache('sqlserver')` (eager full reload). You also need a manual invalidate to pick up changes made entirely out of band (e.g. by another client) while `mssql_catalog_cache_ttl` is `0`. See [Cache & invalidation](DATAMODEL.md#cache-invalidation) in `DATAMODEL.md` for how the two-layer cache works.
+> **Note**: After **schema-changing** DDL run through `mssql_exec()` (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`), invalidate the metadata cache yourself — the same as the Postgres extension's `postgres_execute`. By default (`mssql_exec_invalidate_cache = false`) `mssql_exec()` does **not** touch the cache, so use `mssql_invalidate_cache('sqlserver' [, schema [, table]])` (lazy, point-scoped) or `mssql_refresh_cache('sqlserver')` (eager full reload). Standard DuckDB-catalog DDL (e.g. `CREATE TABLE db.dbo.t`) still invalidates automatically. Set `mssql_exec_invalidate_cache = true` to make `mssql_exec()` DDL auto-invalidate too. The same manual step picks up changes made entirely out of band (e.g. by another client) while `mssql_catalog_cache_ttl` is `0`. See [Cache & invalidation](DATAMODEL.md#cache-invalidation) in `DATAMODEL.md` for how the two-layer cache works.
 
 ## Function Reference
 
@@ -1305,7 +1305,7 @@ Queries involving unsupported types will raise an error.
 | `mssql_query_timeout`      | BIGINT  | 30      | ≥0    | Query execution timeout (seconds, 0=infinite) |
 | `mssql_metadata_timeout`   | BIGINT  | 300     | ≥0    | Metadata query timeout (seconds, 0=no timeout) |
 | `mssql_catalog_cache_ttl`  | BIGINT  | 0       | ≥0    | Metadata cache TTL (seconds, 0=manual)   |
-| `mssql_exec_invalidate_cache` | BOOLEAN | true | true/false | Auto-invalidate the catalog cache after DDL run via `mssql_exec()`. Set `false` to keep a large preloaded cache and invalidate manually with `mssql_invalidate_cache()`. |
+| `mssql_exec_invalidate_cache` | BOOLEAN | false | true/false | Auto-invalidate the catalog cache after DDL run via `mssql_exec()`. Default `false` (like the Postgres extension's `postgres_execute`): invalidate manually with `mssql_invalidate_cache()` after schema-changing DDL. Set `true` to auto-invalidate. |
 | `mssql_attach_validation_timeout` | BIGINT | 0 | ≥0 | ATTACH-time eager-validation timeout (seconds). `0` inherits `mssql_connection_timeout`. Spec 047 FR-011. |
 
 ### Statistics Settings

--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ SELECT mssql_exec('sqlserver', 'CREATE UNIQUE INDEX IX_users_username ON dbo.use
 SELECT mssql_exec('sqlserver', 'DROP INDEX IX_users_email ON dbo.users');
 ```
 
-> **Note**: Schema-changing statements run through `mssql_exec()` (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) invalidate the metadata cache automatically, the same as standard DuckDB DDL. You only need `mssql_refresh_cache('sqlserver')` to pick up changes made entirely out of band (e.g. by another client) while `mssql_catalog_cache_ttl` is `0`. See [Cache & invalidation](DATAMODEL.md#cache-invalidation) in `DATAMODEL.md` for how the two-layer cache works.
+> **Note**: Schema-changing statements run through `mssql_exec()` (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) invalidate the metadata cache automatically, the same as standard DuckDB DDL. To preserve a large manually-preloaded cache, set `mssql_exec_invalidate_cache = false` and invalidate yourself with `mssql_invalidate_cache('sqlserver' [, schema [, table]])` (lazy, point-scoped) or `mssql_refresh_cache('sqlserver')` (eager full reload). You also need a manual invalidate to pick up changes made entirely out of band (e.g. by another client) while `mssql_catalog_cache_ttl` is `0`. See [Cache & invalidation](DATAMODEL.md#cache-invalidation) in `DATAMODEL.md` for how the two-layer cache works.
 
 ## Function Reference
 
@@ -1182,6 +1182,26 @@ SELECT mssql_refresh_cache('sqlserver');
 - Non-existent catalog throws an error
 - Catalog that is not an MSSQL type throws an error
 
+### mssql_invalidate_cache()
+
+Lazily invalidate the metadata cache at a chosen granularity, without an eager reload (reload happens on next access). Unlike `mssql_refresh_cache()`, this is point-scoped, so it can drop a single table or schema while keeping the rest of a large preloaded cache intact.
+
+**Signature:** `mssql_invalidate_cache(catalog_name VARCHAR [, schema VARCHAR [, table VARCHAR]]) -> BOOLEAN`
+
+```sql
+-- Whole catalog (lazy; equivalent to what mssql_exec() DDL triggers automatically)
+SELECT mssql_invalidate_cache('sqlserver');
+
+-- One schema
+SELECT mssql_invalidate_cache('sqlserver', 'dbo');
+
+-- One table — re-fetches this table's columns + re-checks its existence,
+-- keeping every other table's cached column metadata
+SELECT mssql_invalidate_cache('sqlserver', 'dbo', 'orders');
+```
+
+Use this after changing schema out of band (e.g. via `mssql_exec()` with `mssql_exec_invalidate_cache = false`, or from another client) instead of paying for a full `mssql_refresh_cache()` reload.
+
 ### mssql_preload_catalog()
 
 Bulk-load all metadata (schemas, tables, columns) for an attached MSSQL catalog in a single operation. This is useful for large databases where you want to avoid per-table metadata queries during subsequent queries.
@@ -1285,6 +1305,7 @@ Queries involving unsupported types will raise an error.
 | `mssql_query_timeout`      | BIGINT  | 30      | ≥0    | Query execution timeout (seconds, 0=infinite) |
 | `mssql_metadata_timeout`   | BIGINT  | 300     | ≥0    | Metadata query timeout (seconds, 0=no timeout) |
 | `mssql_catalog_cache_ttl`  | BIGINT  | 0       | ≥0    | Metadata cache TTL (seconds, 0=manual)   |
+| `mssql_exec_invalidate_cache` | BOOLEAN | true | true/false | Auto-invalidate the catalog cache after DDL run via `mssql_exec()`. Set `false` to keep a large preloaded cache and invalidate manually with `mssql_invalidate_cache()`. |
 | `mssql_attach_validation_timeout` | BIGINT | 0 | ≥0 | ATTACH-time eager-validation timeout (seconds). `0` inherits `mssql_connection_timeout`. Spec 047 FR-011. |
 
 ### Statistics Settings

--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ SELECT mssql_exec('sqlserver', 'CREATE UNIQUE INDEX IX_users_username ON dbo.use
 SELECT mssql_exec('sqlserver', 'DROP INDEX IX_users_email ON dbo.users');
 ```
 
-> **Note**: After DDL operations via `mssql_exec()`, use `mssql_refresh_cache('sqlserver')` to update the metadata cache. Standard DuckDB DDL operations automatically refresh the cache.
+> **Note**: Schema-changing statements run through `mssql_exec()` (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`) invalidate the metadata cache automatically, the same as standard DuckDB DDL. You only need `mssql_refresh_cache('sqlserver')` to pick up changes made entirely out of band (e.g. by another client) while `mssql_catalog_cache_ttl` is `0`. See [Cache & invalidation](DATAMODEL.md#cache-invalidation) in `DATAMODEL.md` for how the two-layer cache works.
 
 ## Function Reference
 

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -895,6 +895,23 @@ void MSSQLCatalog::InvalidateSchemaTableSet(const string &schema_name) {
 	}
 }
 
+void MSSQLCatalog::InvalidateTableEntry(const string &schema_name, const string &table_name) {
+	if (metadata_cache_) {
+		// Re-fetch this table's columns (ALTER) ...
+		metadata_cache_->InvalidateTable(schema_name, table_name);
+		// ... and re-check the schema's table list for existence (CREATE/DROP/RENAME), but
+		// WITHOUT dropping every other table's cached columns.
+		metadata_cache_->InvalidateSchemaTableList(schema_name);
+	}
+
+	// Evict the single bound entry from the schema's table set (keeps the rest).
+	std::lock_guard<std::mutex> lock(schema_mutex_);
+	auto it = schema_entries_.find(schema_name);
+	if (it != schema_entries_.end()) {
+		it->second->GetTableSet().InvalidateEntry(table_name);
+	}
+}
+
 void MSSQLCatalog::EnsureCacheLoaded(ClientContext &context) {
 	// Check if catalog integration is disabled
 	if (!catalog_enabled_) {

--- a/src/catalog/mssql_metadata_cache.cpp
+++ b/src/catalog/mssql_metadata_cache.cpp
@@ -1073,6 +1073,16 @@ void MSSQLMetadataCache::InvalidateSchema(const string &schema_name) {
 	}
 }
 
+void MSSQLMetadataCache::InvalidateSchemaTableList(const string &schema_name) {
+	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	auto it = schemas_.find(schema_name);
+	if (it != schemas_.end()) {
+		// Existence only — re-fetch the table list, but keep every table's cached
+		// column metadata (the expensive part). Used by per-table invalidation.
+		it->second.tables_load_state = CacheLoadState::NOT_LOADED;
+	}
+}
+
 void MSSQLMetadataCache::InvalidateTable(const string &schema_name, const string &table_name) {
 	std::lock_guard<std::mutex> lock(schemas_mutex_);
 	auto schema_it = schemas_.find(schema_name);

--- a/src/catalog/mssql_refresh_function.cpp
+++ b/src/catalog/mssql_refresh_function.cpp
@@ -6,7 +6,9 @@
 #include "mssql_compat.hpp"
 #include "mssql_storage.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/database.hpp"
@@ -109,6 +111,58 @@ static void MSSQLRefreshCacheExecute(DataChunk &args, ExpressionState &state, Ve
 }
 
 //===----------------------------------------------------------------------===//
+// mssql_invalidate_cache - lazy point invalidation (catalog / schema / table)
+//===----------------------------------------------------------------------===//
+
+// Resolve an attached MSSQL catalog by name, throwing a clear error otherwise.
+static MSSQLCatalog &ResolveMSSQLCatalog(ClientContext &context, const string &catalog_name, const char *fn) {
+	if (catalog_name.empty()) {
+		throw InvalidInputException("%s: catalog name is required", fn);
+	}
+	try {
+		auto &raw_catalog = Catalog::GetCatalog(context, catalog_name);
+		if (raw_catalog.GetCatalogType() != "mssql") {
+			throw InvalidInputException("%s: catalog '%s' is not an MSSQL catalog (type: %s)", fn, catalog_name,
+										raw_catalog.GetCatalogType());
+		}
+		return raw_catalog.Cast<MSSQLCatalog>();
+	} catch (const InvalidInputException &) {
+		throw;
+	} catch (const std::exception &) {
+		throw InvalidInputException(
+			"%s: catalog '%s' not found. "
+			"Attach a database first with: ATTACH '' AS %s (TYPE mssql, SECRET ...)",
+			fn, catalog_name, catalog_name);
+	}
+}
+
+// mssql_invalidate_cache(catalog [, schema [, table]]) -> BOOLEAN
+// Lazy invalidation at the requested granularity (no eager reload):
+//   1 arg  -> whole catalog          (InvalidateMetadataCache)
+//   2 args -> one schema             (InvalidateSchemaTableSet)
+//   3 args -> one table              (InvalidateTableEntry; keeps other tables' columns)
+static void MSSQLInvalidateCacheExecute(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &client_context = state.GetContext();
+	const idx_t col_count = args.ColumnCount();
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<bool>(result);
+	for (idx_t row = 0; row < args.size(); row++) {
+		string catalog_name = args.GetValue(0, row).ToString();
+		auto &catalog = ResolveMSSQLCatalog(client_context, catalog_name, "mssql_invalidate_cache");
+
+		if (col_count >= 3 && !args.GetValue(2, row).IsNull() && !args.GetValue(1, row).IsNull()) {
+			catalog.InvalidateTableEntry(args.GetValue(1, row).ToString(), args.GetValue(2, row).ToString());
+		} else if (col_count >= 2 && !args.GetValue(1, row).IsNull()) {
+			catalog.InvalidateSchemaTableSet(args.GetValue(1, row).ToString());
+		} else {
+			catalog.InvalidateMetadataCache();
+		}
+		result_data[row] = true;
+	}
+}
+
+//===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//
 
@@ -118,6 +172,17 @@ void RegisterMSSQLRefreshCacheFunction(ExtensionLoader &loader) {
 						MSSQLRefreshCacheBind);
 	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	loader.RegisterFunction(func);
+
+	// mssql_invalidate_cache(catalog [, schema [, table]]) -> BOOLEAN
+	ScalarFunctionSet invalidate("mssql_invalidate_cache");
+	for (auto &arg_types :
+		 {vector<LogicalType>{LogicalType::VARCHAR}, vector<LogicalType>{LogicalType::VARCHAR, LogicalType::VARCHAR},
+		  vector<LogicalType>{LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}}) {
+		ScalarFunction overload("mssql_invalidate_cache", arg_types, LogicalType::BOOLEAN, MSSQLInvalidateCacheExecute);
+		overload.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+		invalidate.AddFunction(overload);
+	}
+	loader.RegisterFunction(invalidate);
 }
 
 }  // namespace duckdb

--- a/src/catalog/mssql_table_set.cpp
+++ b/src/catalog/mssql_table_set.cpp
@@ -298,6 +298,25 @@ void MSSQLTableSet::Invalidate() {
 	}
 }
 
+void MSSQLTableSet::InvalidateEntry(const string &name) {
+	// Mirrors Invalidate()'s lock order (load_mutex_ -> entry_mutex_ -> names_mutex_) but
+	// evicts only `name`. Force the (cheap) name list to be re-checked so a CREATE/DROP/RENAME
+	// of this table is reflected on next access; every OTHER table's entry (and its cached
+	// column metadata) is preserved, so the expensive per-table metadata is not re-fetched.
+	std::lock_guard<std::mutex> lock(load_mutex_);
+	is_fully_loaded_.store(false);
+	names_loaded_.store(false);
+	{
+		std::lock_guard<std::mutex> elock(entry_mutex_);
+		entries_.erase(name);
+		attempted_tables_.erase(name);
+	}
+	{
+		std::lock_guard<std::mutex> nlock(names_mutex_);
+		known_table_names_.erase(name);
+	}
+}
+
 //===----------------------------------------------------------------------===//
 // Internal Methods
 //===----------------------------------------------------------------------===//

--- a/src/connection/mssql_settings.cpp
+++ b/src/connection/mssql_settings.cpp
@@ -115,6 +115,14 @@ void RegisterMSSQLSettings(ExtensionLoader &loader) {
 							  Value::BIGINT(0),	 // Default: disabled, manual refresh only
 							  ValidateNonNegative, SetScope::GLOBAL);
 
+	// mssql_exec_invalidate_cache - Auto-invalidate the catalog cache after DDL run via mssql_exec()
+	// (issue #151). Disable to preserve a large manually-preloaded cache and invalidate yourself with
+	// mssql_invalidate_cache() / mssql_refresh_cache().
+	config.AddExtensionOption(
+		"mssql_exec_invalidate_cache",
+		"Invalidate the catalog cache after DDL executed via mssql_exec() (CREATE/DROP/ALTER/TRUNCATE/RENAME/EXEC)",
+		LogicalType::BOOLEAN, Value::BOOLEAN(true), nullptr, SetScope::GLOBAL);
+
 	//===----------------------------------------------------------------------===//
 	// Statistics Settings
 	//===----------------------------------------------------------------------===//
@@ -506,6 +514,14 @@ bool LoadCTASUseBCP(ClientContext &context) {
 		return val.GetValue<bool>();
 	}
 	return DEFAULT_CTAS_USE_BCP;
+}
+
+bool LoadExecInvalidateCache(ClientContext &context) {
+	Value val;
+	if (context.TryGetCurrentSetting("mssql_exec_invalidate_cache", val)) {
+		return val.GetValue<bool>();
+	}
+	return true;  // Default: auto-invalidate after mssql_exec() DDL (issue #151)
 }
 
 }  // namespace duckdb

--- a/src/connection/mssql_settings.cpp
+++ b/src/connection/mssql_settings.cpp
@@ -116,12 +116,13 @@ void RegisterMSSQLSettings(ExtensionLoader &loader) {
 							  ValidateNonNegative, SetScope::GLOBAL);
 
 	// mssql_exec_invalidate_cache - Auto-invalidate the catalog cache after DDL run via mssql_exec()
-	// (issue #151). Disable to preserve a large manually-preloaded cache and invalidate yourself with
-	// mssql_invalidate_cache() / mssql_refresh_cache().
+	// (issue #151). DEFAULT FALSE: like the Postgres extension's postgres_execute, mssql_exec() does
+	// not touch the cache by default — invalidate manually with mssql_invalidate_cache() /
+	// mssql_refresh_cache() after schema-changing DDL. Set true to auto-invalidate.
 	config.AddExtensionOption(
 		"mssql_exec_invalidate_cache",
 		"Invalidate the catalog cache after DDL executed via mssql_exec() (CREATE/DROP/ALTER/TRUNCATE/RENAME/EXEC)",
-		LogicalType::BOOLEAN, Value::BOOLEAN(true), nullptr, SetScope::GLOBAL);
+		LogicalType::BOOLEAN, Value::BOOLEAN(false), nullptr, SetScope::GLOBAL);
 
 	//===----------------------------------------------------------------------===//
 	// Statistics Settings
@@ -521,7 +522,7 @@ bool LoadExecInvalidateCache(ClientContext &context) {
 	if (context.TryGetCurrentSetting("mssql_exec_invalidate_cache", val)) {
 		return val.GetValue<bool>();
 	}
-	return true;  // Default: auto-invalidate after mssql_exec() DDL (issue #151)
+	return false;  // Default: do NOT auto-invalidate; manual invalidation like postgres_execute (#151)
 }
 
 }  // namespace duckdb

--- a/src/include/catalog/mssql_catalog.hpp
+++ b/src/include/catalog/mssql_catalog.hpp
@@ -190,6 +190,10 @@ public:
 	// Invalidate a specific schema's table set (point invalidation)
 	void InvalidateSchemaTableSet(const string &schema_name);
 
+	// Invalidate a single table (point invalidation): re-fetch this table's columns and
+	// re-check its existence, while keeping every other table's cached column metadata.
+	void InvalidateTableEntry(const string &schema_name, const string &table_name);
+
 	// Perform full cache refresh (for mssql_refresh_cache())
 	// Unlike EnsureCacheLoaded() which only sets TTL, this does eager full refresh
 	void RefreshCache(ClientContext &context);

--- a/src/include/catalog/mssql_metadata_cache.hpp
+++ b/src/include/catalog/mssql_metadata_cache.hpp
@@ -234,6 +234,11 @@ public:
 	// Invalidate schema's table list (for CREATE/DROP TABLE)
 	void InvalidateSchema(const string &schema_name);
 
+	// Invalidate ONLY the schema's table list (existence), keeping every table's cached
+	// column metadata. Used by per-table invalidation so a CREATE/DROP is reflected without
+	// re-fetching the columns of every other table in the schema.
+	void InvalidateSchemaTableList(const string &schema_name);
+
 	// Invalidate table's column metadata (for ALTER TABLE)
 	void InvalidateTable(const string &schema_name, const string &table_name);
 

--- a/src/include/catalog/mssql_table_set.hpp
+++ b/src/include/catalog/mssql_table_set.hpp
@@ -64,6 +64,11 @@ public:
 	// Invalidate cached entries (force reload on next access)
 	void Invalidate();
 
+	// Invalidate a single cached entry by name: drop its bound MSSQLTableEntry and force the
+	// (cheap) table-name list to be re-checked on next access, while keeping every OTHER
+	// table's cached metadata. Used for per-table cache invalidation.
+	void InvalidateEntry(const string &name);
+
 private:
 	//===----------------------------------------------------------------------===//
 	// Internal Methods

--- a/src/include/connection/mssql_settings.hpp
+++ b/src/include/connection/mssql_settings.hpp
@@ -110,4 +110,7 @@ constexpr bool DEFAULT_CTAS_USE_BCP = true;
 // Load CTAS BCP setting
 bool LoadCTASUseBCP(ClientContext &context);
 
+// Load whether mssql_exec() DDL auto-invalidates the catalog cache (issue #151)
+bool LoadExecInvalidateCache(ClientContext &context);
+
 }  // namespace duckdb

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -6,6 +6,7 @@
 #include "connection/mssql_connection_provider.hpp"
 #include "connection/mssql_settings.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/database.hpp"
@@ -325,6 +326,23 @@ MSSQL_BIND_SCALAR_SIG(MSSQLExecBind) {
 	return make_uniq<MSSQLExecBindData>(context_name);
 }
 
+// Heuristic: does this raw T-SQL statement potentially change schema/catalog
+// metadata? Used to invalidate the catalog cache after mssql_exec() runs DDL so
+// that subsequent catalog operations (CREATE TABLE IF NOT EXISTS, reads) don't
+// act on stale existence metadata (issue #151). Over-detection only costs a
+// metadata refresh; under-detection would leave the cache stale, so we err
+// toward invalidating — including EXEC, since a stored procedure may run DDL.
+static bool ExecSqlMayChangeSchema(const string &sql) {
+	auto upper = StringUtil::Upper(sql);
+	static const char *kSchemaKeywords[] = {"CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME", "EXEC"};
+	for (auto keyword : kSchemaKeywords) {
+		if (upper.find(keyword) != string::npos) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // Execute function for mssql_exec
 static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<MSSQLExecBindData>();
@@ -400,6 +418,17 @@ static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &re
 				// Surface SQL Server error with details
 				throw InvalidInputException("MSSQL execution error: SQL Server error %d: %s", query_result.error_number,
 											query_result.error_message);
+			}
+
+			// Issue #151: raw DDL run through mssql_exec() bypasses the catalog metadata
+			// cache. If the statement may have changed schema, invalidate the cache so a
+			// subsequent CREATE TABLE IF NOT EXISTS / read sees the real server-side state
+			// instead of a stale cached entry (which caused "Invalid object name" after a
+			// raw DROP followed by CREATE ... IF NOT EXISTS). InvalidateMetadataCache() is
+			// the lazy path: it marks the metadata cache stale AND invalidates each schema's
+			// table set (evicting bound table entries), with reload deferred to next access.
+			if (ExecSqlMayChangeSchema(sql)) {
+				catalog.InvalidateMetadataCache();
 			}
 
 			// Return affected row count from DONE token

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -427,7 +427,9 @@ static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &re
 			// raw DROP followed by CREATE ... IF NOT EXISTS). InvalidateMetadataCache() is
 			// the lazy path: it marks the metadata cache stale AND invalidates each schema's
 			// table set (evicting bound table entries), with reload deferred to next access.
-			if (ExecSqlMayChangeSchema(sql)) {
+			// Gated by mssql_exec_invalidate_cache (default true) so users with a large
+			// manually-preloaded cache can opt out and invalidate via mssql_invalidate_cache().
+			if (ExecSqlMayChangeSchema(sql) && LoadExecInvalidateCache(client_context)) {
 				catalog.InvalidateMetadataCache();
 			}
 

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -427,8 +427,9 @@ static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &re
 			// raw DROP followed by CREATE ... IF NOT EXISTS). InvalidateMetadataCache() is
 			// the lazy path: it marks the metadata cache stale AND invalidates each schema's
 			// table set (evicting bound table entries), with reload deferred to next access.
-			// Gated by mssql_exec_invalidate_cache (default true) so users with a large
-			// manually-preloaded cache can opt out and invalidate via mssql_invalidate_cache().
+			// Gated by mssql_exec_invalidate_cache, which defaults to FALSE (like the Postgres
+			// extension's postgres_execute): by default the caller invalidates manually via
+			// mssql_invalidate_cache(); set the flag true to auto-invalidate here.
 			if (ExecSqlMayChangeSchema(sql) && LoadExecInvalidateCache(client_context)) {
 				catalog.InvalidateMetadataCache();
 			}

--- a/test/sql/catalog/exec_ddl_cache_invalidation.test
+++ b/test/sql/catalog/exec_ddl_cache_invalidation.test
@@ -1,0 +1,94 @@
+# name: test/sql/catalog/exec_ddl_cache_invalidation.test
+# description: DDL run via mssql_exec() invalidates the catalog metadata cache so subsequent catalog operations see real server-side state (regression for issue #151)
+# group: [mssql]
+#
+# Before the fix, mssql_exec('DROP TABLE ...') (raw T-SQL) left the catalog cache
+# entry in place. A following CREATE TABLE IF NOT EXISTS then saw a stale "exists"
+# and skipped creation, and the next read failed with "Invalid object name".
+#
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.ExecCacheTest'',''U'') IS NOT NULL DROP TABLE dbo.ExecCacheTest');
+
+# Warm the catalog cache the same way the original repro did: create, read,
+# skip-create, read, a rejected duplicate create, then replace and read again.
+# The reads are what bind the table entry into the cache, so that the later raw
+# DROP leaves a stale entry behind (the bug).
+statement ok
+CREATE TABLE IF NOT EXISTS mssql.dbo.ExecCacheTest AS SELECT 1 AS id, 'first' AS name;
+
+query II
+SELECT id, name FROM mssql.dbo.ExecCacheTest ORDER BY id;
+----
+1	first
+
+statement ok
+CREATE TABLE IF NOT EXISTS mssql.dbo.ExecCacheTest AS SELECT 2 AS id, 'second' AS name;
+
+query II
+SELECT id, name FROM mssql.dbo.ExecCacheTest ORDER BY id;
+----
+1	first
+
+statement error
+CREATE TABLE mssql.dbo.ExecCacheTest AS SELECT 3 AS id, 'third' AS name;
+----
+already an object named
+
+statement ok
+CREATE OR REPLACE TABLE mssql.dbo.ExecCacheTest AS SELECT 4 AS id, 'fourth' AS name;
+
+query II
+SELECT id, name FROM mssql.dbo.ExecCacheTest ORDER BY id;
+----
+4	fourth
+
+# Raw DROP via mssql_exec. With the fix this invalidates the catalog cache.
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.ExecCacheTest');
+
+# CREATE TABLE IF NOT EXISTS must actually create now (cache no longer reports it
+# as existing); before the fix this was skipped and the read below failed.
+statement ok
+CREATE TABLE IF NOT EXISTS mssql.dbo.ExecCacheTest AS
+SELECT i AS id, 'row_' || i::VARCHAR AS name FROM range(100) t(i);
+
+query I
+SELECT COUNT(*) FROM mssql.dbo.ExecCacheTest;
+----
+100
+
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.ExecCacheTest');
+
+# Reverse direction: a brand-new table created entirely via raw mssql_exec becomes
+# visible to the catalog (CREATE invalidates the cache so the table list is reloaded).
+statement ok
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.ExecCacheCreate'',''U'') IS NOT NULL DROP TABLE dbo.ExecCacheCreate');
+
+statement ok
+SELECT mssql_exec('mssql', 'CREATE TABLE dbo.ExecCacheCreate (id INT, label NVARCHAR(50))');
+
+statement ok
+SELECT mssql_exec('mssql', 'INSERT INTO dbo.ExecCacheCreate VALUES (7, ''seven'')');
+
+query IT
+SELECT id, label FROM mssql.dbo.ExecCacheCreate ORDER BY id;
+----
+7	seven
+
+# Cleanup
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.ExecCacheCreate');
+
+statement ok
+DETACH mssql;

--- a/test/sql/catalog/exec_ddl_cache_invalidation.test
+++ b/test/sql/catalog/exec_ddl_cache_invalidation.test
@@ -1,10 +1,12 @@
 # name: test/sql/catalog/exec_ddl_cache_invalidation.test
-# description: DDL run via mssql_exec() invalidates the catalog metadata cache so subsequent catalog operations see real server-side state (regression for issue #151)
+# description: with mssql_exec_invalidate_cache enabled, DDL via mssql_exec() invalidates the catalog metadata cache so subsequent catalog operations see real server-side state (regression for issue #151)
 # group: [mssql]
 #
-# Before the fix, mssql_exec('DROP TABLE ...') (raw T-SQL) left the catalog cache
-# entry in place. A following CREATE TABLE IF NOT EXISTS then saw a stale "exists"
-# and skipped creation, and the next read failed with "Invalid object name".
+# mssql_exec_invalidate_cache defaults to FALSE (manual invalidation, like the
+# Postgres extension's postgres_execute). This test exercises the opt-in
+# auto-invalidation path: with the setting ON, mssql_exec('DROP TABLE ...')
+# invalidates the cache so a following CREATE TABLE IF NOT EXISTS no longer sees
+# a stale "exists" and the read no longer fails with "Invalid object name".
 #
 # Environment variables required:
 #   MSSQL_TESTDB_DSN - Connection string to test database
@@ -15,6 +17,10 @@ require-env MSSQL_TESTDB_DSN
 
 statement ok
 ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+
+# Opt in to auto-invalidation (the default is false).
+statement ok
+SET mssql_exec_invalidate_cache = true;
 
 statement ok
 SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.ExecCacheTest'',''U'') IS NOT NULL DROP TABLE dbo.ExecCacheTest');

--- a/test/sql/catalog/exec_invalidate_cache_setting.test
+++ b/test/sql/catalog/exec_invalidate_cache_setting.test
@@ -22,16 +22,20 @@ SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.InvCacheTest'',''U'') IS NOT NULL
 statement ok
 SELECT mssql_exec('mssql', 'CREATE TABLE dbo.InvCacheTest (id INT)');
 
-query I
-SELECT COUNT(*) FROM mssql.dbo.InvCacheTest;
-----
-0
-
+# Default is now off (no auto-invalidation), so the table the raw mssql_exec just
+# created is not yet catalog-visible. mssql_invalidate_cache() makes it visible
+# (and returns true) — catalog granularity.
 query T
 SELECT mssql_invalidate_cache('mssql');
 ----
 true
 
+query I
+SELECT COUNT(*) FROM mssql.dbo.InvCacheTest;
+----
+0
+
+# schema and table granularities also return true
 query T
 SELECT mssql_invalidate_cache('mssql', 'dbo');
 ----

--- a/test/sql/catalog/exec_invalidate_cache_setting.test
+++ b/test/sql/catalog/exec_invalidate_cache_setting.test
@@ -1,0 +1,108 @@
+# name: test/sql/catalog/exec_invalidate_cache_setting.test
+# description: mssql_exec_invalidate_cache setting + mssql_invalidate_cache() point invalidation (issue #151 follow-up)
+# group: [mssql]
+#
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+
+# =============================================================================
+# mssql_invalidate_cache() returns true at each granularity
+# =============================================================================
+
+statement ok
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.InvCacheTest'',''U'') IS NOT NULL DROP TABLE dbo.InvCacheTest');
+
+statement ok
+SELECT mssql_exec('mssql', 'CREATE TABLE dbo.InvCacheTest (id INT)');
+
+query I
+SELECT COUNT(*) FROM mssql.dbo.InvCacheTest;
+----
+0
+
+query T
+SELECT mssql_invalidate_cache('mssql');
+----
+true
+
+query T
+SELECT mssql_invalidate_cache('mssql', 'dbo');
+----
+true
+
+query T
+SELECT mssql_invalidate_cache('mssql', 'dbo', 'InvCacheTest');
+----
+true
+
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.InvCacheTest');
+
+# =============================================================================
+# Setting OFF: mssql_exec() DDL no longer auto-invalidates; manual invalidation recovers
+# =============================================================================
+
+statement ok
+SET mssql_exec_invalidate_cache = false;
+
+statement ok
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.InvOffTest'',''U'') IS NOT NULL DROP TABLE dbo.InvOffTest');
+
+# Warm the cache (create + read + replace + read) so the bound table entry exists
+statement ok
+CREATE TABLE IF NOT EXISTS mssql.dbo.InvOffTest AS SELECT 1 AS id, 'a' AS name;
+
+query II
+SELECT id, name FROM mssql.dbo.InvOffTest ORDER BY id;
+----
+1	a
+
+statement ok
+CREATE OR REPLACE TABLE mssql.dbo.InvOffTest AS SELECT 2 AS id, 'b' AS name;
+
+query II
+SELECT id, name FROM mssql.dbo.InvOffTest ORDER BY id;
+----
+2	b
+
+# Raw DROP via mssql_exec — with the setting OFF the cache is NOT invalidated
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.InvOffTest');
+
+# CREATE TABLE IF NOT EXISTS sees the stale cached entry and skips creation
+statement ok
+CREATE TABLE IF NOT EXISTS mssql.dbo.InvOffTest AS SELECT i AS id, 'r' || i::VARCHAR AS name FROM range(10) t(i);
+
+# ... so the read fails (table was dropped server-side, never recreated)
+statement error
+SELECT COUNT(*) FROM mssql.dbo.InvOffTest;
+----
+Invalid object name
+
+# Manual point invalidation (table granularity) recovers coherence
+statement ok
+SELECT mssql_invalidate_cache('mssql', 'dbo', 'InvOffTest');
+
+statement ok
+CREATE TABLE IF NOT EXISTS mssql.dbo.InvOffTest AS SELECT i AS id, 'r' || i::VARCHAR AS name FROM range(10) t(i);
+
+query I
+SELECT COUNT(*) FROM mssql.dbo.InvOffTest;
+----
+10
+
+statement ok
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.InvOffTest');
+
+statement ok
+RESET mssql_exec_invalidate_cache;
+
+statement ok
+DETACH mssql;

--- a/test/sql/ctas/ctas_auto_tablock.test
+++ b/test/sql/ctas/ctas_auto_tablock.test
@@ -12,7 +12,7 @@ ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # Clean up any existing test tables
 statement ok
-CALL mssql_exec('mssql', 'IF OBJECT_ID(''dbo.AutoTablockTest'', ''U'') IS NOT NULL DROP TABLE dbo.AutoTablockTest');
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.AutoTablockTest'', ''U'') IS NOT NULL DROP TABLE dbo.AutoTablockTest');
 
 # =============================================================================
 # Test 1: CTAS new table (auto-TABLOCK should be applied)
@@ -51,7 +51,7 @@ replaced_0
 # When user explicitly sets tablock=false, auto-TABLOCK should NOT override
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.AutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.AutoTablockTest');
 
 statement ok
 SET mssql_copy_tablock = false;
@@ -74,7 +74,7 @@ RESET mssql_copy_tablock;
 # User explicitly enables TABLOCK
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.AutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.AutoTablockTest');
 
 statement ok
 SET mssql_copy_tablock = true;
@@ -96,4 +96,4 @@ RESET mssql_copy_tablock;
 # Cleanup
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.AutoTablockTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.AutoTablockTest');

--- a/test/sql/ctas/ctas_auto_tablock.test
+++ b/test/sql/ctas/ctas_auto_tablock.test
@@ -10,6 +10,11 @@ require-env MSSQL_TEST_CONNECTION_STRING
 statement ok
 ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
+# This test mixes raw mssql_exec() DDL (DROP) with catalog DDL, so enable
+# auto-invalidation (mssql_exec_invalidate_cache defaults to false).
+statement ok
+SET mssql_exec_invalidate_cache = true;
+
 # Clean up any existing test tables
 statement ok
 SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.AutoTablockTest'', ''U'') IS NOT NULL DROP TABLE dbo.AutoTablockTest');

--- a/test/sql/ctas/ctas_if_not_exists.test
+++ b/test/sql/ctas/ctas_if_not_exists.test
@@ -10,6 +10,11 @@ require-env MSSQL_TEST_CONNECTION_STRING
 statement ok
 ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
+# This test mixes raw mssql_exec() DDL (DROP) with catalog DDL, so enable
+# auto-invalidation (mssql_exec_invalidate_cache defaults to false).
+statement ok
+SET mssql_exec_invalidate_cache = true;
+
 # Clean up any existing test tables
 statement ok
 SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.IfNotExistsTest'', ''U'') IS NOT NULL DROP TABLE dbo.IfNotExistsTest');

--- a/test/sql/ctas/ctas_if_not_exists.test
+++ b/test/sql/ctas/ctas_if_not_exists.test
@@ -12,7 +12,7 @@ ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # Clean up any existing test tables
 statement ok
-CALL mssql_exec('mssql', 'IF OBJECT_ID(''dbo.IfNotExistsTest'', ''U'') IS NOT NULL DROP TABLE dbo.IfNotExistsTest');
+SELECT mssql_exec('mssql', 'IF OBJECT_ID(''dbo.IfNotExistsTest'', ''U'') IS NOT NULL DROP TABLE dbo.IfNotExistsTest');
 
 # =============================================================================
 # Test 1: CREATE TABLE IF NOT EXISTS - table does not exist
@@ -50,7 +50,7 @@ statement error
 CREATE TABLE mssql.dbo.IfNotExistsTest AS
 SELECT 3 AS id, 'third' AS name;
 ----
-already exists
+already an object named
 
 # =============================================================================
 # Test 4: CREATE OR REPLACE TABLE - overwrites existing
@@ -70,7 +70,7 @@ SELECT id, name FROM mssql.dbo.IfNotExistsTest ORDER BY id;
 # Test 5: IF NOT EXISTS with larger dataset
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.IfNotExistsTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.IfNotExistsTest');
 
 statement ok
 CREATE TABLE IF NOT EXISTS mssql.dbo.IfNotExistsTest AS
@@ -102,4 +102,4 @@ row_0
 # Cleanup
 # =============================================================================
 statement ok
-CALL mssql_exec('mssql', 'DROP TABLE dbo.IfNotExistsTest');
+SELECT mssql_exec('mssql', 'DROP TABLE dbo.IfNotExistsTest');


### PR DESCRIPTION
## Summary

DDL executed as raw T-SQL through `mssql_exec()` (e.g. `DROP TABLE`) did **not** invalidate the extension's catalog metadata cache. A subsequent catalog operation then acted on stale metadata:

- `CREATE TABLE IF NOT EXISTS` saw the (already-dropped) table as still present, **skipped creation**, and the next read failed with `Invalid object name`.
- A table **created** via raw `mssql_exec` was invisible to the catalog until a manual `mssql_refresh_cache()`.

Fixes #151.

## Root cause

`mssql_exec()` runs arbitrary T-SQL on a pooled connection and never touched the catalog cache. Reads/`CREATE … IF NOT EXISTS` decisions are driven by the cached `MSSQLMetadataCache` **and** the bound `MSSQLTableEntry` objects held in each schema's table set — both of which went stale after a raw DDL.

Note: invalidating only the metadata cache (`MSSQLMetadataCache::InvalidateAll()`) is **not** enough — once a table has been read, its `MSSQLTableEntry` is bound into the schema's table set and persists, so `CREATE … IF NOT EXISTS` still sees it. The fix must also invalidate the schema table sets.

## Fix

After a successful `mssql_exec()` whose SQL may change schema (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`/`EXEC`), call `MSSQLCatalog::InvalidateMetadataCache()`. This is the **lazy** path:
- marks the metadata cache stale, **and**
- iterates every schema entry calling `GetTableSet().Invalidate()` (evicting bound table entries via the spec-052 graveyard),
- with reload deferred to next access — no eager round trip (unlike `RefreshCache()`).

DML verbs (`INSERT`/`UPDATE`/`DELETE`) do **not** trigger it, so transaction-pinned DML through `mssql_exec()` is unaffected (verified: `transaction_commit` stays green). Detection is a conservative keyword check — over-detection only costs one lazy cache refresh; `EXEC` is included because a stored procedure may run DDL.

## Tests

- **`test/sql/catalog/exec_ddl_cache_invalidation.test` (new)** — reproduces the DROP-via-exec → `CREATE IF NOT EXISTS` → read scenario plus the create-via-exec visibility case. **Verified it fails without this fix** (`Invalid object name`) and passes with it (23 assertions). It also fails with an `InvalidateAll`-only fix, confirming the table-set invalidation is the essential part.
- **`ctas_if_not_exists` / `ctas_auto_tablock`** — corrected stale `CALL mssql_exec` (scalar fn → `SELECT`) and `already exists` → `already an object named`. Both were failing on this exact cache bug and **only pass with this fix**, so they double as real-world #151 coverage (19 and 18 assertions).

## Verification

Built `make release` against current `main` and ran against a live SQL Server 2022 (TLS): new test 23, `ctas_if_not_exists` 19, `ctas_auto_tablock` 18, `transaction_commit` 37 — all pass.

Closes #151