### PR TITLE
Fix #168 (datetime2 far-future overflow), #149 (release version stamp), #152 (pool_stats test)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so extension-ci-tools' `git describe` stamps the
+          # version tag (vX.Y.Z) into the artifact metadata instead of a bare
+          # commit SHA (#149). Default shallow checkout can't see the tag.
+          fetch-depth: 0
 
       - name: Extract extension version from tag
         id: version
@@ -190,6 +195,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so extension-ci-tools' `git describe` stamps the
+          # version tag instead of a bare commit SHA (#149).
+          fetch-depth: 0
 
       - name: Extract extension version from tag
         id: version
@@ -314,6 +323,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so extension-ci-tools' `git describe` stamps the
+          # version tag instead of a bare commit SHA (#149).
+          fetch-depth: 0
 
       - name: Extract extension version from tag
         id: version

--- a/src/codec/datetime_codec.cpp
+++ b/src/codec/datetime_codec.cpp
@@ -66,6 +66,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <string>
 
 namespace duckdb {
@@ -228,7 +229,15 @@ void ComputeDatetime2Components(int64_t raw_ticks, LogicalTypeId source_type, ui
 // bypassing the µs-intermediate that ConvertDatetime2 hard-codes. This is
 // lossless whenever target precision ≥ wire precision (DATETIME2(7) → TIMESTAMP_NS
 // preserves every 100-ns tick; DATETIME2(3) → TIMESTAMP_MS preserves every ms).
-int64_t Datetime2WireToNativeUnit(const uint8_t *data, size_t time_len, uint8_t wire_scale, LogicalTypeId target_type) {
+//
+// Returns false (leaving out_native untouched) when the value falls outside the
+// target variant's int64 range. SQL Server's datetime2 domain runs to
+// 9999-12-31, but TIMESTAMP_NS (int64 nanoseconds) only reaches ~2262-04-11, so
+// the far-future valid-to sentinel that temporal tables use (9999-12-31
+// 23:59:59.9999999) overflows. Caller emits SQL NULL rather than letting the
+// multiply silently wrap to a nonsense past instant (issue #168).
+bool Datetime2WireToNativeUnit(const uint8_t *data, size_t time_len, uint8_t wire_scale, LogicalTypeId target_type,
+							   int64_t &out_native) {
 	int64_t time_ticks = 0;
 	for (size_t i = 0; i < time_len; i++) {
 		time_ticks |= static_cast<int64_t>(data[i]) << (i * 8);
@@ -246,7 +255,23 @@ int64_t Datetime2WireToNativeUnit(const uint8_t *data, size_t time_len, uint8_t 
 	} else {
 		sub_day_ticks = time_ticks / (wire_per_sec / target_per_sec);
 	}
-	return static_cast<int64_t>(unix_days) * SECONDS_PER_DAY * target_per_sec + sub_day_ticks;
+
+	// Overflow-checked: out_native = unix_days * SECONDS_PER_DAY * target_per_sec + sub_day_ticks.
+	// ticks_per_day is at most 86400 * 1e9 ≈ 8.64e13 (fits int64); the unbounded
+	// factor is unix_days (±~2.9M over the full [0001,9999] datetime2 domain),
+	// which overflows int64 only for TIMESTAMP_NS outside ~[1677,2262].
+	int64_t ticks_per_day = SECONDS_PER_DAY * target_per_sec;
+	if (unix_days > std::numeric_limits<int64_t>::max() / ticks_per_day ||
+		unix_days < std::numeric_limits<int64_t>::min() / ticks_per_day) {
+		return false;
+	}
+	int64_t days_ticks = static_cast<int64_t>(unix_days) * ticks_per_day;
+	// sub_day_ticks is always >= 0, so only positive-direction add overflow is possible.
+	if (days_ticks > std::numeric_limits<int64_t>::max() - sub_day_ticks) {
+		return false;
+	}
+	out_native = days_ticks + sub_day_ticks;
+	return true;
 }
 
 size_t Datetime2TimeByteLen(uint8_t scale) {
@@ -285,7 +310,15 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		// TIMESTAMP_MS / TIMESTAMP / TIMESTAMP_NS) so the µs-bottleneck doesn't
 		// drop precision on DATETIME2(7) → TIMESTAMP_NS round-trips.
 		size_t time_len = Datetime2TimeByteLen(col.scale);
-		int64_t native = Datetime2WireToNativeUnit(bytes.data(), time_len, col.scale, out.GetType().id());
+		int64_t native;
+		if (!Datetime2WireToNativeUnit(bytes.data(), time_len, col.scale, out.GetType().id(), native)) {
+			// Value outside the target TIMESTAMP variant's range — e.g. a
+			// datetime2(7) far-future value (9999-12-31 temporal-table ValidTo
+			// sentinel) mapped to TIMESTAMP_NS, whose domain ends at ~2262.
+			// Emit SQL NULL instead of a silently-wrapped wrong instant (issue #168).
+			FlatVector::SetNull(out, row, true);
+			return;
+		}
 		FlatVector::GetData<timestamp_t>(out)[row] = timestamp_t(native);
 		return;
 	}

--- a/test/cpp/codec/test_datetime_codec.cpp
+++ b/test/cpp/codec/test_datetime_codec.cpp
@@ -251,6 +251,49 @@ void TestDecodeDatetime2Scale6() {
 	CHECK_EQ(duckdb::FlatVector::GetData<timestamp_t>(vec)[0].value, expected.value);
 }
 
+void TestDecodeDatetime2Scale7NsInRange() {
+	std::cout << "Test: DecodeFromTds — DATETIME2(7) in-range → TIMESTAMP_NS lossless (issue #168 guard not over-eager)\n";
+	// 2024-01-15 14:30:00.1234567 — well within TIMESTAMP_NS's ~[1677,2262] window.
+	int64_t time_ticks = ((14LL * 3600 + 30 * 60) * 10000000LL) + 1234567LL;  // 100-ns ticks
+	auto target_date = duckdb::Date::FromDate(2024, 1, 15);
+	int32_t days_from_0001 = target_date.days + DAYS_0001_TO_EPOCH;
+	std::vector<uint8_t> wire(8);
+	for (int i = 0; i < 5; i++) {
+		wire[i] = static_cast<uint8_t>((time_ticks >> (i * 8)) & 0xFF);
+	}
+	wire[5] = static_cast<uint8_t>(days_from_0001 & 0xFF);
+	wire[6] = static_cast<uint8_t>((days_from_0001 >> 8) & 0xFF);
+	wire[7] = static_cast<uint8_t>((days_from_0001 >> 16) & 0xFF);
+	duckdb::Vector vec(LogicalType::TIMESTAMP_NS, 1);
+	auto col = MakeTdsColumn(duckdb::tds::TDS_TYPE_DATETIME2, 7);
+	duckdb::mssql::codec::datetime::DecodeFromTds(wire, col, vec, 0);
+	CHECK_TRUE(!duckdb::FlatVector::IsNull(vec, 0));
+	// ns since epoch = days_since_1970 * 86400 * 1e9 + time_ticks * 100
+	int64_t expected = static_cast<int64_t>(target_date.days) * 86400LL * 1000000000LL + time_ticks * 100LL;
+	CHECK_EQ(duckdb::FlatVector::GetData<timestamp_t>(vec)[0].value, expected);
+}
+
+void TestDecodeDatetime2FarFutureNull() {
+	std::cout << "Test: DecodeFromTds — DATETIME2(7) 9999-12-31 sentinel → TIMESTAMP_NS NULL (issue #168)\n";
+	// 9999-12-31 23:59:59.9999999 — the temporal-table ValidTo sentinel. This
+	// is past TIMESTAMP_NS's 2262-04-11 ceiling; before the fix the decode
+	// multiply wrapped to ~1816-03-30. Now it must surface as SQL NULL.
+	int64_t time_ticks = ((23LL * 3600 + 59 * 60 + 59) * 10000000LL) + 9999999LL;
+	auto target_date = duckdb::Date::FromDate(9999, 12, 31);
+	int32_t days_from_0001 = target_date.days + DAYS_0001_TO_EPOCH;
+	std::vector<uint8_t> wire(8);
+	for (int i = 0; i < 5; i++) {
+		wire[i] = static_cast<uint8_t>((time_ticks >> (i * 8)) & 0xFF);
+	}
+	wire[5] = static_cast<uint8_t>(days_from_0001 & 0xFF);
+	wire[6] = static_cast<uint8_t>((days_from_0001 >> 8) & 0xFF);
+	wire[7] = static_cast<uint8_t>((days_from_0001 >> 16) & 0xFF);
+	duckdb::Vector vec(LogicalType::TIMESTAMP_NS, 1);
+	auto col = MakeTdsColumn(duckdb::tds::TDS_TYPE_DATETIME2, 7);
+	duckdb::mssql::codec::datetime::DecodeFromTds(wire, col, vec, 0);
+	CHECK_TRUE(duckdb::FlatVector::IsNull(vec, 0));
+}
+
 void TestDecodeDatetimeOffset() {
 	std::cout << "Test: DecodeFromTds — DATETIMEOFFSET(7) reads UTC time directly\n";
 	// 14:30:00 UTC encoded as 100-ns ticks.
@@ -602,6 +645,8 @@ int main() {
 	TestDecodeDatetimen8();
 	TestDecodeDatetimen4();
 	TestDecodeDatetime2Scale6();
+	TestDecodeDatetime2Scale7NsInRange();
+	TestDecodeDatetime2FarFutureNull();
 	TestDecodeDatetimeOffset();
 
 	TestEncodeDateVector();

--- a/test/sql/copy/copy_connection_leak.test
+++ b/test/sql/copy/copy_connection_leak.test
@@ -22,11 +22,15 @@ CREATE TABLE varchar_data AS SELECT 'not_a_number' AS id FROM range(5) t(i);
 # T012: Test bind phase errors don't leak connections
 #
 
-# Store initial pool stats
+# Store initial pool stats.
+# Schema note (#152): mssql_pool_stats() no longer exposes a `pool_size` column
+# (the configured limit is not surfaced); use `total_connections` (current live
+# count = idle + active) instead. `total_connections_created` was renamed to
+# `connections_created`. After ATTACH the pool holds a single idle connection.
 query IIII
-SELECT pool_size, idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT total_connections, idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
-10	1	0	1
+1	1	0	1
 
 # Try COPY to non-existent catalog (should fail before connection acquired)
 statement error
@@ -36,9 +40,9 @@ not found
 
 # Verify pool stats unchanged
 query IIII
-SELECT pool_size, idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT total_connections, idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
-10	1	0	1
+1	1	0	1
 
 #
 # T013: Test sink phase errors release connections
@@ -53,9 +57,9 @@ CALL mssql_exec('db', 'CREATE TABLE dbo.int_table (id INT)');
 
 # Get current pool stats
 query IIII
-SELECT pool_size, idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT total_connections, idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
-10	1	0	1
+1	1	0	1
 
 # Try COPY with type mismatch (VARCHAR to INT) - should fail during sink
 statement error
@@ -65,9 +69,9 @@ type mismatch
 
 # Verify connection was released (not leaked)
 query IIII
-SELECT pool_size, idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT total_connections, idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
-10	1	0	1
+1	1	0	1
 
 # Cleanup
 statement ok
@@ -82,7 +86,7 @@ CALL mssql_exec('db', 'DROP TABLE dbo.int_table');
 
 # Get current pool stats
 query III
-SELECT idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
 1	0	1
 
@@ -92,7 +96,7 @@ COPY test_data TO 'db.dbo.test_finalize' (FORMAT 'bcp', REPLACE true);
 
 # Verify connection was released after successful COPY
 query III
-SELECT idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
 1	0	1
 
@@ -106,7 +110,7 @@ DROP TABLE IF EXISTS db.dbo.test_finalize;
 
 # Store initial stats
 query III
-SELECT idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
 1	0	1
 
@@ -123,7 +127,7 @@ endloop
 
 # Verify no connections leaked after all failures
 query III
-SELECT idle_connections, active_connections, total_connections_created FROM mssql_pool_stats('db');
+SELECT idle_connections, active_connections, connections_created FROM mssql_pool_stats('db');
 ----
 1	0	1
 


### PR DESCRIPTION
Knocks out three triaged issues, each in its own commit.

## #168 — `datetime2(7)` far-future values silently wrap to ~1816 (data integrity)
`datetime2`'s domain runs to `9999-12-31`, but the scale-7 catalog mapping targets `TIMESTAMP_NS` (int64 nanoseconds), whose range ends at ~`2262-04-11`. `Datetime2WireToNativeUnit` did an unchecked int64 multiply, so far-future values — notably the `9999-12-31 23:59:59.9999999` sentinel that **system-versioned temporal tables** use for a current row's `ValidTo` — wrapped to a nonsense past instant (`~1816-03-30`) with no error.

**Fix (Option B from the issue):** range-check the decode and emit SQL `NULL` on overflow instead of a silently-wrapped value. The guard only trips for `TIMESTAMP_NS` outside ~[1677, 2262]; the µs `TIMESTAMP` domain is never falsely nulled.

**Tests:** added C++ regression tests in `test/cpp/codec/test_datetime_codec.cpp` — the 9999 sentinel → NULL, and an in-range scale-7 value still decoding losslessly into `TIMESTAMP_NS`. Run with `make test-codec-datetime`.

## #149 — Release artifacts stamp `extension_version` as commit SHA instead of the tag
The build jobs used the default shallow checkout (`fetch-depth: 1`, no tags), so extension-ci-tools' `git describe --tags` fell back to a bare short-SHA (e.g. `51f4781` instead of `v0.2.1`) in the artifact metadata footer and `duckdb_extensions()`.

**Fix:** `fetch-depth: 0` on the checkout step of the three build jobs (Unix, Windows MSVC, Windows MinGW).

## #152 — `copy_connection_leak.test` references removed `mssql_pool_stats` columns
The test queried `pool_size` / `total_connections_created`, which no longer exist, so it failed to bind and the T012–T015 leak assertions never ran.

**Fix:** switch to `total_connections` / `connections_created` and re-derive expected values (`1 1 0 1` — pool holds one idle connection after ATTACH). `pool_size` / the configured limit is intentionally not exposed by `mssql_pool_stats`.

## Verification
- `src/codec/datetime_codec.cpp` passes `clang-format-14` (release lint gate) unchanged.
- Not built locally (fresh worktree, no DuckDB submodule); CI exercises the codec unit test and the integration-only #152 test. #168 test logic verified statically.

Closes #168
Closes #149
Closes #152