### PR TITLE
ci: run codec datetime unit test (#168 regression) in the build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,23 @@ jobs:
           ./build/test/test_login7_encoding
           echo "::endgroup::"
 
+          echo "::group::test_datetime_codec (codec::datetime — issue #168 datetime2(7) overflow -> NULL)"
+          # Unlike the TDS-only test above, the codec test uses DuckDB
+          # Value/Vector/Date/Timestamp, so it links the libduckdb just built in
+          # this job (build/release/src). Mirrors the Makefile `test-codec-datetime`
+          # recipe: all src/codec/*.cpp + the encoding helpers, -lsimdutf -lduckdb.
+          "${CXX:-c++}" -std=c++17 -pthread -Wno-deprecated-declarations \
+            -I src/include -I duckdb/src/include -I "$PREFIX/include" \
+            test/cpp/codec/test_datetime_codec.cpp \
+            src/codec/*.cpp \
+            src/tds/encoding/utf16.cpp src/tds/encoding/datetime_encoding.cpp \
+            src/tds/encoding/decimal_encoding.cpp src/tds/encoding/guid_encoding.cpp \
+            -L "$PREFIX/lib" -lsimdutf \
+            -L build/release/src -lduckdb \
+            -o build/test/test_datetime_codec
+          LD_LIBRARY_PATH=build/release/src DYLD_LIBRARY_PATH=build/release/src ./build/test/test_datetime_codec
+          echo "::endgroup::"
+
       # Spec 053 (#161): the shipped Linux extension must NOT hard-link the
       # Kerberos runtime, or it fails to LOAD on images without it. GSSAPI/krb5
       # are dlopen'd lazily, so they must be absent from DT_NEEDED.


### PR DESCRIPTION
Closes the coverage gap noted during #169: the `codec::datetime` unit test — including the new #168 regression (`datetime2(7)` far-future → NULL) — wasn't run by any CI job.

## Change
Adds a `test_datetime_codec` compile+run block to the Build job's existing **"Run C++ unit tests"** step, right after the `test_login7_encoding` block. It mirrors the Makefile `make test-codec-datetime` recipe:
- compiles `test/cpp/codec/test_datetime_codec.cpp` + all `src/codec/*.cpp` + the encoding helpers (`utf16`, `datetime_encoding`, `decimal_encoding`, `guid_encoding`)
- links `-lsimdutf` (vcpkg) and `-lduckdb` (the libduckdb already built in this job at `build/release/src`) — the codec test needs DuckDB `Value`/`Vector` symbols, unlike the TDS-only LOGIN7 test next to it
- runs on the Linux + macOS build matrix with `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` pointed at the built lib

## Scope / caveat
The Build job is `workflow_dispatch`-gated (`run_build`), so this exercises #168 on the **manual build/verification path** (e.g. the dispatch run used to validate #169), **not on every PR**. That's inherent: the codec test requires a full `libduckdb`, and no per-PR job builds one (the lightweight `cpp-unit-tests` job is DuckDB-free by design). Wiring it here is the cheapest correct home; making it per-PR would mean building DuckDB on every PR, which the CI-cost design (see #170) deliberately avoids.

## Verification
YAML validates. The compile/link flags mirror the working Makefile recipe, substituting the release tree (`build/release`, `$PREFIX/lib`) for debug — the same substitution the adjacent LOGIN7 step already uses successfully. Will be exercised by the next dispatched build.