### PR TITLE
fix(catalog): TSan/ASan-confirmed concurrency races behind concurrent-read crashes (#178)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ duckdb --unsigned -c "INSTALL mssql FROM local_build_debug; LOAD mssql;"
 ## Key Architecture Concepts
 
 - **Custom TDS implementation**: No external TDS/ODBC library. TDS v7.4 protocol with PRELOGIN, LOGIN7, SQL_BATCH, ATTENTION packet types.
-- **Connection pool**: Thread-safe pool, **owned per `MSSQLCatalog` via `unique_ptr<ConnectionPool>` (spec 047)** — pool lifetime is bounded by catalog lifetime; no singleton, no cross-instance sharing. Two ATTACHes against the same DSN under different aliases get independent pools; DETACH tears down the pool deterministically via RAII. Idle timeout, background cleanup, configurable limits as before.
+- **Connection pool**: Thread-safe pool, **owned per `MSSQLCatalog` (spec 047; since the issue #178 review a `shared_ptr` whose SOLE strong reference is the catalog — result streams hold `weak_ptr` handles for safe destructor-time release)** — pool lifetime is bounded by catalog lifetime; no singleton, no cross-instance sharing. Two ATTACHes against the same DSN under different aliases get independent pools; DETACH tears down the pool deterministically via RAII. Idle timeout, background cleanup, configurable limits as before.
 - **Transaction support**: Connection pinning maps DuckDB transactions to SQL Server transactions via 8-byte ENVCHANGE descriptors. See `docs/transactions.md`.
 - **Catalog integration**: DuckDB Catalog/Schema/Table APIs with incremental metadata cache (lazy loading, TTL-based expiration, point invalidation), primary key discovery for rowid support.
 - **DML**: INSERT uses batched VALUES; UPDATE/DELETE use rowid-based VALUES JOIN pattern with deferred execution in transactions.

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -30,7 +30,7 @@ flowchart TD
         tx[MSSQLTransaction]
     end
     subgraph L2["Layer 2 — Pool (spec 047)"]
-        pool["ConnectionPool<br/>(per-catalog, unique_ptr)"]
+        pool["ConnectionPool<br/>(per-catalog; sole strong ref,<br/>streams hold weak_ptr)"]
     end
     subgraph L1["Layer 1 — Protocol (TDS)"]
         conn[TdsConnection]
@@ -150,7 +150,7 @@ classDiagram
         +LookupSchema()
         +RegisterStream(stream) uuid
         +RetrieveStream(uuid) stream
-        -connection_pool_ : unique_ptr~ConnectionPool~
+        -connection_pool_ : shared_ptr~ConnectionPool~ (sole strong ref)
         -metadata_cache_ : unique_ptr~MSSQLMetadataCache~
         -statistics_provider_ : unique_ptr~MSSQLStatisticsProvider~
         -schema_entries_ : map~string,shared_ptr~MSSQLSchemaEntry~~

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -276,7 +276,7 @@ classDiagram
     note for TokenCache "Spec 047 FR-012:<br/>two DatabaseInstances<br/>sharing a secret name<br/>do NOT alias"
 ```
 
-- `MSSQLMetadataCache` is incremental and lazy. Hand-out contract is documented in the header: the caller (`MSSQLTableSet::LoadSingleEntry`) copies the metadata immediately, so the cache's raw-pointer return is safe.
+- `MSSQLMetadataCache` is incremental and lazy. `GetTableMetadata` **copies** the metadata out under the cache mutex — the previous raw-pointer return escaped the lock and raced `Refresh` / bulk reloads freeing the map node (issue #178 review finding).
 - **Locking invariant (issue #178)**: ONE cache-wide `mutex_` guards `schemas_` and everything reachable through it (tables, columns, load states), plus `state_` / `database_collation_`. Loads hold it across their SQL round trip so partial state is never visible — concurrent metadata loads serialize by design. `ttl_seconds_` / `metadata_timeout_ms_` are atomics (written per-lookup by `EnsureCacheLoaded`, read by loaders mid-query while the mutex is held). The pre-#178 split (`mutex_` for Refresh/HasSchema, `schemas_mutex_` for everything else) let `Refresh()` free the whole map under a reader — TSan-confirmed UAF.
 - `MSSQLStatisticsProvider` returns stats by value; no raw-pointer hand-out.
 - `TokenCache` is the only remaining process-wide static, but it is **namespaced by `DatabaseInstance*`** (spec 047 FR-012) so two embeddings can use the same Azure secret name without aliasing.

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -277,6 +277,7 @@ classDiagram
 ```
 
 - `MSSQLMetadataCache` is incremental and lazy. Hand-out contract is documented in the header: the caller (`MSSQLTableSet::LoadSingleEntry`) copies the metadata immediately, so the cache's raw-pointer return is safe.
+- **Locking invariant (issue #178)**: ONE cache-wide `mutex_` guards `schemas_` and everything reachable through it (tables, columns, load states), plus `state_` / `database_collation_`. Loads hold it across their SQL round trip so partial state is never visible — concurrent metadata loads serialize by design. `ttl_seconds_` / `metadata_timeout_ms_` are atomics (written per-lookup by `EnsureCacheLoaded`, read by loaders mid-query while the mutex is held). The pre-#178 split (`mutex_` for Refresh/HasSchema, `schemas_mutex_` for everything else) let `Refresh()` free the whole map under a reader — TSan-confirmed UAF.
 - `MSSQLStatisticsProvider` returns stats by value; no raw-pointer hand-out.
 - `TokenCache` is the only remaining process-wide static, but it is **namespaced by `DatabaseInstance*`** (spec 047 FR-012) so two embeddings can use the same Azure secret name without aliasing.
 - Result streams (large `mssql_scan` results) live in `MSSQLCatalog::active_streams_`, keyed by a UUID handle that bridges Bind-time stream creation and InitGlobal-time consumption (spec 047 US3).
@@ -423,6 +424,7 @@ sequenceDiagram
 | 047 | Per-catalog `unique_ptr<ConnectionPool>` (was process-wide); per-catalog `active_streams_`; `TokenCache` keyed by `(DatabaseInstance*, key)` |
 | 051 | `src/include/mssql_compat.hpp` — DuckDB API shims (header relocation, single-arg `BindScalarFunctionInput`) |
 | 052 | `shared_ptr` ownership for schema/table entries + `enable_shared_from_this`; `MSSQLBindAnchors` per-ClientContext anchor holder; `MSSQLTableSet` singleflight loader; `MSSQLTableEntry::pk_load_mutex_` double-checked PK load |
+| #178 | Single cache-wide mutex in `MSSQLMetadataCache` (was split across two, Refresh raced readers → UAF); atomic TTL/timeout config fields; `known_table_names_` consistently under `names_mutex_` (Scan was mutating it under `entry_mutex_`); thread-safe magic-static debug-level init everywhere |
 
 ## Where to read the code
 

--- a/docs/proposals/issue-178-concurrent-crash-analysis.md
+++ b/docs/proposals/issue-178-concurrent-crash-analysis.md
@@ -230,6 +230,36 @@ an invalidation epoch counter: `Invalidate`/`InvalidateEntry` bump it,
 * If Phase 1/2 uncovers a new race: fix + DATAMODEL.md invariant update in the
   same PR (per project policy).
 
+## Self-review round (multi-agent, high effort) — additional fixes
+
+A workflow-backed adversarial review of the first fix commit surfaced 10
+verified findings (5 root causes), all fixed in the follow-up commit:
+
+1. **Residual UAF**: `GetTableMetadata`'s raw-pointer return escaped the cache
+   mutex; `LoadSingleEntry` dereferenced it while `Refresh` /
+   `LoadAllTableMetadata` / TTL reloads freed the map node. → metadata is now
+   **copied out under the mutex** (`bool GetTableMetadata(..., out_meta)`).
+2. **Stale resurrection**: the invalidation epoch guard covered only Scan's
+   trailing flag stores; Scan's fill phase and `LoadSingleEntry`'s publication
+   could re-insert pre-invalidation entries after `Invalidate()` cleared them
+   (GetEntry's step-1 fast path serves entries_ unconditionally). → both
+   publications are now epoch-guarded; on a dirty epoch the entry is served to
+   the in-flight call only (anchored via out_entry / snapshot) and nothing
+   persists.
+3. **Negative-cache poisoning (TOCTOU)**: GetEntry step 4 read `names_loaded_`
+   before acquiring `names_mutex_`; a racing `Invalidate` could let it record a
+   permanent `attempted_tables_` negative for an existing table. → flag
+   re-checked under the lock (Invalidate stores the flag before clearing).
+4. **Lock-hold latency**: Scan held `names_mutex_`+`entry_mutex_` while blocking
+   on the cache mutex (held across metadata round trips by other threads),
+   stalling GetEntry's fast path for cached tables. → Scan restructured into
+   three passes; table-set locks and the cache mutex are never held together.
+5. **Empty-list latch**: `Refresh()`'s failure path left `schemas_` cleared with
+   `schemas_load_state_` still LOADED → every later lookup reported existing
+   tables missing until manual invalidation. → state reset to NOT_LOADED in the
+   catch. Dead `EnsureNamesLoaded` (unguarded flag publisher, no callers)
+   deleted.
+
 ## Artifacts from this investigation
 * New regression test: `test/sql/integration/issue178_concurrent_same_table.test`
   (8-connection same-table `concurrentloop`, big-table LIMIT → abandoned-stream path).

--- a/docs/proposals/issue-178-concurrent-crash-analysis.md
+++ b/docs/proposals/issue-178-concurrent-crash-analysis.md
@@ -1,0 +1,239 @@
+# Issue #178 — Concurrent same-table queries crash (Python / DuckDB.NET, Windows): analysis & fix plan
+
+Status: analysis complete, fix plan proposed. Date: 2026-07-08. Main @ `f7ddb6e`.
+
+## TL;DR
+
+1. **Two of the three DuckDB versions the reporter tested ship pre-spec-052 extension
+   binaries that contain the already-fixed concurrent-read UAF (#126).** Verified
+   empirically via `INSTALL mssql FROM community` + `mssql_version()`:
+
+   | DuckDB | community `mssql` binary | spec 052 fix (#127, PR merged 2026-05-27)? |
+   |---|---|---|
+   | 1.5.2 | **0.1.18** (2026-04-14) | NO — contains #126 crash |
+   | 1.5.3 | **0.2.0** (2026-05-20) | NO — contains #126 crash |
+   | 1.5.4 | 0.2.1 (2026-06-05) | yes |
+
+   The reported symptom (two threads reading the **same table** through the attached
+   catalog segfault; one thread fine) is exactly the #126 / spec-052 signature
+   ("dbt threads>=2 segfault", concurrent `MSSQLTableSet::GetEntry` on one table).
+
+2. **The minimal 2-SELECT repro on 1.5.4 (= 0.2.1) could not be reproduced** on
+   macOS (release) or Linux (debug + ASan/UBSan + TSan), including a purpose-built
+   8-connection same-table stress over the previously-untested abandoned-stream
+   path. The report's evidence is Windows-only (Windows Store Python 3.11,
+   DuckDB.NET) and **CI has zero Windows concurrency coverage**.
+
+3. **TSan found two crash-grade mutex-mismatch bugs on main / v0.2.1 (D6, D7)**:
+   `MSSQLMetadataCache::Refresh` frees the whole `schemas_` map under `mutex_`
+   while all readers synchronize on `schemas_mutex_` (use-after-free), and
+   `MSSQLTableSet::Scan` mutates `known_table_names_` under `entry_mutex_` while
+   everyone else uses `names_mutex_` (container corruption). Both fire when
+   reads run concurrently with `mssql_refresh_cache` / invalidation / catalog
+   enumeration — a plausible match for the reporter's real 1.5.4 workload even
+   though their minimal repro doesn't hit these paths. Additional non-crash
+   defects: D1 (missing `stability = VOLATILE`), D2 (raw pointer into cache),
+   D3–D5 (destructor contract, unsynchronized config fields, debug-logger races).
+
+## Reproduction attempts (none crashed, except as noted)
+
+Environment: SQL Server 2022 in Docker (`mssql-dev`), tables: 500k-row PK table,
+200k-row heap (no PK) table. `LIMIT 10` on those tables abandons the TDS stream
+mid-flight → exercises Cancel/ATTENTION/drain/pool-reuse.
+
+| # | Build | Platform | Scenario | Result |
+|---|---|---|---|---|
+| 1 | main release (DuckDB v1.5.4) | macOS, python 1.5.4 | issue repro verbatim, 2–8 threads × 30 iters, same table | no crash |
+| 2 | main release | macOS | exact-match: secret with `USE_ENCRYPT FALSE, CATALOG TRUE, SCHEMA_FILTER '^(dbo)$'`, heap table, LIMIT 10, 2 threads × 15 | no crash |
+| 3 | community **0.1.18** (pre-052!) | macOS, python 1.5.2 | 8 threads × 50, warm + cold binds (cache dropped per round) | no crash (see note) |
+| 4 | main debug **ASan+UBSan** | Linux arm64 (ubuntu 22.04) | new `test/sql/integration/issue178_concurrent_same_table.test`: `concurrentloop` 8 connections × same 500k-row table, LIMIT 10 | **PASS, sanitizer-clean** |
+| 5 | main debug ASan+UBSan | Linux | spec-052 harness `test_concurrent_reads` scenarios 1–8 (incl. 30s invalidation-race & sibling-cache soaks) | **ALL PASS** |
+| 6 | main debug **TSan** | Linux | issue178 test (8 connections, same table) | test PASSES; 5 data races reported — none crash-grade (see D4/D5) |
+| 7 | main debug **TSan** | Linux | spec-052 harness scenarios 1–8 | all PASS; **55 race reports → 2 CRASH-GRADE mutex-mismatch bugs (D6, D7)** + repeats of D4/D5 |
+| 8 | main (pre-fix) debug **ASan** | Linux | harness scenario 6 (readers + `mssql_refresh_cache` invalidator + `duckdb_tables()` walker), repeated runs | **CRASHES: heap-use-after-free, 2 of 3 runs** — freed `MSSQLTableMetadata` read in `MakeTableInfo` (mssql_table_entry.cpp:46) while `Refresh()` freed the map. This IS the D6 bug producing a hard segfault-class abort on v0.2.1-era code. |
+| 9 | `fix/178-concurrency-races` | Linux | issue178 test + harness under TSan/ASan | **0 race reports** (was 5 + 55); functional flag-stomp bug in `Scan`-vs-`Invalidate` found & fixed via invalidation epoch guard |
+
+Note on (3): #126 was only ever trapped by UBSan on Linux; a macOS release binary
+not crashing is weak evidence of absence. The pre-052 UAF in 0.1.18/0.2.0 is
+documented and fixed history, not a hypothesis.
+
+macOS-local sanitizers were unusable during this work: on Darwin 25.5 the Xcode
+clang ASan runtime hangs in `InitializeShadowMemory`/`get_dyld_hdr` and TSan
+SIGSEGVs in `__tsan::SlotLock` at startup — hence the Linux container lab
+(`docker/Dockerfile.build` derivative, arm64).
+
+## Code audit (main @ f7ddb6e)
+
+Audited for the two-concurrent-same-table-scans scenario: catalog entry lifetime
+(`MSSQLTableSet::GetEntry` singleflight + `MSSQLBindAnchors`), `EnsurePKLoaded`,
+metadata cache, statistics provider, catalog filter regexes, transaction manager,
+`ConnectionPool` (acquire/release/cleanup thread), `ConnectionProvider`,
+`MSSQLResultStream` cancel/drain/destructor, connection factory closures,
+optimizer hooks, `MaxThreads()`. **No crash-grade race found on this path
+post-052** — consistent with the sanitizer-clean Linux runs.
+
+Real defects found (to fix regardless):
+
+### D6. CRASH-GRADE (TSan-confirmed): `MSSQLMetadataCache::Refresh` guards `schemas_` with the WRONG mutex
+The cache has two mutexes. Hot-path readers/writers of the `schemas_` map —
+`GetTableMetadata` (:281), `EnsureSchemasLoaded` (:926), `ForEachTableInSchema`
+(:787), `GetTableNames` (:261), `LoadAllTableMetadata` (:631),
+`TryGetCachedSchemaNames` (:412), `InvalidateAll` (:1100) — all take
+**`schemas_mutex_`**. But **`Refresh()` (:801) takes `mutex_` and does
+`schemas_.clear()` (:808) + full rebuild**, and `HasSchema` (:398) / `HasTable`
+(:403) also read `schemas_` under `mutex_`. There is **no mutual exclusion**
+between `Refresh` and the entire read side: a refresh frees every
+`MSSQLSchemaMetadata` node and `vector<MSSQLColumnInfo>` while a concurrent bind
+iterates them → **use-after-free → segfault**. TSan caught the freed-vs-read
+pairs live in harness scenarios 5/6 (32 `operator delete` race reports on
+`_Hash_node<pair<string, MSSQLSchemaMetadata>>` and `vector<MSSQLColumnInfo>`).
+
+Triggers: `mssql_refresh_cache()` concurrent with any query on the same catalog
+(a documented, recommended call after external DDL — very plausible in notebook
+/ .NET app workloads), and any future TTL-driven refresh path. NOT triggered by
+the minimal 2-SELECT repro (that path never calls `Refresh`).
+
+Fix: ONE mutex for all `schemas_` access (fold `mutex_`-guarded methods onto
+`schemas_mutex_`, or vice versa), and audit every `schemas_` touch site.
+
+### D7. CRASH-GRADE (TSan-confirmed): `known_table_names_` written under mismatched mutexes
+`MSSQLTableSet::Scan` phase 1 inserts into `known_table_names_` at
+mssql_table_set.cpp:152 while holding **`entry_mutex_`**; every other reader /
+writer (`GetEntry` :86, `EnsureNamesLoaded` :341/:368, `Invalidate` :297,
+`InvalidateEntry` :316) uses **`names_mutex_`**. Concurrent
+`SHOW TABLES` / `duckdb_tables()` / any `Scan` + a refresh/invalidate →
+unsynchronized `unordered_set` mutation → heap corruption. TSan caught
+`Scan`-insert racing `Invalidate`-clear live (read stack:
+`PhysicalTableScan::GetGlobalSourceState → MSSQLSchemaEntry::Scan → :152`;
+write stack: `RefreshCache → MSSQLTableSet::Invalidate → :297`).
+
+Fix: take `names_mutex_` around the insert in `Scan` phase 1 (lock order
+`entry_mutex_` → `names_mutex_` matches the documented order in
+`InvalidateEntry`).
+
+### D1. Side-effecting scalar functions are constant-foldable
+`src/catalog/mssql_refresh_function.cpp` registers `mssql_refresh_cache` and
+`mssql_invalidate_cache` without `stability = FunctionStability::VOLATILE`
+(default CONSISTENT). DuckDB constant-folds them:
+* debug builds: `D_ASSERT(allow_unfoldable || result.GetVectorType() == CONSTANT_VECTOR)`
+  fires in `expression_executor.cpp:136` (reproduced on Linux debug — the function
+  writes a FLAT vector);
+* release builds: the side effect executes at **plan time** and the result may be
+  folded/cached — semantically wrong.
+
+No function in `src/` sets `stability` at all → audit every side-effecting scalar
+(`mssql_exec`, `mssql_open/close/ping/close_all`, auth-test functions, preload).
+
+### D2. `MSSQLMetadataCache::GetTableMetadata` returns a raw pointer into the cache
+`src/catalog/mssql_metadata_cache.cpp:276-395` returns `&table_it->second` /
+`&table_meta`; `schemas_mutex_` is released on return, and the caller
+(`MSSQLTableSet::LoadSingleEntry`) dereferences it afterwards
+(`CreateTableEntry(*table_meta)`). Safe today only because the table-set
+singleflight serialises same-table loads and map node pointers survive sibling
+inserts — any future caller without those guarantees is a UAF. Copy out under the
+lock (or provide a visit-under-lock API).
+
+### D4. Unsynchronized config fields on `MSSQLMetadataCache` (TSan-confirmed)
+`MSSQLCatalog::EnsureCacheLoaded` (mssql_catalog.cpp:933) calls
+`SetMetadataTimeout` / `SetTTL` on **every catalog lookup**, writing
+`metadata_timeout_ms_` (int) and `ttl_seconds_` (long) with **no lock**, while
+concurrent threads read them mid-metadata-query (`ExecuteMetadataQuery`
+mssql_metadata_cache.cpp:909, `EnsureSchemasLoaded` fast path :919). The
+`EnsureSchemasLoaded` fast path also reads `schemas_load_state_` /
+`schemas_last_refresh_` outside `schemas_mutex_` (unsynchronized double-checked
+locking). Not crash-grade (same-value scalar rewrites in steady state), but
+formal UB and it pollutes every future TSan run. Fix: make the two fields
+`std::atomic`, and make the DCL fast path an atomic load (or drop the fast path
+— the mutex is cheap here).
+
+### D5. Lazy-init `static int level` debug-logger race (TSan-confirmed, project-wide)
+`GetCatalogDebugLevel` / `GetDebugLevel` / `GetExecutorDebugLevel` etc. use
+`static int level = -1; if (level == -1) level = atoi(getenv(...))` — concurrent
+first calls race on the plain int (TSan reports 3 instances; the pattern exists
+in ~10 files). Benign in practice (same value written), formal UB. Fix once:
+`static const int level = [] { ... }();` (C++11 magic statics) in a shared
+header, or `std::atomic<int>`.
+
+### D3. `~MSSQLResultStream` may run outside the owning query
+The destructor releases the connection via `ConnectionProvider::ReleaseConnection`
+→ `MetaTransaction::Get(context)`. Host apps can destroy query results after the
+query/transaction is gone (.NET reader disposal, Python GC); today a catch-all
+downgrades that to "drop connection instead of pooling it". Works by accident —
+make the no-active-transaction path explicit.
+
+## Fix plan
+
+### Phase 0 — reporter follow-up (issue comment, no code)
+1. Ask for `SELECT mssql_version();` from the **crashing 1.5.4** environment — was
+   0.2.1 actually exercised, or was the crash observed on 1.5.2/1.5.3 (= 0.1.18 /
+   0.2.0, both pre-fix) and extrapolated?
+2. Explain the version mapping above; recommend DuckDB 1.5.4 + `FORCE INSTALL
+   mssql FROM community` and re-test.
+3. If it still crashes on 0.2.1: request a native stack
+   (`python -X faulthandler ...` or WinDbg `!analyze -v`), the table's row count &
+   schema (does `LIMIT` abandon a large stream?), and SQL Server version.
+
+### Phase 1 — Windows concurrency CI (highest leverage)
+The crash evidence is Windows-only and `concurrency-tests.yml` runs only on
+ubuntu. Add a `windows-latest` job: MSVC build (existing `x64-windows-static-release`
+config), SQL Server 2022 Express (choco silent install, TCP enabled) or LocalDB
+with TCP; run `test_concurrent_reads` scenarios + the new
+`issue178_concurrent_same_table.test`. If it reproduces → root-cause there
+(prime suspects: Winsock teardown timing in cancel/drain, `WSAPoll` semantics).
+
+### Phase 2 — TSan sweep
+`THREADSAN=1` Linux build (in progress in the lab); if clean, add a
+`workflow_dispatch` TSan variant to `concurrency-tests.yml` so races that don't
+corrupt the heap stay catchable.
+
+### Phase 3 — deterministic fixes (independent of repro), in priority order
+1. **D6 (crash-grade)**: unify `schemas_` locking in `MSSQLMetadataCache` on one
+   mutex; audit all `schemas_` touch sites (`Refresh`, `HasSchema`, `HasTable`
+   are on the wrong mutex today).
+2. **D7 (crash-grade)**: `Scan` phase 1 must take `names_mutex_` around the
+   `known_table_names_` insert.
+3. **D2**: `GetTableMetadata` → copy-out-under-lock (or callback API) — removes
+   the raw-pointer-into-cache contract that D6-style bugs feed on.
+4. **D1**: set `stability = VOLATILE` on all side-effecting scalars (+ the
+   `SetVectorType` contract review). Small, testable, fixes a real release-mode bug.
+5. **D3**: explicit transaction-less release path in `~MSSQLResultStream`.
+6. **D4**: atomics for `metadata_timeout_ms_` / `ttl_seconds_` + fix the
+   `EnsureSchemasLoaded` double-checked fast path.
+7. **D5**: replace the lazy-init debug-level pattern with a magic-static in one
+   shared helper. After D4–D7 the extension is TSan-clean on these paths — keep
+   it that way via the Phase-2 CI job.
+8. Keep `test/sql/integration/issue178_concurrent_same_table.test` (added by this
+   work); add an abandoned-stream scenario 9 (big table + LIMIT) AND a
+   reads-vs-`mssql_refresh_cache` scenario 10 (deterministic D6 repro) to
+   `test_concurrent_reads.cpp`; wire everything into the concurrency CI job.
+
+Note on issue #178 attribution: D6 is a **proven hard crash** on v0.2.1-era code —
+ASan aborts with heap-use-after-free in 2 of 3 harness scenario-6 runs (reads +
+`mssql_refresh_cache` + `duckdb_tables()` walker). Workloads mixing reads with
+refresh/invalidation/catalog enumeration (notebook variable explorers, IDE
+introspection, dbt) hit exactly this — a very plausible match for the reporter's
+real notebook / .NET workloads on 1.5.4, even though their minimal 2-SELECT
+repro is sanitizer-clean on that build. Phase 0 confirms or refutes.
+
+Additional fix shipped with D7: `Scan`'s unconditional trailing
+`names_loaded_/is_fully_loaded_ = true` stomped a concurrent `Invalidate()`,
+leaving TRUE flags over cleared containers — `GetEntry` then reported existing
+tables as missing ("Table ... does not exist", harness scenario 6). Fixed with
+an invalidation epoch counter: `Invalidate`/`InvalidateEntry` bump it,
+`Scan` publishes the flags only if the epoch is unchanged.
+
+### Phase 4 — release & docs
+* Ship as v0.2.2 for DuckDB 1.5.4+.
+* README/troubleshooting note: concurrency requires extension ≥ 0.2.1; DuckDB
+  1.5.2/1.5.3 community channels permanently serve pre-fix binaries (0.1.18 /
+  0.2.0) — the only remedy is upgrading DuckDB.
+* If Phase 1/2 uncovers a new race: fix + DATAMODEL.md invariant update in the
+  same PR (per project policy).
+
+## Artifacts from this investigation
+* New regression test: `test/sql/integration/issue178_concurrent_same_table.test`
+  (8-connection same-table `concurrentloop`, big-table LIMIT → abandoned-stream path).
+* Linux sanitizer lab: ubuntu 22.04 container, repo copy + vcpkg + `GEN=ninja make debug`
+  (ASan/UBSan) and `GEN=ninja THREADSAN=1 DUCKDB_PLATFORM=linux_arm64 make debug` (TSan).
+* Known-broken: macOS Darwin 25.5 + current Xcode clang sanitizer runtimes
+  (ASan hangs at init, TSan SIGSEGV at init) — use the Linux lab.

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -216,7 +216,7 @@ void MSSQLCatalog::Initialize(bool load_builtin) {
 	}
 	}
 
-	connection_pool_ = make_uniq<tds::ConnectionPool>(context_name_, pool_config_, std::move(factory));
+	connection_pool_ = make_shared_ptr<tds::ConnectionPool>(context_name_, pool_config_, std::move(factory));
 
 	// Skip metadata initialization when catalog integration is disabled
 	// (mssql_scan/mssql_exec will still work via raw queries)
@@ -776,6 +776,10 @@ void MSSQLCatalog::OnDetach(ClientContext &context) {
 //===----------------------------------------------------------------------===//
 // MSSQL-specific Accessors
 //===----------------------------------------------------------------------===//
+
+weak_ptr<tds::ConnectionPool> MSSQLCatalog::GetConnectionPoolHandle() const {
+	return weak_ptr<tds::ConnectionPool>(connection_pool_);
+}
 
 tds::ConnectionPool &MSSQLCatalog::GetConnectionPool() {
 	if (!connection_pool_) {

--- a/src/catalog/mssql_metadata_cache.cpp
+++ b/src/catalog/mssql_metadata_cache.cpp
@@ -230,8 +230,8 @@ vector<string> MSSQLMetadataCache::GetTableNames(tds::TdsConnection &connection,
 	return names;
 }
 
-const MSSQLTableMetadata *MSSQLMetadataCache::GetTableMetadata(tds::TdsConnection &connection,
-															   const string &schema_name, const string &table_name) {
+bool MSSQLMetadataCache::GetTableMetadata(tds::TdsConnection &connection, const string &schema_name,
+										  const string &table_name, MSSQLTableMetadata &out_meta) {
 	// Only load schemas (fast — just schema names, no tables)
 	EnsureSchemasLoaded(connection);
 
@@ -241,7 +241,7 @@ const MSSQLTableMetadata *MSSQLMetadataCache::GetTableMetadata(tds::TdsConnectio
 	auto schema_it = schemas_.find(schema_name);
 	if (schema_it == schemas_.end()) {
 		CACHE_DEBUG(1, "GetTableMetadata('%s.%s') — schema not found", schema_name.c_str(), table_name.c_str());
-		return nullptr;
+		return false;
 	}
 
 	auto &schema = schema_it->second;
@@ -252,7 +252,8 @@ const MSSQLTableMetadata *MSSQLMetadataCache::GetTableMetadata(tds::TdsConnectio
 		!IsTTLExpired(table_it->second.columns_last_refresh, ttl_seconds_)) {
 		CACHE_DEBUG(2, "GetTableMetadata('%s.%s') — cache hit (%zu columns)", schema_name.c_str(), table_name.c_str(),
 					table_it->second.columns.size());
-		return &table_it->second;
+		out_meta = table_it->second;  // copy under mutex_ — see header contract
+		return true;
 	}
 
 	// Single-table query: load object type + columns in one round trip
@@ -338,7 +339,7 @@ const MSSQLTableMetadata *MSSQLMetadataCache::GetTableMetadata(tds::TdsConnectio
 		schema.tables.erase(slot_it);
 		CACHE_DEBUG(1, "GetTableMetadata('%s.%s') — table not found on SQL Server", schema_name.c_str(),
 					table_name.c_str());
-		return nullptr;
+		return false;
 	}
 
 	// Cache the result (slot is already in the map)
@@ -348,7 +349,8 @@ const MSSQLTableMetadata *MSSQLMetadataCache::GetTableMetadata(tds::TdsConnectio
 	CACHE_DEBUG(1, "GetTableMetadata('%s.%s') — loaded %zu columns", schema_name.c_str(), table_name.c_str(),
 				table_meta.columns.size());
 
-	return &table_meta;
+	out_meta = table_meta;	// copy under mutex_ — see header contract
+	return true;
 }
 
 bool MSSQLMetadataCache::HasSchema(const string &schema_name) {
@@ -799,6 +801,11 @@ void MSSQLMetadataCache::Refresh(tds::TdsConnection &connection, const string &d
 		}
 	} catch (...) {
 		state_ = MSSQLCacheState::INVALID;
+		// Issue #178 review: schemas_ was cleared at the top of Refresh; if the
+		// reload threw, schemas_load_state_ must NOT remain LOADED (a stale
+		// LOADED over the emptied map made every later lookup report existing
+		// tables as missing until a manual invalidation).
+		schemas_load_state_ = CacheLoadState::NOT_LOADED;
 		throw;
 	}
 }

--- a/src/catalog/mssql_metadata_cache.cpp
+++ b/src/catalog/mssql_metadata_cache.cpp
@@ -6,11 +6,10 @@
 
 // Debug logging for metadata cache operations
 static int GetMetadataCacheDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 
@@ -174,57 +173,15 @@ static void RunMetadataQuery(tds::TdsConnection &connection, const string &sql, 
 }
 
 //===----------------------------------------------------------------------===//
-// Move constructors for structs with mutex (T007, T008)
-//===----------------------------------------------------------------------===//
-
-MSSQLTableMetadata::MSSQLTableMetadata(MSSQLTableMetadata &&other) noexcept
-	: name(std::move(other.name)),
-	  object_type(other.object_type),
-	  columns(std::move(other.columns)),
-	  approx_row_count(other.approx_row_count),
-	  columns_load_state(other.columns_load_state),
-	  columns_last_refresh(other.columns_last_refresh) {
-	// Note: load_mutex is default-constructed (not moved)
-}
-
-MSSQLTableMetadata &MSSQLTableMetadata::operator=(MSSQLTableMetadata &&other) noexcept {
-	if (this != &other) {
-		name = std::move(other.name);
-		object_type = other.object_type;
-		columns = std::move(other.columns);
-		approx_row_count = other.approx_row_count;
-		columns_load_state = other.columns_load_state;
-		columns_last_refresh = other.columns_last_refresh;
-		// Note: load_mutex is not moved
-	}
-	return *this;
-}
-
-MSSQLSchemaMetadata::MSSQLSchemaMetadata(MSSQLSchemaMetadata &&other) noexcept
-	: name(std::move(other.name)),
-	  tables(std::move(other.tables)),
-	  tables_load_state(other.tables_load_state),
-	  tables_last_refresh(other.tables_last_refresh) {
-	// Note: load_mutex is default-constructed (not moved)
-}
-
-MSSQLSchemaMetadata &MSSQLSchemaMetadata::operator=(MSSQLSchemaMetadata &&other) noexcept {
-	if (this != &other) {
-		name = std::move(other.name);
-		tables = std::move(other.tables);
-		tables_load_state = other.tables_load_state;
-		tables_last_refresh = other.tables_last_refresh;
-		// Note: load_mutex is not moved
-	}
-	return *this;
-}
-
-//===----------------------------------------------------------------------===//
 // Constructor
 //===----------------------------------------------------------------------===//
 
 MSSQLMetadataCache::MSSQLMetadataCache(int64_t ttl_seconds)
-	: state_(MSSQLCacheState::EMPTY), ttl_seconds_(ttl_seconds) {}
+	: state_(MSSQLCacheState::EMPTY),
+	  ttl_seconds_(ttl_seconds),
+	  // Pre-ATTACH placeholder only: EnsureCacheLoaded / RefreshCache overwrite
+	  // this from the mssql_metadata_timeout setting on every catalog lookup.
+	  metadata_timeout_ms_(tds::DEFAULT_METADATA_TIMEOUT * 1000) {}
 
 //===----------------------------------------------------------------------===//
 // Cache Access (with lazy loading) - T016, T017, T018
@@ -242,7 +199,7 @@ vector<string> MSSQLMetadataCache::GetSchemaNames(tds::TdsConnection &connection
 	// Trigger lazy loading of schema list
 	EnsureSchemasLoaded(connection);
 
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	vector<string> names;
 	for (const auto &pair : schemas_) {
 		// Apply schema filter if set
@@ -258,7 +215,7 @@ vector<string> MSSQLMetadataCache::GetTableNames(tds::TdsConnection &connection,
 	// Trigger lazy loading of schemas and tables for this schema
 	EnsureTablesLoaded(connection, schema_name);
 
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	vector<string> names;
 	auto it = schemas_.find(schema_name);
 	if (it != schemas_.end()) {
@@ -278,7 +235,7 @@ const MSSQLTableMetadata *MSSQLMetadataCache::GetTableMetadata(tds::TdsConnectio
 	// Only load schemas (fast — just schema names, no tables)
 	EnsureSchemasLoaded(connection);
 
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 
 	// Ensure schema entry exists
 	auto schema_it = schemas_.find(schema_name);
@@ -409,7 +366,7 @@ bool MSSQLMetadataCache::HasTable(const string &schema_name, const string &table
 }
 
 bool MSSQLMetadataCache::TryGetCachedSchemaNames(vector<string> &out_names) {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 
 	// T036: Return cached schema names only if schemas are loaded and not expired
 	if (schemas_load_state_ != CacheLoadState::LOADED) {
@@ -442,7 +399,7 @@ void MSSQLMetadataCache::LoadAllTableMetadata(tds::TdsConnection &connection, co
 
 	// Check if all tables in this schema already have columns loaded
 	{
-		std::lock_guard<std::mutex> lock(schemas_mutex_);
+		std::lock_guard<std::mutex> lock(mutex_);
 		auto schema_it = schemas_.find(schema_name);
 		if (schema_it == schemas_.end()) {
 			CACHE_DEBUG(1, "LoadAllTableMetadata('%s') — schema not found", schema_name.c_str());
@@ -491,7 +448,7 @@ void MSSQLMetadataCache::LoadAllTableMetadata(tds::TdsConnection &connection, co
 	idx_t table_count = 0;
 	idx_t column_count = 0;
 
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto schema_it = schemas_.find(schema_name);
 	if (schema_it == schemas_.end()) {
 		return;
@@ -628,7 +585,7 @@ void MSSQLMetadataCache::BulkLoadAll(tds::TdsConnection &connection, const strin
 		CACHE_DEBUG(1, "BulkLoadAll: discovered %zu schemas to load", schemas_to_load.size());
 	}
 
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 
 	// Load metadata per schema — each query sorts only within one schema,
 	// keeping the result set small enough to avoid tempdb spills
@@ -774,7 +731,7 @@ void MSSQLMetadataCache::BulkLoadAll(tds::TdsConnection &connection, const strin
 
 void MSSQLMetadataCache::ForEachTable(
 	const std::function<void(const string &, const string &, idx_t)> &callback) const {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	for (const auto &schema_pair : schemas_) {
 		for (const auto &table_pair : schema_pair.second.tables) {
 			callback(schema_pair.first, table_pair.first, table_pair.second.approx_row_count);
@@ -784,7 +741,7 @@ void MSSQLMetadataCache::ForEachTable(
 
 void MSSQLMetadataCache::ForEachTableInSchema(
 	const string &schema_name, const std::function<void(const string &, const MSSQLTableMetadata &)> &callback) const {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto schema_it = schemas_.find(schema_name);
 	if (schema_it == schemas_.end()) {
 		return;
@@ -877,12 +834,10 @@ MSSQLCacheState MSSQLMetadataCache::GetState() const {
 }
 
 void MSSQLMetadataCache::SetTTL(int64_t ttl_seconds) {
-	std::lock_guard<std::mutex> lock(mutex_);
 	ttl_seconds_ = ttl_seconds;
 }
 
 int64_t MSSQLMetadataCache::GetTTL() const {
-	std::lock_guard<std::mutex> lock(mutex_);
 	return ttl_seconds_;
 }
 
@@ -891,7 +846,7 @@ void MSSQLMetadataCache::SetDatabaseCollation(const string &collation) {
 	database_collation_ = collation;
 }
 
-const string &MSSQLMetadataCache::GetDatabaseCollation() const {
+string MSSQLMetadataCache::GetDatabaseCollation() const {
 	std::lock_guard<std::mutex> lock(mutex_);
 	return database_collation_;
 }
@@ -915,20 +870,17 @@ void MSSQLMetadataCache::ExecuteMetadataQuery(tds::TdsConnection &connection, co
 //===----------------------------------------------------------------------===//
 
 void MSSQLMetadataCache::EnsureSchemasLoaded(tds::TdsConnection &connection) {
-	// Fast path: already loaded and not expired
+	// Issue #178 (D4): no unlocked fast path — the old pre-lock check read
+	// schemas_load_state_ / schemas_last_refresh_ racily. The mutex is cheap
+	// next to everything around it (a catalog lookup already did a settings
+	// read and a pool interaction to get here).
+	std::lock_guard<std::mutex> lock(mutex_);
+
 	if (schemas_load_state_ == CacheLoadState::LOADED && !IsTTLExpired(schemas_last_refresh_, ttl_seconds_)) {
 		CACHE_DEBUG(2, "EnsureSchemasLoaded — already loaded (%zu schemas)", schemas_.size());
 		return;
 	}
 	CACHE_DEBUG(1, "EnsureSchemasLoaded — loading schemas from SQL Server");
-
-	// Slow path: acquire lock and double-check
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
-
-	// Double-check after acquiring lock
-	if (schemas_load_state_ == CacheLoadState::LOADED && !IsTTLExpired(schemas_last_refresh_, ttl_seconds_)) {
-		return;
-	}
 
 	// Mark as loading
 	schemas_load_state_ = CacheLoadState::LOADING;
@@ -972,10 +924,15 @@ void MSSQLMetadataCache::EnsureSchemasLoaded(tds::TdsConnection &connection) {
 }
 
 void MSSQLMetadataCache::EnsureTablesLoaded(tds::TdsConnection &connection, const string &schema_name) {
-	// First ensure schemas are loaded
+	// First ensure schemas are loaded (takes and releases mutex_ internally)
 	EnsureSchemasLoaded(connection);
 
-	// Find schema
+	// Issue #178 (D6): everything below runs under the cache-wide mutex_. The
+	// old code found the schema and checked its load state with NO lock, then
+	// mutated schema.tables under the per-schema load_mutex — which excluded
+	// nothing: every other reader/writer of the same containers holds mutex_.
+	std::lock_guard<std::mutex> lock(mutex_);
+
 	auto schema_it = schemas_.find(schema_name);
 	if (schema_it == schemas_.end()) {
 		return;	 // Schema doesn't exist
@@ -983,21 +940,12 @@ void MSSQLMetadataCache::EnsureTablesLoaded(tds::TdsConnection &connection, cons
 
 	MSSQLSchemaMetadata &schema = schema_it->second;
 
-	// Fast path: already loaded and not expired
 	if (schema.tables_load_state == CacheLoadState::LOADED && !IsTTLExpired(schema.tables_last_refresh, ttl_seconds_)) {
 		CACHE_DEBUG(2, "EnsureTablesLoaded('%s') — already loaded (%zu tables)", schema_name.c_str(),
 					schema.tables.size());
 		return;
 	}
 	CACHE_DEBUG(1, "EnsureTablesLoaded('%s') — loading table names from SQL Server", schema_name.c_str());
-
-	// Slow path: acquire schema's lock and double-check
-	std::lock_guard<std::mutex> lock(schema.load_mutex);
-
-	// Double-check after acquiring lock
-	if (schema.tables_load_state == CacheLoadState::LOADED && !IsTTLExpired(schema.tables_last_refresh, ttl_seconds_)) {
-		return;
-	}
 
 	// Mark as loading
 	schema.tables_load_state = CacheLoadState::LOADING;
@@ -1061,7 +1009,7 @@ void MSSQLMetadataCache::EnsureTablesLoaded(tds::TdsConnection &connection, cons
 //===----------------------------------------------------------------------===//
 
 void MSSQLMetadataCache::InvalidateSchema(const string &schema_name) {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = schemas_.find(schema_name);
 	if (it != schemas_.end()) {
 		it->second.tables_load_state = CacheLoadState::NOT_LOADED;
@@ -1074,7 +1022,7 @@ void MSSQLMetadataCache::InvalidateSchema(const string &schema_name) {
 }
 
 void MSSQLMetadataCache::InvalidateSchemaTableList(const string &schema_name) {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = schemas_.find(schema_name);
 	if (it != schemas_.end()) {
 		// Existence only — re-fetch the table list, but keep every table's cached
@@ -1084,7 +1032,7 @@ void MSSQLMetadataCache::InvalidateSchemaTableList(const string &schema_name) {
 }
 
 void MSSQLMetadataCache::InvalidateTable(const string &schema_name, const string &table_name) {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto schema_it = schemas_.find(schema_name);
 	if (schema_it == schemas_.end()) {
 		return;
@@ -1097,7 +1045,7 @@ void MSSQLMetadataCache::InvalidateTable(const string &schema_name, const string
 }
 
 void MSSQLMetadataCache::InvalidateAll() {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	schemas_load_state_ = CacheLoadState::NOT_LOADED;
 	for (auto &schema_entry : schemas_) {
 		schema_entry.second.tables_load_state = CacheLoadState::NOT_LOADED;
@@ -1114,12 +1062,12 @@ void MSSQLMetadataCache::InvalidateAll() {
 //===----------------------------------------------------------------------===//
 
 CacheLoadState MSSQLMetadataCache::GetSchemasState() const {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	return schemas_load_state_;
 }
 
 CacheLoadState MSSQLMetadataCache::GetTablesState(const string &schema_name) const {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = schemas_.find(schema_name);
 	if (it == schemas_.end()) {
 		return CacheLoadState::NOT_LOADED;
@@ -1128,7 +1076,7 @@ CacheLoadState MSSQLMetadataCache::GetTablesState(const string &schema_name) con
 }
 
 CacheLoadState MSSQLMetadataCache::GetColumnsState(const string &schema_name, const string &table_name) const {
-	std::lock_guard<std::mutex> lock(schemas_mutex_);
+	std::lock_guard<std::mutex> lock(mutex_);
 	auto schema_it = schemas_.find(schema_name);
 	if (schema_it == schemas_.end()) {
 		return CacheLoadState::NOT_LOADED;

--- a/src/catalog/mssql_primary_key.cpp
+++ b/src/catalog/mssql_primary_key.cpp
@@ -9,11 +9,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetPKDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/catalog/mssql_table_entry.cpp
+++ b/src/catalog/mssql_table_entry.cpp
@@ -16,11 +16,10 @@
 
 // Debug logging
 static int GetTableEntryDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/catalog/mssql_table_set.cpp
+++ b/src/catalog/mssql_table_set.cpp
@@ -83,7 +83,14 @@ optional_ptr<CatalogEntry> MSSQLTableSet::GetEntry(ClientContext &context, const
 	//    This avoids an expensive round trip to SQL Server for nonexistent tables
 	if (names_loaded_.load()) {
 		std::lock_guard<std::mutex> nlock(names_mutex_);
-		if (known_table_names_.find(name) == known_table_names_.end()) {
+		// Issue #178 review: RE-CHECK the flag under the lock. The unlocked read
+		// above can see TRUE while a concurrent Invalidate() (flag already
+		// stored false, names clear pending on this mutex) is about to empty
+		// the set — treating "flag true + empty set" as authoritative would
+		// poison attempted_tables_ with a permanent negative for an existing
+		// table. Invalidate stores the flag BEFORE clearing, so a false read
+		// here reliably routes us to the load path instead.
+		if (names_loaded_.load() && known_table_names_.find(name) == known_table_names_.end()) {
 			CATALOG_DEBUG(2, "  -> not in known_table_names_ (%zu names loaded)", known_table_names_.size());
 			std::lock_guard<std::mutex> elock(entry_mutex_);
 			attempted_tables_.insert(name);
@@ -91,13 +98,21 @@ optional_ptr<CatalogEntry> MSSQLTableSet::GetEntry(ClientContext &context, const
 		}
 	}
 
-	// 5. Load single entry with full metadata (columns included)
+	// 5. Load single entry with full metadata (columns included). LoadSingleEntry
+	// hands the freshly built entry back via out param when it skipped publishing
+	// it into entries_ (an Invalidate raced the fetch) — this query still gets a
+	// consistent entry; the next bind reloads fresh metadata.
 	CATALOG_DEBUG(1, "  -> loading columns for '%s.%s' (single table)", schema_.name.c_str(), name.c_str());
-	if (LoadSingleEntry(context, name)) {
-		std::lock_guard<std::mutex> lock(entry_mutex_);
-		auto it = entries_.find(name);
-		if (it != entries_.end()) {
-			anchored = it->second;	// shared_ptr copy under lock
+	shared_ptr<MSSQLTableEntry> loaded;
+	if (LoadSingleEntry(context, name, &loaded)) {
+		if (loaded) {
+			anchored = std::move(loaded);
+		} else {
+			std::lock_guard<std::mutex> lock(entry_mutex_);
+			auto it = entries_.find(name);
+			if (it != entries_.end()) {
+				anchored = it->second;	// shared_ptr copy under lock
+			}
 		}
 	}
 	if (anchored) {
@@ -139,43 +154,82 @@ void MSSQLTableSet::Scan(ClientContext &context, const std::function<void(Catalo
 	// duckdb_tables() calls GetStorageInfo() on each table entry.
 	auto &stats_provider = catalog.GetStatisticsProvider();
 
-	// Phase 1: populate entries_ under entry_mutex_ and capture shared_ptr
-	// references for the callback phase. We collect refs rather than invoking
-	// callback() here so the lock can be released before user code runs —
-	// callbacks frequently call back into DuckDB binder paths that resolve
-	// virtual columns or sibling tables, which would re-enter LoadSingleEntry
-	// and block on entry_mutex_ (spec 052 singleflight grabs it first).
-	// shared_ptr copies in the snapshot keep entries alive even if a sibling
-	// thread fires Invalidate() between phase 1 and phase 2.
+	// Issue #178 review: three passes so the table-set locks (names_mutex_ /
+	// entry_mutex_) are NEVER held while blocking on the cache-wide mutex —
+	// another thread can hold that across a metadata round trip, and nesting
+	// them stalled GetEntry's fast path (SELECTs on already-cached tables) for
+	// the full round trip.
+
+	// Pass A: snapshot which entries already exist (brief entry_mutex_ hold).
+	std::unordered_set<string> have_entries;
+	{
+		std::lock_guard<std::mutex> lock(entry_mutex_);
+		for (const auto &pair : entries_) {
+			have_entries.insert(pair.first);
+		}
+	}
+
+	// Pass B: walk the cache under ONLY the cache mutex. Collect the name list,
+	// preload statistics, and COPY metadata for tables that need new entries
+	// (CreateTableEntry copies it anyway, so this adds no asymptotic cost).
+	vector<string> names_list;
+	vector<MSSQLTableMetadata> to_create;
+	cache.ForEachTableInSchema(schema_.name, [&](const string &table_name, const MSSQLTableMetadata &table_meta) {
+		stats_provider.PreloadRowCount(schema_.name, table_name, table_meta.approx_row_count);
+		names_list.push_back(table_name);
+		if (have_entries.find(table_name) == have_entries.end()) {
+			to_create.push_back(table_meta);
+		}
+	});
+
+	// Pass C: fill entries_/known_table_names_ under names_mutex_ + entry_mutex_
+	// (taken in GetEntry's step-4 nesting order: names before entry). We collect
+	// shared_ptr refs rather than invoking callback() here so the locks are
+	// released before user code runs — callbacks frequently re-enter
+	// LoadSingleEntry paths that need entry_mutex_ (spec 052 singleflight).
 	//
-	// Issue #178 (D7): known_table_names_ is guarded by names_mutex_ everywhere
-	// else (GetEntry, EnsureNamesLoaded, Invalidate*); the insert below used to
-	// run under entry_mutex_ only — TSan caught it racing Invalidate()'s clear.
-	// names_mutex_ is taken BEFORE entry_mutex_ to match GetEntry's nesting
-	// order (its step-4 block acquires entry_mutex_ while holding names_mutex_).
+	// Issue #178 review: the persistent inserts are epoch-guarded too. If an
+	// Invalidate() landed after our metadata load, emplacing here would
+	// resurrect pre-invalidation entries that GetEntry's step-1 fast path then
+	// serves indefinitely. On a dirty epoch we still build entries for THIS
+	// call's callback (anchored, stale-but-consistent listing) but persist
+	// nothing — the next bind reloads fresh metadata.
 	vector<shared_ptr<MSSQLTableEntry>> snapshot;
 	{
 		std::lock_guard<std::mutex> nlock(names_mutex_);
 		std::lock_guard<std::mutex> lock(entry_mutex_);
-		cache.ForEachTableInSchema(schema_.name, [&](const string &table_name, const MSSQLTableMetadata &table_meta) {
-			stats_provider.PreloadRowCount(schema_.name, table_name, table_meta.approx_row_count);
-			known_table_names_.insert(table_name);
+		const bool epoch_clean = invalidation_epoch_.load() == epoch_at_start;
 
-			auto it = entries_.find(table_name);
-			if (it != entries_.end()) {
-				snapshot.push_back(it->second);
-				return;
-			}
-
+		for (auto &table_meta : to_create) {
 			auto entry = CreateTableEntry(table_meta);
-			if (entry) {
-				// Spec 052 T007: emplace-only (winner wins on race
-				// vs LoadSingleEntry). C++11-compatible pair access
-				// (CLAUDE.md ODR rule: no structured bindings).
+			if (!entry) {
+				continue;
+			}
+			if (epoch_clean) {
+				// Spec 052 T007: emplace-only (winner wins on race vs
+				// LoadSingleEntry). C++11-compatible pair access (CLAUDE.md
+				// ODR rule: no structured bindings).
 				auto insert_result = entries_.emplace(entry->name, std::move(entry));
 				snapshot.push_back(insert_result.first->second);
+			} else {
+				snapshot.push_back(std::move(entry));
 			}
-		});
+		}
+		for (const auto &table_name : names_list) {
+			if (have_entries.find(table_name) != have_entries.end()) {
+				auto it = entries_.find(table_name);
+				if (it != entries_.end()) {
+					snapshot.push_back(it->second);
+				}
+				// else: invalidated between passes — omit from this listing;
+				// the epoch guard below keeps the flags unpublished.
+			}
+		}
+		if (epoch_clean) {
+			for (const auto &table_name : names_list) {
+				known_table_names_.insert(table_name);
+			}
+		}
 	}
 
 	// Spec 052 (Option D): anchor each entry in the per-ClientContext
@@ -216,7 +270,8 @@ void MSSQLTableSet::Scan(ClientContext &context, const std::function<void(Catalo
 // Entry Loading
 //===----------------------------------------------------------------------===//
 
-bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name) {
+bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name,
+									shared_ptr<MSSQLTableEntry> *out_entry) {
 	auto &catalog = schema_.GetMSSQLCatalog();
 	auto &cache = catalog.GetMetadataCache();
 	auto &pool = catalog.GetConnectionPool();
@@ -228,6 +283,7 @@ bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name) 
 	// same table so only ONE thread issues the SQL Server round trip. Waiters
 	// re-check the cache after the owner finishes; on cache hit they return
 	// the owner's entry without a redundant fetch.
+	uint64_t epoch_at_start;
 	{
 		std::unique_lock<std::mutex> lock(entry_mutex_);
 		load_cv_.wait(lock, [this, &name]() { return loads_in_progress_.find(name) == loads_in_progress_.end(); });
@@ -240,6 +296,10 @@ bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name) 
 		}
 		// Take the load slot. From here we are the sole fetcher for `name`.
 		loads_in_progress_.insert(name);
+		// Issue #178 review: snapshot the invalidation epoch for the
+		// publication guard below. Captured under entry_mutex_ so any
+		// invalidation whose clears already ran is reflected here.
+		epoch_at_start = invalidation_epoch_.load();
 	}
 
 	// Owner of the load slot. The SQL Server round trip happens with no mutex
@@ -255,18 +315,23 @@ bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name) 
 		if (!connection) {
 			throw IOException("Failed to acquire connection for table loading");
 		}
-		const MSSQLTableMetadata *table_meta = nullptr;
+		// Issue #178 review: metadata is COPIED out of the cache under its
+		// mutex (see GetTableMetadata contract) — the old raw-pointer return
+		// was dereferenced here after the lock was released, racing
+		// Refresh/LoadAllTableMetadata/TTL reloads that free the map node.
+		MSSQLTableMetadata table_meta;
+		bool found = false;
 		try {
-			table_meta = cache.GetTableMetadata(*connection, schema_.name, name);
+			found = cache.GetTableMetadata(*connection, schema_.name, name, table_meta);
 		} catch (...) {
 			pool.Release(std::move(connection));
 			throw;
 		}
 		pool.Release(std::move(connection));
 
-		if (table_meta) {
+		if (found) {
 			table_exists = true;
-			fetched_entry = CreateTableEntry(*table_meta);
+			fetched_entry = CreateTableEntry(table_meta);
 		}
 	} catch (...) {
 		propagated = std::current_exception();
@@ -275,12 +340,19 @@ bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name) 
 	// Publish results + release the load slot. attempted_tables_ is set on
 	// success and on confirmed-not-exists; on exception it is NOT set so the
 	// next caller retries the fetch.
+	//
+	// Issue #178 review: publication is epoch-guarded. If an Invalidate()
+	// landed after our snapshot, emplacing would resurrect a pre-invalidation
+	// entry (and a stale not-exists verdict would poison attempted_tables_).
+	// On a dirty epoch nothing is persisted; the fetched entry is still handed
+	// to THIS caller via out_entry, and the next bind reloads fresh metadata.
 	{
 		std::unique_lock<std::mutex> lock(entry_mutex_);
-		if (table_exists && fetched_entry) {
-			entries_.emplace(fetched_entry->name, std::move(fetched_entry));
+		const bool epoch_clean = invalidation_epoch_.load() == epoch_at_start;
+		if (epoch_clean && table_exists && fetched_entry) {
+			entries_.emplace(fetched_entry->name, fetched_entry);
 			attempted_tables_.insert(name);
-		} else if (!propagated && !table_exists) {
+		} else if (epoch_clean && !propagated && !table_exists) {
 			attempted_tables_.insert(name);
 		}
 		loads_in_progress_.erase(name);
@@ -289,6 +361,9 @@ bool MSSQLTableSet::LoadSingleEntry(ClientContext &context, const string &name) 
 
 	if (propagated) {
 		std::rethrow_exception(propagated);
+	}
+	if (out_entry && fetched_entry) {
+		*out_entry = std::move(fetched_entry);
 	}
 	return table_exists;
 }
@@ -349,49 +424,6 @@ shared_ptr<MSSQLTableEntry> MSSQLTableSet::CreateTableEntry(const MSSQLTableMeta
 	// enable_shared_from_this to work in MSSQLTableEntry::GetScanFunction's
 	// bind-data anchor (shared_from_this()).
 	return make_shared_ptr<MSSQLTableEntry>(schema_.catalog, schema_, metadata);
-}
-
-void MSSQLTableSet::EnsureNamesLoaded(ClientContext &context) {
-	// Fast path: names already loaded
-	if (names_loaded_.load()) {
-		CATALOG_DEBUG(2, "EnsureNamesLoaded('%s') — already loaded", schema_.name.c_str());
-		return;
-	}
-	CATALOG_DEBUG(1, "EnsureNamesLoaded('%s') — loading table names from SQL Server", schema_.name.c_str());
-
-	// Double-checked locking
-	std::lock_guard<std::mutex> lock(names_mutex_);
-	if (names_loaded_.load()) {
-		return;
-	}
-
-	auto &catalog = schema_.GetMSSQLCatalog();
-	auto &cache = catalog.GetMetadataCache();
-	auto &pool = catalog.GetConnectionPool();
-
-	catalog.EnsureCacheLoaded(context);
-	auto connection = pool.Acquire();
-	if (!connection) {
-		throw IOException("Failed to acquire connection for table name loading");
-	}
-
-	// Only loads table names (fast, no column queries)
-	vector<string> table_names;
-	try {
-		table_names = cache.GetTableNames(*connection, schema_.name);
-	} catch (...) {
-		pool.Release(std::move(connection));
-		throw;
-	}
-
-	pool.Release(std::move(connection));
-
-	for (const auto &name : table_names) {
-		known_table_names_.insert(name);
-	}
-	CATALOG_DEBUG(1, "EnsureNamesLoaded('%s') — loaded %zu table names (no column queries)", schema_.name.c_str(),
-				  known_table_names_.size());
-	names_loaded_.store(true);
 }
 
 }  // namespace duckdb

--- a/src/catalog/mssql_table_set.cpp
+++ b/src/catalog/mssql_table_set.cpp
@@ -11,11 +11,10 @@
 
 // Debug logging for catalog operations
 static int GetCatalogDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 
@@ -111,6 +110,10 @@ optional_ptr<CatalogEntry> MSSQLTableSet::GetEntry(ClientContext &context, const
 void MSSQLTableSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
 	CATALOG_DEBUG(1, "Scan('%s') — bulk loading all table metadata", schema_.name.c_str());
 
+	// Issue #178: snapshot the invalidation epoch BEFORE loading; the trailing
+	// names_loaded_/is_fully_loaded_ publication is skipped if it changed.
+	const uint64_t epoch_at_start = invalidation_epoch_.load();
+
 	auto &catalog = schema_.GetMSSQLCatalog();
 	auto &cache = catalog.GetMetadataCache();
 	auto &pool = catalog.GetConnectionPool();
@@ -144,8 +147,15 @@ void MSSQLTableSet::Scan(ClientContext &context, const std::function<void(Catalo
 	// and block on entry_mutex_ (spec 052 singleflight grabs it first).
 	// shared_ptr copies in the snapshot keep entries alive even if a sibling
 	// thread fires Invalidate() between phase 1 and phase 2.
+	//
+	// Issue #178 (D7): known_table_names_ is guarded by names_mutex_ everywhere
+	// else (GetEntry, EnsureNamesLoaded, Invalidate*); the insert below used to
+	// run under entry_mutex_ only — TSan caught it racing Invalidate()'s clear.
+	// names_mutex_ is taken BEFORE entry_mutex_ to match GetEntry's nesting
+	// order (its step-4 block acquires entry_mutex_ while holding names_mutex_).
 	vector<shared_ptr<MSSQLTableEntry>> snapshot;
 	{
+		std::lock_guard<std::mutex> nlock(names_mutex_);
 		std::lock_guard<std::mutex> lock(entry_mutex_);
 		cache.ForEachTableInSchema(schema_.name, [&](const string &table_name, const MSSQLTableMetadata &table_meta) {
 			stats_provider.PreloadRowCount(schema_.name, table_name, table_meta.approx_row_count);
@@ -188,8 +198,18 @@ void MSSQLTableSet::Scan(ClientContext &context, const std::function<void(Catalo
 		callback(*entry_ptr);
 	}
 
-	names_loaded_.store(true);
-	is_fully_loaded_.store(true);
+	// Issue #178: publish the loaded flags ONLY if no Invalidate() landed since
+	// we started filling. An unconditional store here stomped a concurrent
+	// invalidation: flags TRUE over just-cleared containers made GetEntry
+	// answer "not found" for existing tables. load_mutex_ excludes
+	// Invalidate/InvalidateEntry while we compare-and-publish.
+	{
+		std::lock_guard<std::mutex> llock(load_mutex_);
+		if (invalidation_epoch_.load() == epoch_at_start) {
+			names_loaded_.store(true);
+			is_fully_loaded_.store(true);
+		}
+	}
 }
 
 //===----------------------------------------------------------------------===//
@@ -279,6 +299,7 @@ bool MSSQLTableSet::IsLoaded() const {
 
 void MSSQLTableSet::Invalidate() {
 	std::lock_guard<std::mutex> lock(load_mutex_);
+	invalidation_epoch_.fetch_add(1);  // Issue #178: defeats a concurrent Scan's trailing flag publication
 	is_fully_loaded_.store(false);
 	names_loaded_.store(false);
 	// Spec 052 (Option D): just clear entries_. In-flight binders that
@@ -304,6 +325,7 @@ void MSSQLTableSet::InvalidateEntry(const string &name) {
 	// of this table is reflected on next access; every OTHER table's entry (and its cached
 	// column metadata) is preserved, so the expensive per-table metadata is not re-fetched.
 	std::lock_guard<std::mutex> lock(load_mutex_);
+	invalidation_epoch_.fetch_add(1);  // Issue #178: same guard as Invalidate()
 	is_fully_loaded_.store(false);
 	names_loaded_.store(false);
 	{

--- a/src/catalog/mssql_transaction.cpp
+++ b/src/catalog/mssql_transaction.cpp
@@ -12,11 +12,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetTxnDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/connection/mssql_connection_provider.cpp
+++ b/src/connection/mssql_connection_provider.cpp
@@ -15,11 +15,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetConnProviderDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/copy/bcp_writer.cpp
+++ b/src/copy/bcp_writer.cpp
@@ -33,11 +33,10 @@ constexpr uint16_t CURCMD_INSERT = 0x00C3;
 //===----------------------------------------------------------------------===//
 
 static int GetBCPDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/dml/delete/mssql_delete_executor.cpp
+++ b/src/dml/delete/mssql_delete_executor.cpp
@@ -16,11 +16,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetDeleteDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/dml/insert/mssql_insert_executor.cpp
+++ b/src/dml/insert/mssql_insert_executor.cpp
@@ -17,11 +17,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetInsertDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/dml/update/mssql_update_executor.cpp
+++ b/src/dml/update/mssql_update_executor.cpp
@@ -16,11 +16,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetUpdateDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/include/catalog/mssql_catalog.hpp
+++ b/src/include/catalog/mssql_catalog.hpp
@@ -42,7 +42,8 @@ class LogicalUpdate;
 
 class MSSQLCatalog : public Catalog {
 public:
-	// Constructor (spec 047: catalog now owns its connection pool via unique_ptr).
+	// Constructor (spec 047: catalog owns its connection pool; sole strong ref —
+	// see connection_pool_ member comment).
 	// @param pool_config Pool sizing/timeout configuration translated from DuckDB settings.
 	// @param fedauth_token_utf16le Pre-acquired FEDAUTH token (UTF-16LE) for Azure/manual-token
 	//        auth paths; empty for SQL auth and integrated auth. Captured by the pool factory.
@@ -53,9 +54,9 @@ public:
 				 bool catalog_enabled = true);
 
 	// noexcept (spec 047 T046k): defaulted body destructs the per-catalog
-	// `unique_ptr<ConnectionPool>` (and other unique_ptr members), each of
-	// whose destructors is also `noexcept`. Marked explicit for grep-ability
-	// and to keep the teardown contract loud: a throw here during
+	// pool (catalog holds the sole strong reference) and other owned members,
+	// each of whose destructors is also `noexcept`. Marked explicit for
+	// grep-ability and to keep the teardown contract loud: a throw here during
 	// `~AttachedDatabase` unwind would invoke std::terminate.
 	~MSSQLCatalog() noexcept override;
 
@@ -115,6 +116,12 @@ public:
 
 	// Get connection pool for this catalog
 	tds::ConnectionPool &GetConnectionPool();
+
+	// Weak handle to the pool for result streams (issue #178 review). Lets
+	// ~MSSQLResultStream release its connection without dereferencing the
+	// catalog: lock() failure (catalog torn down) degrades to dropping the
+	// connection — a safe failure mode instead of UB on a dangling pointer.
+	weak_ptr<tds::ConnectionPool> GetConnectionPoolHandle() const;
 
 	// Get metadata cache
 	MSSQLMetadataCache &GetMetadataCache();
@@ -224,14 +231,19 @@ private:
 	// Member Variables
 	//===----------------------------------------------------------------------===//
 
-	string context_name_;									   // Attached context name
-	shared_ptr<MSSQLConnectionInfo> connection_info_;		   // Connection parameters
-	tds::PoolConfiguration pool_config_;					   // Pool config (spec 047)
-	std::vector<uint8_t> fedauth_token_utf16le_;			   // FEDAUTH token (spec 047)
-	AccessMode access_mode_;								   // READ_ONLY enforced
-	bool catalog_enabled_;									   // Catalog integration enabled
-	MSSQLCatalogFilter catalog_filter_;						   // Regex visibility filter
-	unique_ptr<tds::ConnectionPool> connection_pool_;		   // Connection pool (per-catalog owned, spec 047)
+	string context_name_;							   // Attached context name
+	shared_ptr<MSSQLConnectionInfo> connection_info_;  // Connection parameters
+	tds::PoolConfiguration pool_config_;			   // Pool config (spec 047)
+	std::vector<uint8_t> fedauth_token_utf16le_;	   // FEDAUTH token (spec 047)
+	AccessMode access_mode_;						   // READ_ONLY enforced
+	bool catalog_enabled_;							   // Catalog integration enabled
+	MSSQLCatalogFilter catalog_filter_;				   // Regex visibility filter
+	// Connection pool (per-catalog, spec 047). shared_ptr, but the catalog holds
+	// the ONLY strong reference — teardown stays deterministic at ~MSSQLCatalog.
+	// Result streams hold weak_ptr handles (issue #178 review); a transient
+	// lock() during a racing teardown at most defers ~ConnectionPool to that
+	// release call, never past it.
+	shared_ptr<tds::ConnectionPool> connection_pool_;
 	unique_ptr<MSSQLMetadataCache> metadata_cache_;			   // Metadata cache
 	unique_ptr<MSSQLStatisticsProvider> statistics_provider_;  // Statistics provider
 	string database_collation_;								   // Database default collation

--- a/src/include/catalog/mssql_metadata_cache.hpp
+++ b/src/include/catalog/mssql_metadata_cache.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <unordered_map>
@@ -46,23 +47,14 @@ struct MSSQLTableMetadata {
 	vector<MSSQLColumnInfo> columns;  // Column metadata
 	idx_t approx_row_count;			  // Cardinality estimate from sys.partitions
 
-	// Incremental cache state for columns
+	// Incremental cache state for columns.
+	// Issue #178 (D6): all fields — including these states — are guarded by the
+	// cache-wide MSSQLMetadataCache::mutex_; the former per-table load_mutex is gone.
 	CacheLoadState columns_load_state = CacheLoadState::NOT_LOADED;
 	std::chrono::steady_clock::time_point columns_last_refresh;
-	mutable std::mutex load_mutex;	// Per-table loading synchronization
 
 	// Default constructor
 	MSSQLTableMetadata() : object_type(MSSQLObjectType::TABLE), approx_row_count(0) {}
-
-	// Move constructor (mutex not movable)
-	MSSQLTableMetadata(MSSQLTableMetadata &&other) noexcept;
-
-	// Move assignment (mutex not movable)
-	MSSQLTableMetadata &operator=(MSSQLTableMetadata &&other) noexcept;
-
-	// Non-copyable (mutex not copyable)
-	MSSQLTableMetadata(const MSSQLTableMetadata &) = delete;
-	MSSQLTableMetadata &operator=(const MSSQLTableMetadata &) = delete;
 };
 
 //===----------------------------------------------------------------------===//
@@ -73,26 +65,18 @@ struct MSSQLSchemaMetadata {
 	string name;									   // Schema name
 	unordered_map<string, MSSQLTableMetadata> tables;  // Tables and views in schema
 
-	// Incremental cache state for table list
+	// Incremental cache state for table list.
+	// Issue #178 (D6): guarded by MSSQLMetadataCache::mutex_ (cache-wide); the
+	// former per-schema load_mutex is gone — it did NOT exclude readers holding
+	// the map mutex, which is exactly the race it pretended to prevent.
 	CacheLoadState tables_load_state = CacheLoadState::NOT_LOADED;
 	std::chrono::steady_clock::time_point tables_last_refresh;
-	mutable std::mutex load_mutex;	// Per-schema loading synchronization
 
 	// Default constructor
 	MSSQLSchemaMetadata() = default;
 
 	// Explicit constructor with name
 	explicit MSSQLSchemaMetadata(const string &n) : name(n) {}
-
-	// Move constructor (mutex not movable)
-	MSSQLSchemaMetadata(MSSQLSchemaMetadata &&other) noexcept;
-
-	// Move assignment (mutex not movable)
-	MSSQLSchemaMetadata &operator=(MSSQLSchemaMetadata &&other) noexcept;
-
-	// Non-copyable (mutex not copyable)
-	MSSQLSchemaMetadata(const MSSQLSchemaMetadata &) = delete;
-	MSSQLSchemaMetadata &operator=(const MSSQLSchemaMetadata &) = delete;
 };
 
 //===----------------------------------------------------------------------===//
@@ -214,8 +198,10 @@ public:
 	// Set database default collation
 	void SetDatabaseCollation(const string &collation);
 
-	// Get database default collation
-	const string &GetDatabaseCollation() const;
+	// Get database default collation.
+	// Returns by VALUE: a reference would outlive the internal lock and race
+	// with Refresh() overwriting the string (issue #178 D6 audit).
+	string GetDatabaseCollation() const;
 
 	//===----------------------------------------------------------------------===//
 	// Incremental Cache Loading (Lazy Loading)
@@ -288,19 +274,31 @@ private:
 	// Member Variables
 	//===----------------------------------------------------------------------===//
 
-	mutable std::mutex mutex_;							  // Thread-safety for global operations
+	// Issue #178 (D6): ONE cache-wide mutex. It guards state_, schemas_ (the map
+	// AND everything reachable through it: tables, columns, load states),
+	// last_refresh_, database_collation_, schemas_load_state_ and
+	// schemas_last_refresh_. The previous split (`mutex_` for "global ops",
+	// `schemas_mutex_` for the map) had Refresh() freeing the whole map under
+	// one mutex while every reader iterated it under the other — a TSan-confirmed
+	// use-after-free. Loads intentionally hold this mutex across their SQL round
+	// trip so partial state is never visible; that also serialises concurrent
+	// metadata loads (correctness over parallel-load throughput).
+	mutable std::mutex mutex_;
 	MSSQLCacheState state_;								  // Current cache state (backward compat)
-	const MSSQLCatalogFilter *filter_ = nullptr;		  // Optional visibility filter (owned by MSSQLCatalog)
+	const MSSQLCatalogFilter *filter_ = nullptr;		  // Set once at catalog init, before any concurrency
 	unordered_map<string, MSSQLSchemaMetadata> schemas_;  // Cached schemas
 	std::chrono::steady_clock::time_point last_refresh_;  // Last refresh timestamp (backward compat)
-	int64_t ttl_seconds_;								  // Cache TTL (0 = manual only)
-	int metadata_timeout_ms_ = 300000;					  // Metadata query timeout in ms (default 5 min)
 	string database_collation_;							  // Database default collation
 
-	// Incremental cache state for schema list (catalog-level)
+	// Atomics, NOT guarded by mutex_ (issue #178 D4): written by EnsureCacheLoaded
+	// on every catalog lookup while loaders concurrently read them mid-query
+	// (ExecuteMetadataQuery runs WITH mutex_ held, so these must be lock-free).
+	std::atomic<int64_t> ttl_seconds_;		// Cache TTL (0 = manual only)
+	std::atomic<int> metadata_timeout_ms_;	// Metadata query timeout in ms (default 5 min)
+
+	// Incremental cache state for schema list (catalog-level) — guarded by mutex_
 	CacheLoadState schemas_load_state_ = CacheLoadState::NOT_LOADED;
 	std::chrono::steady_clock::time_point schemas_last_refresh_;
-	mutable std::mutex schemas_mutex_;	// Schema list loading synchronization
 };
 
 }  // namespace duckdb

--- a/src/include/catalog/mssql_metadata_cache.hpp
+++ b/src/include/catalog/mssql_metadata_cache.hpp
@@ -115,20 +115,15 @@ public:
 	vector<string> GetTableNames(tds::TdsConnection &connection, const string &schema_name);
 
 	// Get table metadata: loads schemas (fast) + columns for the specific table in one query.
-	// Does NOT load all tables in the schema. Returns nullptr if the table doesn't exist.
+	// Does NOT load all tables in the schema. Returns false if the table doesn't exist.
 	//
-	// LIFETIME CONTRACT (spec 052 US3 T017):
-	// The returned pointer is valid only until the NEXT InvalidateSchema /
-	// InvalidateTable / InvalidateAll / Refresh / BulkLoadAll call on this
-	// cache. Callers MUST copy the fields they need out before any other
-	// thread can invalidate (typically: immediately, as
-	// MSSQLTableSet::LoadSingleEntry does — it constructs an
-	// MSSQLTableEntry from the metadata then returns; the pointer is dead
-	// from that point onward). DO NOT store this pointer beyond the
-	// immediate call site, DO NOT dereference after releasing the
-	// connection. Adding a new caller? Audit it against this rule.
-	const MSSQLTableMetadata *GetTableMetadata(tds::TdsConnection &connection, const string &schema_name,
-											   const string &table_name);
+	// Issue #178 review: copies the metadata into out_meta UNDER the cache mutex.
+	// The previous raw-pointer return escaped the lock and was dereferenced by
+	// LoadSingleEntry while a concurrent Refresh / LoadAllTableMetadata /
+	// TTL-expired reload freed the map node — a residual use-after-free of the
+	// same class this cache's single-mutex rework eliminated.
+	bool GetTableMetadata(tds::TdsConnection &connection, const string &schema_name, const string &table_name,
+						  MSSQLTableMetadata &out_meta);
 
 	// Load all table metadata for a schema in one bulk query.
 	// If all tables already have columns loaded (e.g. from preload), returns from cache.

--- a/src/include/catalog/mssql_table_set.hpp
+++ b/src/include/catalog/mssql_table_set.hpp
@@ -54,9 +54,15 @@ public:
 	// Entry Loading
 	//===----------------------------------------------------------------------===//
 
-	// Load a single table entry by name (for GetEntry operations)
-	// Returns true if the table exists and was loaded, false otherwise
-	bool LoadSingleEntry(ClientContext &context, const string &name);
+	// Load a single table entry by name (for GetEntry operations).
+	// Returns true if the table exists.
+	//
+	// Issue #178 review: when an Invalidate() races the fetch, the entry is NOT
+	// published into entries_ (see the epoch guard in the implementation); it is
+	// handed back via out_entry instead so the calling query still gets a
+	// consistent entry (kept alive by MSSQLBindAnchors). out_entry is set only
+	// on the owner path — singleflight waiters find the entry in entries_.
+	bool LoadSingleEntry(ClientContext &context, const string &name, shared_ptr<MSSQLTableEntry> *out_entry = nullptr);
 
 	// Check if ALL entries are loaded
 	bool IsLoaded() const;
@@ -78,9 +84,6 @@ private:
 	// Spec 052: returns shared_ptr — entries co-owned by entries_ map and any
 	// in-flight bind data anchor (MSSQLCatalogScanBindData::table_entry_anchor_).
 	shared_ptr<MSSQLTableEntry> CreateTableEntry(const MSSQLTableMetadata &metadata);
-
-	// Ensure table names are loaded (no column queries, fast)
-	void EnsureNamesLoaded(ClientContext &context);
 
 	//===----------------------------------------------------------------------===//
 	// Member Variables

--- a/src/include/catalog/mssql_table_set.hpp
+++ b/src/include/catalog/mssql_table_set.hpp
@@ -97,6 +97,15 @@ private:
 	std::atomic<bool> is_fully_loaded_;	 // True when ALL tables are loaded
 	std::mutex load_mutex_;				 // Loading synchronization
 	std::mutex entry_mutex_;			 // Entry access synchronization
+
+	// Issue #178: invalidation generation counter. Invalidate()/InvalidateEntry()
+	// increment it (under load_mutex_); Scan() snapshots it on entry and only
+	// publishes names_loaded_/is_fully_loaded_ = true at the end if no
+	// invalidation landed in between. Without this guard, an Invalidate racing
+	// between Scan's fill phase and its trailing flag stores left the flags
+	// TRUE over freshly-cleared containers — GetEntry then answered
+	// "table does not exist" for tables that exist (seen in harness scenario 6).
+	std::atomic<uint64_t> invalidation_epoch_{0};
 	// Spec 052: shared_ptr (was unique_ptr) so retired entries can flow into
 	// MSSQLCatalog::table_graveyard_ on Invalidate() while in-flight binders
 	// retain validity. Insertion is emplace-only (winner wins on race).

--- a/src/include/query/mssql_result_stream.hpp
+++ b/src/include/query/mssql_result_stream.hpp
@@ -12,6 +12,7 @@
 namespace duckdb {
 
 class ClientContext;
+class MSSQLCatalog;
 
 //===----------------------------------------------------------------------===//
 // MSSQLResultStream - Streaming result iterator that yields DataChunks
@@ -27,12 +28,26 @@ enum class MSSQLResultStreamState : uint8_t {
 
 class MSSQLResultStream {
 public:
-	// Create result stream with shared connection
-	// context_name is needed for returning connection to pool
-	// client_context is needed for transaction-aware connection release
+	// Create result stream with shared connection.
+	//
+	// Issue #178 review: the destructor must NOT touch any ClientContext — it can
+	// run on a worker thread while the client thread commits the query's
+	// transaction (TSan: MetaTransaction::Get vs TransactionContext::Commit on
+	// the same context). Instead the owning catalog and the pinned-ness of the
+	// connection are captured HERE, on the client thread:
+	//   owning_catalog     — pool owner for the destructor's release; non-owning.
+	//                        A live stream never outlives its catalog (streams
+	//                        registered on the catalog are members destroyed
+	//                        before connection_pool_; scan-local streams die at
+	//                        query end, and the pool's Shutdown() asserts
+	//                        quiescence).
+	//   transaction_pinned — true when the connection is pinned to an explicit
+	//                        DuckDB transaction; the destructor then just drops
+	//                        its reference (the MSSQLTransaction owns the pin).
 	// query_timeout_seconds: query execution timeout (0 = no timeout, default: 30)
 	MSSQLResultStream(std::shared_ptr<tds::TdsConnection> connection, const string &sql, const string &context_name,
-					  ClientContext *client_context = nullptr, int query_timeout_seconds = 30);
+					  MSSQLCatalog *owning_catalog = nullptr, bool transaction_pinned = false,
+					  int query_timeout_seconds = 30);
 	~MSSQLResultStream();
 
 	// Non-copyable, non-movable (manages connection)
@@ -137,9 +152,11 @@ private:
 	// Context name for pool release
 	string context_name_;
 
-	// Client context for transaction-aware connection release
-	// May be nullptr for non-transactional use
-	ClientContext *client_context_;
+	// Owning catalog (non-owning pointer) + pinned-ness, captured at construction
+	// on the client thread so the destructor never dereferences a ClientContext
+	// (issue #178 review: TSan race vs TransactionContext::Commit).
+	MSSQLCatalog *owning_catalog_;
+	bool transaction_pinned_;
 
 	// Query
 	string sql_;

--- a/src/include/query/mssql_result_stream.hpp
+++ b/src/include/query/mssql_result_stream.hpp
@@ -14,6 +14,10 @@ namespace duckdb {
 class ClientContext;
 class MSSQLCatalog;
 
+namespace tds {
+class ConnectionPool;
+}  // namespace tds
+
 //===----------------------------------------------------------------------===//
 // MSSQLResultStream - Streaming result iterator that yields DataChunks
 //===----------------------------------------------------------------------===//
@@ -33,21 +37,19 @@ public:
 	// Issue #178 review: the destructor must NOT touch any ClientContext — it can
 	// run on a worker thread while the client thread commits the query's
 	// transaction (TSan: MetaTransaction::Get vs TransactionContext::Commit on
-	// the same context). Instead the owning catalog and the pinned-ness of the
-	// connection are captured HERE, on the client thread:
-	//   owning_catalog     — pool owner for the destructor's release; non-owning.
-	//                        A live stream never outlives its catalog (streams
-	//                        registered on the catalog are members destroyed
-	//                        before connection_pool_; scan-local streams die at
-	//                        query end, and the pool's Shutdown() asserts
-	//                        quiescence).
+	// the same context). Instead the release targets are captured HERE, on the
+	// client thread:
+	//   pool_handle        — weak_ptr to the catalog's pool. lock() failure
+	//                        (catalog torn down) degrades to dropping the
+	//                        connection — a safe failure mode, never a dangling
+	//                        dereference (PR #179 review).
 	//   transaction_pinned — true when the connection is pinned to an explicit
 	//                        DuckDB transaction; the destructor then just drops
 	//                        its reference (the MSSQLTransaction owns the pin).
 	// query_timeout_seconds: query execution timeout (0 = no timeout, default: 30)
 	MSSQLResultStream(std::shared_ptr<tds::TdsConnection> connection, const string &sql, const string &context_name,
-					  MSSQLCatalog *owning_catalog = nullptr, bool transaction_pinned = false,
-					  int query_timeout_seconds = 30);
+					  weak_ptr<tds::ConnectionPool> pool_handle = weak_ptr<tds::ConnectionPool>(),
+					  bool transaction_pinned = false, int query_timeout_seconds = 30);
 	~MSSQLResultStream();
 
 	// Non-copyable, non-movable (manages connection)
@@ -152,10 +154,10 @@ private:
 	// Context name for pool release
 	string context_name_;
 
-	// Owning catalog (non-owning pointer) + pinned-ness, captured at construction
-	// on the client thread so the destructor never dereferences a ClientContext
-	// (issue #178 review: TSan race vs TransactionContext::Commit).
-	MSSQLCatalog *owning_catalog_;
+	// Release targets captured at construction on the client thread so the
+	// destructor never dereferences a ClientContext (issue #178 review: TSan
+	// race vs TransactionContext::Commit) nor a raw catalog pointer.
+	weak_ptr<tds::ConnectionPool> pool_handle_;
 	bool transaction_pinned_;
 
 	// Query

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -20,11 +20,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetFunctionDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -22,11 +22,10 @@
 
 // Debug logging (same pattern as tds_socket.cpp)
 static int GetMssqlStorageDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/query/mssql_query_executor.cpp
+++ b/src/query/mssql_query_executor.cpp
@@ -11,11 +11,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetExecutorDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/query/mssql_query_executor.cpp
+++ b/src/query/mssql_query_executor.cpp
@@ -82,13 +82,14 @@ unique_ptr<MSSQLResultStream> MSSQLQueryExecutor::Execute(ClientContext &context
 	MSSQL_EXEC_DEBUG_LOG(1, "Execute: query_timeout=%ds", query_timeout);
 
 	// Create result stream with the shared connection.
-	// Issue #178 review: pinned-ness and the owning catalog are resolved HERE,
-	// on the client thread — the stream destructor may run on a worker thread
-	// and must not touch the ClientContext (TSan: MetaTransaction::Get raced
+	// Issue #178 review: pinned-ness and the pool handle are resolved HERE, on
+	// the client thread — the stream destructor may run on a worker thread and
+	// must not touch the ClientContext (TSan: MetaTransaction::Get raced
 	// TransactionContext::Commit).
 	const bool transaction_pinned = ConnectionProvider::IsInTransaction(context, mssql_catalog);
-	auto result_stream = make_uniq<MSSQLResultStream>(std::move(connection), sql, context_name_, &mssql_catalog,
-													  transaction_pinned, query_timeout);
+	auto result_stream =
+		make_uniq<MSSQLResultStream>(std::move(connection), sql, context_name_, mssql_catalog.GetConnectionPoolHandle(),
+									 transaction_pinned, query_timeout);
 
 	// Initialize the stream (sends query, waits for COLMETADATA)
 	// If Initialize() throws, result_stream destructor will release connection back to pool

--- a/src/query/mssql_query_executor.cpp
+++ b/src/query/mssql_query_executor.cpp
@@ -81,10 +81,14 @@ unique_ptr<MSSQLResultStream> MSSQLQueryExecutor::Execute(ClientContext &context
 	int query_timeout = LoadQueryTimeout(context);
 	MSSQL_EXEC_DEBUG_LOG(1, "Execute: query_timeout=%ds", query_timeout);
 
-	// Create result stream with the shared connection
-	// Pass client context for transaction-aware connection release in destructor
-	auto result_stream =
-		make_uniq<MSSQLResultStream>(std::move(connection), sql, context_name_, &context, query_timeout);
+	// Create result stream with the shared connection.
+	// Issue #178 review: pinned-ness and the owning catalog are resolved HERE,
+	// on the client thread — the stream destructor may run on a worker thread
+	// and must not touch the ClientContext (TSan: MetaTransaction::Get raced
+	// TransactionContext::Commit).
+	const bool transaction_pinned = ConnectionProvider::IsInTransaction(context, mssql_catalog);
+	auto result_stream = make_uniq<MSSQLResultStream>(std::move(connection), sql, context_name_, &mssql_catalog,
+													  transaction_pinned, query_timeout);
 
 	// Initialize the stream (sends query, waits for COLMETADATA)
 	// If Initialize() throws, result_stream destructor will release connection back to pool

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -36,11 +36,11 @@ namespace duckdb {
 //===----------------------------------------------------------------------===//
 
 MSSQLResultStream::MSSQLResultStream(std::shared_ptr<tds::TdsConnection> connection, const string &sql,
-									 const string &context_name, MSSQLCatalog *owning_catalog, bool transaction_pinned,
-									 int query_timeout_seconds)
+									 const string &context_name, weak_ptr<tds::ConnectionPool> pool_handle,
+									 bool transaction_pinned, int query_timeout_seconds)
 	: connection_(std::move(connection)),
 	  context_name_(context_name),
-	  owning_catalog_(owning_catalog),
+	  pool_handle_(std::move(pool_handle)),
 	  transaction_pinned_(transaction_pinned),
 	  sql_(sql),
 	  state_(MSSQLResultStreamState::Initializing),
@@ -68,9 +68,11 @@ MSSQLResultStream::~MSSQLResultStream() {
 	// teardown while the client thread commits the query's transaction — the old
 	// `Catalog::GetCatalog(*client_context_, ...)` path called
 	// MetaTransaction::Get on that context and raced
-	// TransactionContext::Commit's unique_ptr move (TSan-confirmed). The catalog
-	// and pinned-ness were captured at construction instead; no ClientContext is
-	// touched here.
+	// TransactionContext::Commit's unique_ptr move (TSan-confirmed). The pool
+	// weak_ptr and pinned-ness were captured at construction instead; no
+	// ClientContext is touched here, and a failed lock() (catalog torn down)
+	// degrades to dropping the connection — never a dangling dereference
+	// (PR #179 review).
 	if (connection_) {
 		auto conn_state = connection_->GetState();
 		if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
@@ -81,14 +83,16 @@ MSSQLResultStream::~MSSQLResultStream() {
 		if (transaction_pinned_) {
 			// The MSSQLTransaction owns the pin; just drop our reference.
 			connection_.reset();
-		} else if (owning_catalog_) {
+		} else if (auto pool = pool_handle_.lock()) {
 			try {
 				// Flag session reset (temp tables, SET options) for the next
-				// reuse — mirrors ConnectionProvider's autocommit release.
+				// reuse — same as ConnectionProvider's autocommit release
+				// (the reset is a header bit on the next SQL_BATCH, not an
+				// extra round trip).
 				connection_->SetNeedsReset(true);
-				owning_catalog_->GetConnectionPool().Release(std::move(connection_));
+				pool->Release(std::move(connection_));
 			} catch (...) {
-				// Pool gone or release failed — drop the connection.
+				// Release failed — drop the connection.
 				// shared_ptr destructor closes the socket.
 				connection_.reset();
 			}

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -15,11 +15,10 @@
 // Debug logging controlled by MSSQL_DEBUG environment variable
 // Set MSSQL_DEBUG=1 to enable, MSSQL_DEBUG=2 for verbose row-level logging
 static int GetDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -36,11 +36,12 @@ namespace duckdb {
 //===----------------------------------------------------------------------===//
 
 MSSQLResultStream::MSSQLResultStream(std::shared_ptr<tds::TdsConnection> connection, const string &sql,
-									 const string &context_name, ClientContext *client_context,
+									 const string &context_name, MSSQLCatalog *owning_catalog, bool transaction_pinned,
 									 int query_timeout_seconds)
 	: connection_(std::move(connection)),
 	  context_name_(context_name),
-	  client_context_(client_context),
+	  owning_catalog_(owning_catalog),
+	  transaction_pinned_(transaction_pinned),
 	  sql_(sql),
 	  state_(MSSQLResultStreamState::Initializing),
 	  is_cancelled_(false),
@@ -61,7 +62,15 @@ MSSQLResultStream::~MSSQLResultStream() {
 		Cancel();
 	}
 
-	// Return connection to the pool
+	// Return connection to the pool.
+	//
+	// Issue #178 review: this destructor can run on a WORKER thread during query
+	// teardown while the client thread commits the query's transaction — the old
+	// `Catalog::GetCatalog(*client_context_, ...)` path called
+	// MetaTransaction::Get on that context and raced
+	// TransactionContext::Commit's unique_ptr move (TSan-confirmed). The catalog
+	// and pinned-ness were captured at construction instead; no ClientContext is
+	// touched here.
 	if (connection_) {
 		auto conn_state = connection_->GetState();
 		if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
@@ -69,17 +78,17 @@ MSSQLResultStream::~MSSQLResultStream() {
 			connection_->Close();
 		}
 
-		// Spec 047: pool is owned by MSSQLCatalog (per-catalog ownership).
-		// Without a ClientContext we can't look up the catalog; the shared_ptr
-		// drop closes the connection on this thread — no leak, just no reuse.
-		// Same outcome when catalog lookup throws (catalog detached mid-query).
-		if (client_context_) {
+		if (transaction_pinned_) {
+			// The MSSQLTransaction owns the pin; just drop our reference.
+			connection_.reset();
+		} else if (owning_catalog_) {
 			try {
-				auto &catalog = Catalog::GetCatalog(*client_context_, context_name_);
-				auto &mssql_catalog = catalog.Cast<MSSQLCatalog>();
-				ConnectionProvider::ReleaseConnection(*client_context_, mssql_catalog, std::move(connection_));
+				// Flag session reset (temp tables, SET options) for the next
+				// reuse — mirrors ConnectionProvider's autocommit release.
+				connection_->SetNeedsReset(true);
+				owning_catalog_->GetConnectionPool().Release(std::move(connection_));
 			} catch (...) {
-				// Catalog gone or release failed — drop the connection.
+				// Pool gone or release failed — drop the connection.
 				// shared_ptr destructor closes the socket.
 				connection_.reset();
 			}

--- a/src/query/mssql_simple_query.cpp
+++ b/src/query/mssql_simple_query.cpp
@@ -12,11 +12,10 @@
 
 // Debug logging
 static int GetSimpleQueryDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/table_scan/filter_encoder.cpp
+++ b/src/table_scan/filter_encoder.cpp
@@ -26,11 +26,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/table_scan/mssql_optimizer.cpp
+++ b/src/table_scan/mssql_optimizer.cpp
@@ -30,11 +30,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetOptimizerDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -17,11 +17,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/table_scan/table_scan_execute.cpp
+++ b/src/table_scan/table_scan_execute.cpp
@@ -7,11 +7,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/table_scan/table_scan_state.cpp
+++ b/src/table_scan/table_scan_state.cpp
@@ -6,11 +6,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/encoding/type_converter.cpp
+++ b/src/tds/encoding/type_converter.cpp
@@ -23,11 +23,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetTypeConverterDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -42,11 +42,10 @@ std::string GetClientHostname() {
 
 // Debug logging
 static int GetMssqlDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tds_connection_pool.cpp
+++ b/src/tds/tds_connection_pool.cpp
@@ -49,6 +49,13 @@ ConnectionPool::~ConnectionPool() noexcept {
 }
 
 void ConnectionPool::Shutdown() {
+	// Thread affinity (PR #179 review): with shared_ptr pool ownership this can
+	// run on WHATEVER thread drops the last strong reference — including a
+	// DuckDB worker thread inside ~MSSQLResultStream when its weak_ptr::lock()
+	// wins a race against DETACH. That is safe: joining cleanup_thread_ is
+	// legal from any thread (the cleanup thread holds no pool references, so a
+	// self-join is impossible), and everything below is self-contained.
+	//
 	// Spec 047 T046l: surface DuckDB quiescence-contract violations in debug
 	// builds via D_ASSERT. PR #118 review M2: also emit a release-mode warning
 	// — silent UB on a real quiescence violation is worse for operators than
@@ -200,11 +207,23 @@ std::shared_ptr<TdsConnection> ConnectionPool::Acquire(int timeout_ms) {
 }
 
 void ConnectionPool::Release(std::shared_ptr<TdsConnection> conn) {
+	// Post-Shutdown contract (PR #179 review): drop, never enqueue. Under
+	// shared_ptr ownership this is belt-and-suspenders — Shutdown() only runs
+	// from ~ConnectionPool, which cannot execute while a Release caller still
+	// holds a strong reference (the ~MSSQLResultStream path holds one from
+	// weak_ptr::lock() for the duration of this call).
 	if (!conn || shutdown_flag_.load()) {
 		return;
 	}
 
 	std::lock_guard<std::mutex> lock(pool_mutex_);
+
+	// Re-check under the mutex: if a shutdown raced past the unlocked check
+	// above, close instead of enqueueing into a quiesced pool.
+	if (shutdown_flag_.load()) {
+		conn->Close();
+		return;
+	}
 
 	// Find and remove from active connections
 	uint64_t found_id = 0;

--- a/src/tds/tds_connection_pool.cpp
+++ b/src/tds/tds_connection_pool.cpp
@@ -9,11 +9,10 @@ namespace tds {
 
 // Debug logging infrastructure (T005-T006)
 static int GetPoolDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tds_protocol.cpp
+++ b/src/tds/tds_protocol.cpp
@@ -14,11 +14,10 @@
 
 // Debug logging
 static int GetMssqlDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tds_row_reader.cpp
+++ b/src/tds/tds_row_reader.cpp
@@ -489,11 +489,10 @@ static constexpr uint64_t PLP_UNKNOWN_MARKER = 0xFFFFFFFFFFFFFFFEULL;
 
 // Debug logging for PLP parsing
 static int GetPLPDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG_PLP");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tds_socket.cpp
+++ b/src/tds/tds_socket.cpp
@@ -67,11 +67,10 @@ static void InitializeWinsock() {
 
 // Debug logging
 static int GetMssqlDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tds_token_parser.cpp
+++ b/src/tds/tds_token_parser.cpp
@@ -10,11 +10,10 @@
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetParserDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tls/tds_tls_context.cpp
+++ b/src/tds/tls/tds_tls_context.cpp
@@ -15,11 +15,10 @@
 
 // Debug logging
 static int GetMssqlDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/src/tds/tls/tds_tls_impl.cpp
+++ b/src/tds/tls/tds_tls_impl.cpp
@@ -40,11 +40,10 @@ namespace tds {
 
 // Debug logging controlled by MSSQL_DEBUG environment variable
 static int GetMssqlDebugLevel() {
-	static int level = -1;
-	if (level == -1) {
+	static const int level = []() {
 		const char *env = std::getenv("MSSQL_DEBUG");
-		level = env ? std::atoi(env) : 0;
-	}
+		return env ? std::atoi(env) : 0;
+	}();
 	return level;
 }
 

--- a/test/sql/integration/issue178_concurrent_same_table.test
+++ b/test/sql/integration/issue178_concurrent_same_table.test
@@ -1,0 +1,42 @@
+# name: test/sql/integration/issue178_concurrent_same_table.test
+# description: Issue #178 — concurrent scans of the SAME table from multiple connections crash
+# group: [integration]
+#
+# Repro for https://github.com/hugr-lab/mssql-extension/issues/178
+# Two (or more) client connections concurrently scanning the same attached table
+# crash the process, while a single connection or different tables work fine.
+# Run with: MSSQL_TEST_DSN='Server=localhost,1433;Database=master;User Id=sa;Password=...' \
+#   build/debug/test/unittest test/sql/integration/issue178_concurrent_same_table.test
+
+require mssql
+
+require-env MSSQL_TEST_DSN
+
+statement ok
+ATTACH '${MSSQL_TEST_DSN}' AS mss (TYPE mssql);
+
+# Big enough that LIMIT 10 abandons the TDS stream mid-flight (as in the report)
+statement ok
+SELECT mssql_exec('mss', '
+IF OBJECT_ID(''dbo.Issue178Big'', ''U'') IS NULL
+BEGIN
+    CREATE TABLE dbo.Issue178Big (id INT PRIMARY KEY, val NVARCHAR(200));
+    WITH n AS (SELECT TOP 500000 ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS i
+               FROM sys.all_objects a CROSS JOIN sys.all_objects b)
+    INSERT INTO dbo.Issue178Big (id, val)
+    SELECT i, CONCAT(''row-value-padding-padding-padding-'', i) FROM n;
+END
+');
+
+# NOTE: no cache invalidation needed — a fresh unittest process binds cold.
+# (mssql_invalidate_cache also trips a debug-only ExpressionExecutor assertion
+# about CONSTANT_VECTOR folding — tracked separately from #178.)
+
+concurrentloop i 0 8
+
+query I
+SELECT count(*) FROM (SELECT * FROM mss.dbo.Issue178Big LIMIT 10);
+----
+10
+
+endloop

--- a/test/sql/integration/issue178_concurrent_same_table.test
+++ b/test/sql/integration/issue178_concurrent_same_table.test
@@ -15,7 +15,10 @@ require-env MSSQL_TEST_DSN
 statement ok
 ATTACH '${MSSQL_TEST_DSN}' AS mss (TYPE mssql);
 
-# Big enough that LIMIT 10 abandons the TDS stream mid-flight (as in the report)
+# Big enough that LIMIT 10 abandons the TDS stream mid-flight (as in the report).
+# The table is DELIBERATELY persistent (IF OBJECT_ID guard, no DROP): populating
+# 500k rows dominates this test's runtime, so reruns reuse it. Do NOT add a
+# DROP/re-create — concurrent CI runs against a shared server would race on setup.
 statement ok
 SELECT mssql_exec('mss', '
 IF OBJECT_ID(''dbo.Issue178Big'', ''U'') IS NULL


### PR DESCRIPTION
## Summary

Fixes the crash-grade concurrency bugs found while investigating #178 (process crash under concurrent queries against the same attached catalog). Full root-cause analysis and repro history: `docs/proposals/issue-178-concurrent-crash-analysis.md` (included in this PR).

### The crash (ASan-proven on pre-fix main)

`MSSQLMetadataCache` guarded `schemas_` with **two different mutexes**: `Refresh()` (and `HasSchema`/`HasTable`) used `mutex_`, while every hot-path reader/writer (`GetTableMetadata`, `EnsureSchemasLoaded`, `ForEachTableInSchema`, `LoadAllTableMetadata`, …) used `schemas_mutex_`. There was **no mutual exclusion** between a `mssql_refresh_cache()` freeing the whole map and a concurrent bind iterating it:

```
==ERROR: AddressSanitizer: heap-use-after-free ... READ of size 17
    #2 MakeTableInfo src/catalog/mssql_table_entry.cpp:46
    #4 MSSQLTableEntry::MSSQLTableEntry(...)
```

Reproduced on unmodified main with the spec-052 harness scenario 6 (readers + `mssql_refresh_cache` invalidator + `duckdb_tables()` walker): **heap-use-after-free abort in 2 of 3 runs**. Any workload mixing reads with refresh/invalidation/catalog enumeration (IDE introspection, notebooks, dbt) can hit this — the most plausible mechanism for the segfaults reported in #178 on extension v0.2.1.

### Fixes

1. **One cache-wide `mutex_`** in `MSSQLMetadataCache` (merges `mutex_`/`schemas_mutex_`). Also removes the per-schema `load_mutex` in `EnsureTablesLoaded` (it excluded nothing — the containers it "protected" are read under the map mutex) and the unlocked double-checked fast paths; `GetDatabaseCollation` returns by value (a reference would outlive the lock).
2. **`MSSQLTableSet::Scan`**: the `known_table_names_` insert now runs under `names_mutex_` like every other access site (it mutated the set under `entry_mutex_` only — TSan caught it racing `Invalidate()`'s clear). Lock order `names_mutex_ → entry_mutex_` matches `GetEntry`'s existing nesting.
3. **Invalidation epoch guard**: `Scan`'s unconditional trailing `names_loaded_/is_fully_loaded_ = true` stomped a concurrent `Invalidate()`, leaving TRUE flags over just-cleared containers — `GetEntry` then answered *"Table … does not exist"* for existing tables (observed in harness scenario 6 once the memory races were fixed). `Invalidate`/`InvalidateEntry` bump an epoch counter; `Scan` publishes the flags only if the epoch is unchanged.
4. **Hygiene (TSan-clean)**: `ttl_seconds_`/`metadata_timeout_ms_` become atomics — they are rewritten by `EnsureCacheLoaded` on every catalog lookup while loaders read them mid-query with the cache mutex held. Default comes from `tds::DEFAULT_METADATA_TIMEOUT`; the `mssql_metadata_timeout` setting overrides it at runtime exactly as before. The `static int level = -1` lazy-init in 29 debug loggers is replaced with thread-safe magic statics.

### Verification (Linux arm64 sanitizer lab, SQL Server 2022)

| Check | pre-fix main | this branch |
|---|---|---|
| spec-052 harness scenarios 1–8, **ASan+UBSan** | **heap-use-after-free abort** (2/3 runs, scenario 6) | clean ×2, all PASS |
| same suites under **TSan** | 5 + 55 race reports (incl. the two crash-grade ones) | **0 reports**, all PASS |
| new `test/sql/integration/issue178_concurrent_same_table.test` (8-connection `concurrentloop`, same 500k-row table, LIMIT-abandoned streams) | n/a | PASS (release, ASan, TSan) |
| `make test` (unit) + release build (macOS + Linux) | — | PASS |

### Not in this PR (follow-ups from the analysis doc)

- `stability = VOLATILE` for side-effecting scalar functions (`mssql_invalidate_cache` trips a debug-only ExpressionExecutor assert and is constant-folded at plan time in release builds)
- `GetTableMetadata` copy-out-under-lock (retire the raw-pointer-into-cache contract)
- Windows concurrency CI job (the #178 report is Windows-only evidence; no Windows concurrency coverage exists today)
- Reporter follow-up on #178: DuckDB 1.5.2/1.5.3 community channels serve pre-spec-052 binaries (0.1.18 / 0.2.0) containing the known #126 crash; need `mssql_version()` confirmation from the crashing 1.5.4 environment

DATAMODEL.md updated with the new cache locking invariant (per project policy).

Refs #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)