### PR TITLE
Speed up CI: CodeQL off PRs, bigger ccache, ASan-only PR fuzzing, docs skip

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -1,7 +1,11 @@
 name: ClusterFuzzLite PR fuzzing
 # Per-PR regression gate: build the harnesses, fuzz only code changed in the PR
-# for a short budget, replay the seed corpus, and FAIL on any new ASan/UBSan
-# crash. Deep discovery is done locally (see fuzz/README.md), not here.
+# for a short budget, replay the seed corpus, and FAIL on any new ASan crash.
+# Deep discovery is done locally (see fuzz/README.md), not here.
+#
+# PRs run ASan only (fast feedback). UBSan is offloaded to a weekly batch run
+# (`ubsan-weekly` below) against the full corpus, so a UBSan regression is still
+# caught within the week without doubling every PR's fuzzing wall-time.
 on:
   pull_request:
     paths:
@@ -13,35 +17,61 @@ on:
       - 'fuzz/**'
       - '.clusterfuzzlite/**'
       - '.github/workflows/cflite-pr.yml'
+  schedule:
+    # Weekly UBSan batch run against main (offloaded from the per-PR gate).
+    - cron: '47 3 * * 1'
 
 permissions:
   contents: read
 
 jobs:
   PR:
+    # ASan diff gate — runs on PRs only.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        sanitizer: [address, undefined]   # ASan + UBSan, both mandatory
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build fuzzers (${{ matrix.sanitizer }})
+      - name: Build fuzzers (address)
         id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@v1
         with:
           language: c++
-          sanitizer: ${{ matrix.sanitizer }}
+          sanitizer: address
           # Fuzz the diff: instrument only the lines this PR touches.
           storage-repo: ''
 
-      - name: Run fuzzers (${{ matrix.sanitizer }})
+      - name: Run fuzzers (address)
         uses: google/clusterfuzzlite/actions/run_fuzzers@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300
           mode: 'code-change'
-          sanitizer: ${{ matrix.sanitizer }}
+          sanitizer: address
+          output-sarif: true
+
+  ubsan-weekly:
+    # UBSan batch run — weekly schedule only (offloaded from the PR gate).
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build fuzzers (undefined)
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: c++
+          sanitizer: undefined
+          storage-repo: ''
+
+      - name: Run fuzzers (undefined)
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 600
+          mode: 'batch'
+          sanitizer: undefined
           output-sarif: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Docs-only PRs skip CI (lint + C++ unit tests). Prose-scanning workflows
+    # (prompt-injection, secret scan) have their own triggers and still run.
+    # NOTE: if Lint / "C++ Unit Tests" are required status checks, GitHub treats
+    # a path-skipped required check as pending and can block docs PRs — either
+    # mark them non-required or add a passing stub. See PR description.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       run_build:
@@ -182,7 +192,10 @@ jobs:
 
       - name: Configure ccache
         run: |
-          ccache --set-config=max_size=500M
+          # 2G (was 500M): a full DuckDB object set overflows 500M and evicts
+          # itself mid-build, so warm runs were partially cold. 2G holds the
+          # DuckDB + extension objects across runs for a much higher hit rate.
+          ccache --set-config=max_size=2G
           ccache --set-config=compression=true
           ccache -z
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,21 +4,20 @@ name: CodeQL
 # (use-after-free, taint flow into format strings, crypto misuse, OOB reads).
 # Free for public repos. CodeQL traces a real CMake build so the analysis
 # sees the actual translation units, not a stub.
+#
+# Runs on push-to-main and a weekly schedule only — NOT per-PR. The build it
+# traces takes ~50 min (DuckDB + extension, ccache-free so the tracer sees every
+# TU), which dominated PR feedback time. Security drift between merges is caught
+# by the weekly cron and by the push-to-main run on the very next merge.
+# NOTE: if "Analyze (C/C++)" is a required status check in branch protection,
+# remove it from the required set — it no longer reports on PRs.
 
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'CMakeLists.txt'
-      - 'vcpkg.json'
-      - 'extension_config.cmake'
-      - '.github/workflows/codeql.yml'
   schedule:
     # Weekly scan against main so newly-added CodeQL queries (Microsoft ships
-    # them roughly monthly) get applied without waiting for the next PR.
+    # them roughly monthly) get applied, and to catch any drift between merges.
     - cron: '32 4 * * 1'
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Configure ccache
         shell: bash
         run: |
-          ccache --set-config=max_size=500M
+          ccache --set-config=max_size=2G
           ccache --set-config=compression=true
           ccache -z
 
@@ -244,7 +244,7 @@ jobs:
         shell: bash
         run: |
           choco install ccache ninja
-          ccache --set-config=max_size=500M
+          ccache --set-config=max_size=2G
           ccache --set-config=compression=true
           ccache -z
 
@@ -378,7 +378,7 @@ jobs:
         shell: bash
         run: |
           choco install ccache ninja
-          ccache --set-config=max_size=500M
+          ccache --set-config=max_size=2G
           ccache --set-config=compression=true
           ccache -z
 


### PR DESCRIPTION
Cuts PR feedback time. The dominant PR cost was CodeQL (~50 min, traced full DuckDB+extension build). After these changes a typical code PR's critical path is fuzzing-bound (~7 min); a docs-only PR runs ~0 heavy jobs.

## Changes

### 1. CodeQL: push-to-main + weekly only (not per-PR) — `codeql.yml`
The `Analyze (C/C++)` job traces a ccache-free ~50-min build on every PR. Dropped the `pull_request` trigger; kept `push: main` and the existing weekly cron. Security drift is caught on the next merge and weekly.

### 2. ccache 500M → 2G — `ci.yml` build matrix + `release.yml` (×3)
A full DuckDB object set overflows 500M and evicts itself mid-build, so "warm" runs were partially cold. 2G holds DuckDB + extension objects across runs.

### 3. ClusterFuzzLite: ASan-only on PRs, UBSan weekly — `cflite-pr.yml`
PR gate dropped from a 2-sanitizer matrix (ASan+UBSan, ~7 min each) to **ASan only** (diff/code-change). Added a weekly `ubsan-weekly` batch job so UBSan regressions are still caught within the week.

### 4. Docs-only PRs skip CI — `ci.yml`
`paths-ignore` (`**.md`, `docs/**`, `LICENSE`, `.gitignore`) on the `pull_request` trigger so pure-docs PRs skip lint + C++ unit tests. Prompt-injection / secret-scan workflows have their own triggers and still run.

## ⚠️ Required-status-check caveats (action needed in branch protection)
Two of these change which checks report on PRs. If they're in the **required** set, GitHub will treat the now-absent/skipped check as pending and **block merges**:

- **`Analyze (C/C++)` (CodeQL)** no longer reports on PRs → **remove it from required checks**.
- **`Lint` / `C++ Unit Tests`** become "skipped" on docs-only PRs → if required, a docs PR will hang. Either mark them non-required, or I can convert to a `dorny/paths-filter` gate that always reports success (say the word).

## Trade-offs
- Less continuous CodeQL coverage on feature branches (weekly + on-merge instead). For a security-sensitive extension this is the main thing to confirm you're OK with.
- UBSan regressions surface within a week rather than at PR time.
- ccache caches grow to ~2G each; with the 3-platform matrix that's ~6G against GitHub's 10G/repo cache budget (plus vcpkg caches). Watch for cache eviction; drop to ~1.5G if it thrashes.

## Estimated effect
Typical code PR critical path: ~52 min → ~7–8 min. Docs-only PR: ~near-zero heavy jobs.