### PR TITLE
docs: auto-updating download metrics (README chart + DuckDB-Wasm interactive page)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy metrics page
+
+# Publishes web/ (the DuckDB-Wasm interactive download-metrics chart) to
+# GitHub Pages. Requires Settings -> Pages -> "Build and deployment" Source
+# set to "GitHub Actions". Served at https://<owner>.github.io/<repo>/.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/update-metrics.yml
+++ b/.github/workflows/update-metrics.yml
@@ -28,9 +28,16 @@ jobs:
           python-version: "3.x"
 
       - name: Install DuckDB CLI
+        # Pinned version + checksum (not "latest"): this workflow holds
+        # contents:write to the default branch, so the CLI it executes must be
+        # exactly the reviewed bytes. Update both values together when bumping.
+        env:
+          DUCKDB_VERSION: v1.5.3
+          DUCKDB_SHA256: 35caef1fecbc8d7e2c07de4fd2cdefc5189ec9ba9e1cca228fb1a1c48cc52a8a
         run: |
           curl -fsSL -o /tmp/duckdb.zip \
-            https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip
+            "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
+          echo "${DUCKDB_SHA256}  /tmp/duckdb.zip" | sha256sum -c -
           unzip -o /tmp/duckdb.zip -d "$HOME/.local/bin"
           "$HOME/.local/bin/duckdb" --version
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/update-metrics.yml
+++ b/.github/workflows/update-metrics.yml
@@ -1,0 +1,54 @@
+name: Update download metrics
+
+# Keeps the README badges, latest published version and the download-metrics
+# chart in sync with the DuckDB Community Extensions metrics endpoint.
+# Scheduled weekly; also runnable on demand. Scheduled runs only fire on the
+# repository's default branch.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC (the weekly archive refreshes daily ~04:00Z)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-metrics
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL -o /tmp/duckdb.zip \
+            https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip
+          unzip -o /tmp/duckdb.zip -d "$HOME/.local/bin"
+          "$HOME/.local/bin/duckdb" --version
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Update README metrics (data fetched/aggregated by DuckDB)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/update_download_metrics.py
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -z "$(git status --porcelain README.md docs/assets/download-metrics.svg)" ]]; then
+            echo "No metrics changes."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md docs/assets/download-metrics.svg
+          git commit -m "chore(docs): refresh download metrics [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A DuckDB extension for connecting to Microsoft SQL Server databases using native
 
 ![Weekly downloads of the mssql DuckDB community extension](docs/assets/download-metrics.svg)
 
+📊 **[Interactive chart](https://hugr-lab.github.io/mssql-extension/)** — queried live in your browser with DuckDB-Wasm.
+
 > Latest published version **v0.2.1** · **4,441** downloads in the trailing 7 days (snapshot 2026-06-09 UTC). Counts are a Cloudflare estimate of `INSTALL mssql FROM community` events, aggregated across DuckDB versions and platforms. Source: [DuckDB Community Extensions download metrics](https://duckdb.org/community_extensions/download_metrics).
 
 <!-- METRICS-CHART:END -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
+<!-- METRICS-BADGES:START -->
+
+[![CI](https://github.com/hugr-lab/mssql-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/hugr-lab/mssql-extension/actions/workflows/ci.yml)
+[![DuckDB](https://img.shields.io/static/v1?label=duckdb&message=v1.4.1%2B&color=blue)](https://github.com/duckdb/duckdb/releases)
+[![Latest release](https://img.shields.io/github/v/release/hugr-lab/mssql-extension?label=release&color=blue)](https://github.com/hugr-lab/mssql-extension/releases/latest)
+[![Community downloads per week](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcommunity-extensions.duckdb.org%2Fdownloads-last-week.json&query=%24.mssql&label=downloads%2Fweek&color=brightgreen)](https://duckdb.org/community_extensions/download_metrics)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/hugr-lab/mssql-extension?style=flat&color=informational)](https://github.com/hugr-lab/mssql-extension/stargazers)
+
+<!-- METRICS-BADGES:END -->
+
 # DuckDB MSSQL Extension
 
 A DuckDB extension for connecting to Microsoft SQL Server databases using native TDS protocol - no ODBC, JDBC, or external drivers required.
+
+<!-- METRICS-CHART:START -->
+
+### 📈 Community Extension Downloads
+
+![Weekly downloads of the mssql DuckDB community extension](docs/assets/download-metrics.svg)
+
+> Latest published version **v0.2.1** · **4,441** downloads in the trailing 7 days (snapshot 2026-06-09 UTC). Counts are a Cloudflare estimate of `INSTALL mssql FROM community` events, aggregated across DuckDB versions and platforms. Source: [DuckDB Community Extensions download metrics](https://duckdb.org/community_extensions/download_metrics).
+
+<!-- METRICS-CHART:END -->
 
 > **Experimental**: This extension is under active development. APIs and behavior may change between releases. We welcome contributions, bug reports, and testing feedback!
 

--- a/docs/assets/download-metrics.svg
+++ b/docs/assets/download-metrics.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="280" viewBox="0 0 760 280" role="img" aria-label="Weekly downloads of the DuckDB mssql community extension">
+  <defs>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6c344" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#f6c344" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="760" height="280" rx="10" fill="#ffffff" stroke="#e3e8ee"/>
+  <text x="56" y="26" font-size="15" font-weight="700" fill="#2b3a4a">DuckDB mssql extension &#8212; weekly downloads</text>
+  <text x="736" y="26" font-size="12" fill="#8a94a6" text-anchor="end">4,441/wk total</text>
+  <line x1="56.0" y1="232.0" x2="736.0" y2="232.0" stroke="#e3e8ee" stroke-width="1"/>
+  <line x1="56.0" y1="185.0" x2="736.0" y2="185.0" stroke="#e3e8ee" stroke-width="1"/>
+  <line x1="56.0" y1="138.0" x2="736.0" y2="138.0" stroke="#e3e8ee" stroke-width="1"/>
+  <line x1="56.0" y1="91.0" x2="736.0" y2="91.0" stroke="#e3e8ee" stroke-width="1"/>
+  <line x1="56.0" y1="44.0" x2="736.0" y2="44.0" stroke="#e3e8ee" stroke-width="1"/>
+  <text x="48.0" y="232.0" font-size="11" fill="#8a94a6" text-anchor="end" dominant-baseline="middle">0</text>
+  <text x="48.0" y="185.0" font-size="11" fill="#8a94a6" text-anchor="end" dominant-baseline="middle">5k</text>
+  <text x="48.0" y="138.0" font-size="11" fill="#8a94a6" text-anchor="end" dominant-baseline="middle">10k</text>
+  <text x="48.0" y="91.0" font-size="11" fill="#8a94a6" text-anchor="end" dominant-baseline="middle">15k</text>
+  <text x="48.0" y="44.0" font-size="11" fill="#8a94a6" text-anchor="end" dominant-baseline="middle">20k</text>
+  <polygon points="56.0,232.0 56.0,229.1 90.0,224.8 124.0,225.1 158.0,223.4 192.0,220.5 226.0,218.3 260.0,196.6 294.0,179.7 328.0,180.9 362.0,114.7 396.0,163.9 430.0,208.4 464.0,209.1 498.0,208.9 532.0,206.3 566.0,206.6 600.0,201.5 634.0,196.9 668.0,190.8 702.0,193.4 736.0,190.3 736.0,232.0" fill="url(#area)"/>
+  <polyline points="56.0,229.1 90.0,224.8 124.0,225.1 158.0,223.4 192.0,220.5 226.0,218.3 260.0,196.6 294.0,179.7 328.0,180.9 362.0,114.7 396.0,163.9 430.0,208.4 464.0,209.1 498.0,208.9 532.0,206.3 566.0,206.6 600.0,201.5 634.0,196.9 668.0,190.8 702.0,193.4 736.0,190.3" fill="none" stroke="#f6c344" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="56.0" cy="229.1" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="90.0" cy="224.8" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="124.0" cy="225.1" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="158.0" cy="223.4" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="192.0" cy="220.5" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="226.0" cy="218.3" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="260.0" cy="196.6" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="294.0" cy="179.7" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="328.0" cy="180.9" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="362.0" cy="114.7" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="396.0" cy="163.9" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="430.0" cy="208.4" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="464.0" cy="209.1" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="498.0" cy="208.9" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="532.0" cy="206.3" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="566.0" cy="206.6" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="600.0" cy="201.5" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="634.0" cy="196.9" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="668.0" cy="190.8" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="702.0" cy="193.4" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="736.0" cy="190.3" r="2.6" fill="#fff" stroke="#f6c344" stroke-width="2"/>
+  <circle cx="736.0" cy="190.3" r="4.5" fill="#f6c344"/><text x="736.0" y="178.3" font-size="13" font-weight="700" fill="#d4960b" text-anchor="end">4,441</text>
+  <text x="56.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">01-25</text>
+  <text x="124.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">02-08</text>
+  <text x="192.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">02-22</text>
+  <text x="260.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">03-08</text>
+  <text x="328.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">03-22</text>
+  <text x="396.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">04-05</text>
+  <text x="464.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">04-19</text>
+  <text x="532.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">05-03</text>
+  <text x="600.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">05-17</text>
+  <text x="668.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">05-31</text>
+  <text x="736.0" y="250.0" font-size="10" fill="#8a94a6" text-anchor="middle">06-09</text>
+  <text x="56" y="270" font-size="10" fill="#aab2c0">Source: duckdb.org/community_extensions/download_metrics &#183; downloads in the trailing 7 days, sampled weekly</text>
+</svg>

--- a/scripts/update_download_metrics.py
+++ b/scripts/update_download_metrics.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Update README badges, version and the download-metrics chart.
+
+The data is fetched and aggregated *with DuckDB itself* (dogfooding) — the same
+`read_json` queries the DuckDB Community Extensions metrics page documents:
+
+  - https://community-extensions.duckdb.org/downloads-last-week.json
+        rolling "downloads in the last 7 days" snapshot, keyed by extension name.
+  - https://community-extensions.duckdb.org/download-stats-weekly/{year}/{week}.json
+        the same snapshot archived once per ISO week -> our time series.
+
+DuckDB (httpfs + read_json) does the fetch/aggregation; this script renders the
+result into docs/assets/download-metrics.svg (a self-contained SVG line chart
+that GitHub renders inline — README HTML is sanitized, so no JS/WASM there) and
+rewrites the managed block in README.md delimited by
+  <!-- DOWNLOAD-METRICS:START --> ... <!-- DOWNLOAD-METRICS:END -->
+
+See https://duckdb.org/community_extensions/download_metrics
+"""
+
+import datetime
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+EXTENSION = "mssql"
+REPO = os.environ.get("GITHUB_REPOSITORY", "hugr-lab/mssql-extension")
+START_YEAR = 2026  # weekly archive begins 2026-W01 (week of 2026-01-04)
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+README = os.path.join(ROOT, "README.md")
+SVG = os.path.join(ROOT, "docs", "assets", "download-metrics.svg")
+DESCRIPTION = os.path.join(ROOT, "description.yml")
+
+LAST_WEEK_URL = "https://community-extensions.duckdb.org/downloads-last-week.json"
+WEEKLY_URL = "https://community-extensions.duckdb.org/download-stats-weekly/{year}/{week}.json"
+
+# Two managed regions: a shields badge row above the H1 (h3-duckdb convention)
+# and the download chart under the lead paragraph.
+BADGES_BEGIN = "<!-- METRICS-BADGES:START -->"
+BADGES_END = "<!-- METRICS-BADGES:END -->"
+CHART_BEGIN = "<!-- METRICS-CHART:START -->"
+CHART_END = "<!-- METRICS-CHART:END -->"
+
+DUCKDB_MIN_VERSION = "v1.4.1"  # minimum supported DuckDB (see README Prerequisites)
+LICENSE_NAME = "MIT"
+
+UA = {"User-Agent": "mssql-extension-metrics-bot/1.0"}
+
+
+# --------------------------------------------------------------------------- #
+# DuckDB-backed fetching / aggregation
+# --------------------------------------------------------------------------- #
+def find_duckdb():
+    """Resolve a DuckDB CLI: $DUCKDB_BIN, the extension's own build, or PATH."""
+    candidates = [
+        os.environ.get("DUCKDB_BIN"),
+        os.path.join(ROOT, "build", "release", "duckdb"),
+        os.path.join(ROOT, "build", "debug", "duckdb"),
+        shutil.which("duckdb"),
+    ]
+    for c in candidates:
+        if c and os.path.exists(c):
+            return c
+    if candidates[-1]:  # shutil.which returned a name on PATH
+        return candidates[-1]
+    raise RuntimeError(
+        "no DuckDB CLI found; set DUCKDB_BIN or install duckdb on PATH"
+    )
+
+
+DUCKDB = None
+
+
+def run_duckdb(sql):
+    """Run SQL via the DuckDB CLI in JSON mode; return parsed rows (list)."""
+    global DUCKDB
+    if DUCKDB is None:
+        DUCKDB = find_duckdb()
+    proc = subprocess.run(
+        [DUCKDB, "-json", "-c", sql],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise DuckDBError(proc.stderr.strip() or "duckdb failed")
+    out = proc.stdout.strip()
+    if not out:
+        return []
+    return json.loads(out)
+
+
+class DuckDBError(RuntimeError):
+    pass
+
+
+def url_literal(urls):
+    quoted = ", ".join("'%s'" % u.replace("'", "''") for u in urls)
+    return "[" + quoted + "]"
+
+
+def fetch_total_last_week():
+    rows = run_duckdb(
+        "INSTALL httpfs; LOAD httpfs;\n"
+        "SELECT %s AS total FROM read_json('%s');" % (EXTENSION, LAST_WEEK_URL)
+    )
+    if not rows or rows[0].get("total") is None:
+        return 0
+    return int(rows[0]["total"])
+
+
+def fetch_series():
+    """Read the weekly archive with DuckDB; one (date, downloads) per week.
+
+    The not-yet-published current ISO week 404s and would abort read_json, so we
+    drop trailing weeks and retry until the read succeeds.
+    """
+    cur_year, cur_week = iso_week_now()
+    urls = []
+    for year in range(START_YEAR, cur_year + 1):
+        last_week = cur_week if year == cur_year else 53
+        for week in range(1, last_week + 1):
+            urls.append(WEEKLY_URL.format(year=year, week=week))
+
+    while urls:
+        sql = (
+            "INSTALL httpfs; LOAD httpfs;\n"
+            "SELECT CAST(_last_update AS DATE)::VARCHAR AS d, %s AS downloads\n"
+            "FROM read_json(%s, union_by_name = true)\n"
+            "WHERE %s IS NOT NULL\n"
+            "ORDER BY _last_update;" % (EXTENSION, url_literal(urls), EXTENSION)
+        )
+        try:
+            rows = run_duckdb(sql)
+        except DuckDBError as exc:
+            if "404" in str(exc) and len(urls) > 1:
+                dropped = urls.pop()
+                print("  (skipping unpublished week: %s)" % dropped.rsplit("/", 1)[-1])
+                continue
+            raise
+        return [(r["d"], int(r["downloads"])) for r in rows]
+    return []
+
+
+def latest_release():
+    """Latest published version: GitHub release tag, else description.yml."""
+    url = "https://api.github.com/repos/%s/releases/latest" % REPO
+    headers = dict(UA)
+    headers["Accept"] = "application/vnd.github+json"
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            tag = json.loads(resp.read().decode("utf-8")).get("tag_name")
+            if tag:
+                return tag.lstrip("v")
+    except Exception:
+        pass
+    # fallback: description.yml `version: "x.y.z"`
+    try:
+        with open(DESCRIPTION, encoding="utf-8") as fh:
+            for line in fh:
+                m = re.match(r'\s*version:\s*"?([0-9][^"\s]*)"?', line)
+                if m:
+                    return m.group(1)
+    except OSError:
+        pass
+    return "unknown"
+
+
+def iso_week_now():
+    today = datetime.date.today()
+    y, w, _ = today.isocalendar()
+    return y, w
+
+
+# --------------------------------------------------------------------------- #
+# SVG chart
+# --------------------------------------------------------------------------- #
+def esc(text):
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def build_svg(points, total_last_week):
+    W, H = 760, 280
+    ml, mr, mt, mb = 56, 24, 44, 48
+    pw, ph = W - ml - mr, H - mt - mb
+
+    values = [v for _, v in points] or [0]
+    vmax = max(values) or 1
+    vmax_nice = nice_ceil(vmax)
+    n = len(points)
+
+    def x(i):
+        if n <= 1:
+            return ml + pw / 2
+        return ml + pw * i / (n - 1)
+
+    def y(v):
+        return mt + ph * (1 - v / vmax_nice)
+
+    grid = []
+    labels_y = []
+    for g in range(5):
+        gv = vmax_nice * g / 4
+        gy = y(gv)
+        grid.append(
+            '<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" '
+            'stroke="#e3e8ee" stroke-width="1"/>' % (ml, gy, ml + pw, gy)
+        )
+        labels_y.append(
+            '<text x="%.1f" y="%.1f" font-size="11" fill="#8a94a6" '
+            'text-anchor="end" dominant-baseline="middle">%s</text>'
+            % (ml - 8, gy, fmt_short(gv))
+        )
+
+    line_pts = " ".join("%.1f,%.1f" % (x(i), y(v)) for i, (_, v) in enumerate(points))
+    area_pts = (
+        "%.1f,%.1f " % (x(0), mt + ph)
+        + line_pts
+        + " %.1f,%.1f" % (x(n - 1), mt + ph)
+    ) if n else ""
+
+    dots = []
+    for i, (_, v) in enumerate(points):
+        dots.append(
+            '<circle cx="%.1f" cy="%.1f" r="2.6" fill="#fff" '
+            'stroke="#f6c344" stroke-width="2"/>' % (x(i), y(v))
+        )
+
+    # x labels: thinned to ~8 ticks
+    labels_x = []
+    step = max(1, n // 8)
+    for i, (stamp, _) in enumerate(points):
+        if i % step == 0 or i == n - 1:
+            labels_x.append(
+                '<text x="%.1f" y="%.1f" font-size="10" fill="#8a94a6" '
+                'text-anchor="middle">%s</text>'
+                % (x(i), H - mb + 18, esc(stamp[5:]))  # MM-DD
+            )
+
+    # last value callout
+    callout = ""
+    if n:
+        lx, lv = x(n - 1), points[-1][1]
+        ly = y(lv)
+        callout = (
+            '<circle cx="%.1f" cy="%.1f" r="4.5" fill="#f6c344"/>'
+            '<text x="%.1f" y="%.1f" font-size="13" font-weight="700" '
+            'fill="#d4960b" text-anchor="end">%s</text>'
+            % (lx, ly, lx, ly - 12, fmt_full(lv))
+        )
+
+    svg = """<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}" role="img" aria-label="Weekly downloads of the DuckDB mssql community extension">
+  <defs>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6c344" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#f6c344" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="{W}" height="{H}" rx="10" fill="#ffffff" stroke="#e3e8ee"/>
+  <text x="{ml}" y="26" font-size="15" font-weight="700" fill="#2b3banner">{title}</text>
+  <text x="{rightx}" y="26" font-size="12" fill="#8a94a6" text-anchor="end">{total}/wk total</text>
+  {grid}
+  {labels_y}
+  {area}
+  <polyline points="{line}" fill="none" stroke="#f6c344" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+  {dots}
+  {callout}
+  {labels_x}
+  <text x="{ml}" y="{H_minus}" font-size="10" fill="#aab2c0">Source: duckdb.org/community_extensions/download_metrics &#183; downloads in the trailing 7 days, sampled weekly</text>
+</svg>
+""".format(
+        W=W,
+        H=H,
+        ml=ml,
+        rightx=W - mr,
+        title="DuckDB mssql extension &#8212; weekly downloads",
+        total=fmt_full(total_last_week),
+        grid="\n  ".join(grid),
+        labels_y="\n  ".join(labels_y),
+        area=('<polygon points="%s" fill="url(#area)"/>' % area_pts) if area_pts else "",
+        line=line_pts,
+        dots="\n  ".join(dots),
+        callout=callout,
+        labels_x="\n  ".join(labels_x),
+        H_minus=H - 10,
+    ).replace("#2b3banner", "#2b3a4a")
+    return svg
+
+
+def nice_ceil(v):
+    if v <= 0:
+        return 1
+    import math
+
+    exp = math.floor(math.log10(v))
+    base = 10 ** exp
+    for mult in (1, 2, 2.5, 5, 10):
+        if v <= mult * base:
+            return int(mult * base) if mult * base >= 1 else mult * base
+    return int(10 * base)
+
+
+def fmt_short(v):
+    v = float(v)
+    if v >= 1000:
+        return ("%.1fk" % (v / 1000)).replace(".0k", "k")
+    return "%d" % v
+
+
+def fmt_full(v):
+    return "{:,}".format(int(v))
+
+
+# --------------------------------------------------------------------------- #
+# README block
+# --------------------------------------------------------------------------- #
+def build_badges_block():
+    """Shields badge row, h3-duckdb style, placed above the H1."""
+    repo = REPO
+    ci = (
+        "[![CI](https://github.com/%s/actions/workflows/ci.yml/badge.svg)]"
+        "(https://github.com/%s/actions/workflows/ci.yml)" % (repo, repo)
+    )
+    duckdb = (
+        "[![DuckDB](https://img.shields.io/static/v1?label=duckdb&message=%s%%2B&color=blue)]"
+        "(https://github.com/duckdb/duckdb/releases)" % DUCKDB_MIN_VERSION
+    )
+    release = (
+        "[![Latest release](https://img.shields.io/github/v/release/%s?label=release&color=blue)]"
+        "(https://github.com/%s/releases/latest)" % (repo, repo)
+    )
+    downloads = (
+        "[![Community downloads per week]"
+        "(https://img.shields.io/badge/dynamic/json"
+        "?url=https%3A%2F%2Fcommunity-extensions.duckdb.org%2Fdownloads-last-week.json"
+        "&query=%24." + EXTENSION + "&label=downloads%2Fweek&color=brightgreen)]"
+        "(https://duckdb.org/community_extensions/download_metrics)"
+    )
+    license_badge = (
+        "[![License: %s](https://img.shields.io/badge/License-%s-blue.svg)](LICENSE)"
+        % (LICENSE_NAME, LICENSE_NAME)
+    )
+    stars = (
+        "[![GitHub stars](https://img.shields.io/github/stars/%s?style=flat&color=informational)]"
+        "(https://github.com/%s/stargazers)" % (repo, repo)
+    )
+    return "\n".join(
+        [BADGES_BEGIN, "", ci, duckdb, release, downloads, license_badge, stars, "", BADGES_END]
+    )
+
+
+def build_chart_block(version, total_last_week):
+    today = datetime.date.today().isoformat()
+    return "\n".join(
+        [
+            CHART_BEGIN,
+            "",
+            "### 📈 Community Extension Downloads",
+            "",
+            "![Weekly downloads of the mssql DuckDB community extension](docs/assets/download-metrics.svg)",
+            "",
+            "> Latest published version **v%s** · **%s** downloads in the trailing 7 days "
+            "(snapshot %s UTC). Counts are a Cloudflare estimate of `INSTALL mssql FROM community` "
+            "events, aggregated across DuckDB versions and platforms. "
+            "Source: [DuckDB Community Extensions download metrics](https://duckdb.org/community_extensions/download_metrics)."
+            % (version, fmt_full(total_last_week), today),
+            "",
+            CHART_END,
+        ]
+    )
+
+
+def replace_region(text, begin, end, block):
+    pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+    return pattern.sub(lambda _m: block, text, count=1)
+
+
+def splice_badges(text, block):
+    """Replace the badge region, or prepend it above everything (the H1)."""
+    if BADGES_BEGIN in text and BADGES_END in text:
+        return replace_region(text, BADGES_BEGIN, BADGES_END, block)
+    return block + "\n\n" + text.lstrip("\n")
+
+
+def splice_chart(text, block):
+    """Replace the chart region, or insert it after the lead paragraph."""
+    if CHART_BEGIN in text and CHART_END in text:
+        return replace_region(text, CHART_BEGIN, CHART_END, block)
+    # lead paragraph = H1 title + description (first two blank-line groups).
+    parts = text.split("\n\n", 2)
+    if len(parts) >= 2:
+        head = parts[0] + "\n\n" + parts[1]
+        rest = "\n\n" + parts[2] if len(parts) == 3 else ""
+        return head + "\n\n" + block + rest
+    return text.rstrip() + "\n\n" + block + "\n"
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    try:
+        total_last_week = fetch_total_last_week()
+        points = fetch_series()
+    except (DuckDBError, RuntimeError) as exc:
+        print("error: %s" % exc, file=sys.stderr)
+        return 1
+    version = latest_release()
+    print("version=%s total_last_week=%s weekly_points=%d"
+          % (version, total_last_week, len(points)))
+
+    # SVG
+    os.makedirs(os.path.dirname(SVG), exist_ok=True)
+    svg = build_svg(points, total_last_week)
+    with open(SVG, "w", encoding="utf-8") as fh:
+        fh.write(svg)
+
+    # README
+    with open(README, encoding="utf-8") as fh:
+        text = fh.read()
+    # chart first (lead-paragraph logic runs before badges shift the top),
+    # then badges (prepended above the H1).
+    new_text = splice_chart(text, build_chart_block(version, total_last_week))
+    new_text = splice_badges(new_text, build_badges_block())
+    if new_text != text:
+        with open(README, "w", encoding="utf-8") as fh:
+            fh.write(new_text)
+        print("README.md updated")
+    else:
+        print("README.md unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_download_metrics.py
+++ b/scripts/update_download_metrics.py
@@ -358,6 +358,12 @@ def build_badges_block():
     )
 
 
+def pages_url():
+    """GitHub Pages URL for the repo (owner/repo -> owner.github.io/repo/)."""
+    owner, _, repo = REPO.partition("/")
+    return "https://%s.github.io/%s/" % (owner, repo)
+
+
 def build_chart_block(version, total_last_week):
     today = datetime.date.today().isoformat()
     return "\n".join(
@@ -367,6 +373,8 @@ def build_chart_block(version, total_last_week):
             "### 📈 Community Extension Downloads",
             "",
             "![Weekly downloads of the mssql DuckDB community extension](docs/assets/download-metrics.svg)",
+            "",
+            "📊 **[Interactive chart](%s)** — queried live in your browser with DuckDB-Wasm." % pages_url(),
             "",
             "> Latest published version **v%s** · **%s** downloads in the trailing 7 days "
             "(snapshot %s UTC). Counts are a Cloudflare estimate of `INSTALL mssql FROM community` "

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>mssql · DuckDB community extension download metrics</title>
+    <meta
+      name="description"
+      content="Live download metrics for the mssql DuckDB community extension, queried in your browser with DuckDB-Wasm."
+    />
+    <style>
+      :root {
+        --accent: #f6c344;
+        --accent-dark: #d4960b;
+        --ink: #2b3a4a;
+        --muted: #8a94a6;
+        --line: #e3e8ee;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: var(--ink);
+        background: #f7f9fc;
+        line-height: 1.5;
+      }
+      .wrap { max-width: 900px; margin: 0 auto; padding: 32px 20px 64px; }
+      h1 { font-size: 1.5rem; margin: 0 0 4px; }
+      .sub { color: var(--muted); margin: 0 0 24px; font-size: 0.95rem; }
+      .sub a { color: var(--accent-dark); }
+      .cards { display: flex; flex-wrap: wrap; gap: 16px; margin: 0 0 24px; }
+      .card {
+        flex: 1 1 160px;
+        background: #fff;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 16px 18px;
+      }
+      .card .label { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; }
+      .card .value { font-size: 1.8rem; font-weight: 700; margin-top: 4px; }
+      .panel {
+        background: #fff;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 20px;
+        min-height: 380px;
+      }
+      #status { color: var(--muted); font-size: 0.95rem; }
+      .err { color: #c0392b; }
+      figure { margin: 0; overflow-x: auto; }
+      footer { color: var(--muted); font-size: 0.82rem; margin-top: 24px; }
+      footer a { color: var(--accent-dark); }
+      code { background: #eef1f6; padding: 1px 5px; border-radius: 4px; font-size: 0.85em; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>📈 mssql — DuckDB community extension downloads</h1>
+      <p class="sub">
+        Queried live in your browser with
+        <a href="https://duckdb.org/docs/api/wasm/overview" target="_blank" rel="noopener">DuckDB-Wasm</a>
+        against the
+        <a href="https://duckdb.org/community_extensions/download_metrics" target="_blank" rel="noopener"
+          >Community Extensions metrics endpoint</a
+        >. No server — the chart below is the result of <code>read_json(...)</code> running on this page.
+      </p>
+
+      <div class="cards">
+        <div class="card">
+          <div class="label">Downloads / week</div>
+          <div class="value" id="total">…</div>
+        </div>
+        <div class="card">
+          <div class="label">Weeks tracked</div>
+          <div class="value" id="weeks">…</div>
+        </div>
+        <div class="card">
+          <div class="label">Peak week</div>
+          <div class="value" id="peak">…</div>
+        </div>
+      </div>
+
+      <div class="panel">
+        <div id="status">Booting DuckDB-Wasm…</div>
+        <figure id="chart"></figure>
+      </div>
+
+      <footer>
+        Counts are a Cloudflare estimate of <code>INSTALL mssql FROM community</code> events, aggregated across
+        DuckDB versions and platforms, for the trailing 7 days, sampled weekly. ·
+        <a href="https://github.com/hugr-lab/mssql-extension" target="_blank" rel="noopener">Source repo</a>
+      </footer>
+    </div>
+
+    <script type="module">
+      import * as duckdb from "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm";
+      import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+
+      const EXTENSION = "mssql";
+      const START_YEAR = 2026;
+      const BASE = "https://community-extensions.duckdb.org";
+      const statusEl = document.getElementById("status");
+
+      const setStatus = (msg, isErr) => {
+        statusEl.textContent = msg;
+        statusEl.className = isErr ? "err" : "";
+      };
+
+      // ISO week of a UTC date -> [isoYear, isoWeek]
+      function isoYearWeek(d) {
+        const t = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+        const day = (t.getUTCDay() + 6) % 7; // Mon=0
+        t.setUTCDate(t.getUTCDate() - day + 3); // nearest Thursday
+        const isoYear = t.getUTCFullYear();
+        const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+        const fday = (firstThursday.getUTCDay() + 6) % 7;
+        firstThursday.setUTCDate(firstThursday.getUTCDate() - fday + 3);
+        const week = 1 + Math.round((t - firstThursday) / (7 * 864e5));
+        return [isoYear, week];
+      }
+
+      function weeklyUrls() {
+        const [curYear, curWeek] = isoYearWeek(new Date());
+        const urls = [];
+        for (let year = START_YEAR; year <= curYear; year++) {
+          const last = year === curYear ? curWeek : 53;
+          for (let week = 1; week <= last; week++) {
+            urls.push(`${BASE}/download-stats-weekly/${year}/${week}.json`);
+          }
+        }
+        return urls;
+      }
+
+      async function initDuckDB() {
+        const bundles = duckdb.getJsDelivrBundles();
+        const bundle = await duckdb.selectBundle(bundles);
+        const workerUrl = URL.createObjectURL(
+          new Blob([`importScripts("${bundle.mainWorker}");`], { type: "text/javascript" })
+        );
+        const worker = new Worker(workerUrl);
+        const db = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+        URL.revokeObjectURL(workerUrl);
+        return db.connect();
+      }
+
+      const rowsOf = (res) => res.toArray().map((r) => r.toJSON());
+
+      async function fetchTotal(conn) {
+        const res = await conn.query(
+          `SELECT ${EXTENSION} AS total FROM read_json('${BASE}/downloads-last-week.json')`
+        );
+        const rows = rowsOf(res);
+        return rows.length ? Number(rows[0].total) : 0;
+      }
+
+      // read_json aborts if any URL 404s (the current week may be unpublished),
+      // so drop trailing weeks and retry until the read succeeds.
+      async function fetchSeries(conn) {
+        let urls = weeklyUrls();
+        while (urls.length) {
+          const list = urls.map((u) => `'${u}'`).join(", ");
+          const sql =
+            `SELECT CAST(_last_update AS DATE)::VARCHAR AS d, ${EXTENSION} AS downloads ` +
+            `FROM read_json([${list}], union_by_name = true) ` +
+            `WHERE ${EXTENSION} IS NOT NULL ORDER BY _last_update`;
+          try {
+            const res = await conn.query(sql);
+            return rowsOf(res).map((r) => ({ date: new Date(r.d), downloads: Number(r.downloads) }));
+          } catch (e) {
+            if (String(e).includes("404") && urls.length > 1) {
+              urls = urls.slice(0, -1);
+              continue;
+            }
+            throw e;
+          }
+        }
+        return [];
+      }
+
+      function render(series, total) {
+        const fmt = (n) => n.toLocaleString("en-US");
+        document.getElementById("total").textContent = fmt(total);
+        document.getElementById("weeks").textContent = series.length;
+        const peak = series.reduce((m, p) => (p.downloads > m ? p.downloads : m), 0);
+        document.getElementById("peak").textContent = fmt(peak);
+
+        const chart = Plot.plot({
+          width: 840,
+          height: 360,
+          marginLeft: 56,
+          marginBottom: 36,
+          style: { fontSize: "12px" },
+          x: { type: "utc", label: null, grid: false },
+          y: { label: "downloads / week", grid: true, nice: true, zero: true },
+          marks: [
+            Plot.areaY(series, { x: "date", y: "downloads", fill: "#f6c344", fillOpacity: 0.18, curve: "monotone-x" }),
+            Plot.lineY(series, { x: "date", y: "downloads", stroke: "#d4960b", strokeWidth: 2.5, curve: "monotone-x" }),
+            Plot.dot(series, {
+              x: "date",
+              y: "downloads",
+              fill: "#f6c344",
+              stroke: "#fff",
+              r: 3,
+              tip: true,
+              title: (d) => `${d.date.toISOString().slice(0, 10)}\n${d.downloads.toLocaleString("en-US")} downloads`,
+            }),
+            Plot.ruleY([0]),
+          ],
+        });
+        document.getElementById("chart").replaceChildren(chart);
+        setStatus("");
+        statusEl.style.display = "none";
+      }
+
+      (async () => {
+        try {
+          setStatus("Booting DuckDB-Wasm…");
+          const conn = await initDuckDB();
+          try {
+            await conn.query("INSTALL httpfs; LOAD httpfs;");
+          } catch (_) {
+            /* httpfs is built into duckdb-wasm; ignore if not separately loadable */
+          }
+          setStatus("Querying download metrics with read_json()…");
+          const [series, total] = await Promise.all([fetchSeries(conn), fetchTotal(conn)]);
+          if (!series.length) {
+            setStatus("No data returned from the metrics endpoint.", true);
+            return;
+          }
+          render(series, total);
+        } catch (e) {
+          console.error(e);
+          setStatus("Failed to load metrics: " + e + " (the endpoint may be blocking cross-origin requests).", true);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -94,7 +94,8 @@
 
     <script type="module">
       import * as duckdb from "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm";
-      import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+      // Exact version pin (no floating minor) so the CDN can't silently serve new code.
+      import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.17/+esm";
 
       const EXTENSION = "mssql";
       const START_YEAR = 2026;


### PR DESCRIPTION
Adds a bot that keeps the README's published version and download metrics current, plus an interactive in-browser companion chart. All data is fetched/aggregated by **DuckDB itself** (`httpfs` + `read_json`) — the same queries the [Community Extensions metrics page](https://duckdb.org/community_extensions/download_metrics) documents.

## What's included

**Static (renders inside the README on GitHub):**
- Badge row above the title (h3-duckdb convention): CI · DuckDB v1.4.1+ · release · downloads/week · MIT · stars
- Inline SVG download-trend chart + summary line + a link to the interactive version
- `scripts/update_download_metrics.py` — DuckDB-backed fetch/aggregate → renders SVG + rewrites two managed README regions (`METRICS-BADGES`, `METRICS-CHART`). Idempotent: re-runs produce no diff.
- `.github/workflows/update-metrics.yml` — weekly cron + manual dispatch; installs the DuckDB CLI, commits only on change.

**Interactive (GitHub Pages):**
- `web/index.html` — boots DuckDB-Wasm and runs the *same* `read_json()` queries live in the browser (no backend), rendering an Observable Plot trend chart with hover tooltips + summary cards.
- `.github/workflows/pages.yml` — deploys `web/` to GitHub Pages.

## ⚠️ Required setup for the Interactive (GitHub Pages) part

1. **Enable Pages**: repo **Settings → Pages → Build and deployment → Source = "GitHub Actions"**, or the `pages.yml` deploy step will fail. Once enabled it serves at `https://hugr-lab.github.io/mssql-extension/`.
2. **Merge to `main`**: the scheduled metrics workflow and the Pages workflow only trigger from the default branch — they won't run while this is on the feature branch.
3. **CORS caveat**: the interactive page depends on the metrics endpoint allowing cross-origin browser requests. The DuckDB metrics page does the same in-browser queries, so it should work — worth a glance once Pages is live (the page shows a clear error if CORS blocks it).

## Notes
- Data layer dogfoods DuckDB end-to-end (CLI for the README bot, DuckDB-Wasm for the page).
- No new build/runtime dependencies for the extension itself; the bot installs the DuckDB CLI in CI only.