### PR TITLE
ci(metrics): create ~/.local/bin before unzipping DuckDB CLI

### DIFF
--- a/.github/workflows/update-metrics.yml
+++ b/.github/workflows/update-metrics.yml
@@ -38,6 +38,7 @@ jobs:
           curl -fsSL -o /tmp/duckdb.zip \
             "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
           echo "${DUCKDB_SHA256}  /tmp/duckdb.zip" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
           unzip -o /tmp/duckdb.zip -d "$HOME/.local/bin"
           "$HOME/.local/bin/duckdb" --version
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Problem

The scheduled **Update download metrics** workflow has been failing at the **Install DuckDB CLI** step ([run 27533888720](https://github.com/hugr-lab/mssql-extension/actions/runs/27533888720)):

```
echo "${DUCKDB_SHA256}  /tmp/duckdb.zip" | sha256sum -c -     # OK
unzip -o /tmp/duckdb.zip -d "$HOME/.local/bin"
checkdir:  cannot create extraction directory: /home/runner/.local/bin
           No such file or directory
##[error]Process completed with exit code 2.
```

The download and SHA256 verification succeed. `unzip -d` does **not** create the parent directory, and the `ubuntu-24` runner image no longer ships `~/.local/bin`, so extraction fails.

## Fix

Add `mkdir -p "$HOME/.local/bin"` before the `unzip`. One line, no behavior change otherwise (pinned version + checksum unchanged).

Only `.github/workflows/update-metrics.yml` uses this pattern; the other workflows were checked and are unaffected.