### PR TITLE
fix(functions): mark side-effecting scalar functions VOLATILE (#178 follow-up D1)

### DIFF
--- a/src/azure/azure_test_function.cpp
+++ b/src/azure/azure_test_function.cpp
@@ -81,10 +81,15 @@ static void AzureAuthTestFunctionWithTenant(DataChunk &args, ExpressionState &st
 // RegisterAzureTestFunction
 //===----------------------------------------------------------------------===//
 void RegisterAzureTestFunction(ExtensionLoader &loader) {
+	// Both variants hit the network (OAuth2 token acquisition) and are
+	// non-deterministic: VOLATILE prevents plan-time constant folding
+	// (issue #178 D1).
+
 	// Version 1: secret_name only
 	ScalarFunction func1("mssql_azure_auth_test", {LogicalType::VARCHAR},  // secret_name
 						 LogicalType::VARCHAR,							   // return type
 						 AzureAuthTestFunction);
+	func1.SetVolatile();
 	loader.RegisterFunction(func1);
 
 	// Version 2: secret_name + tenant_id (for interactive auth)
@@ -92,6 +97,7 @@ void RegisterAzureTestFunction(ExtensionLoader &loader) {
 						 {LogicalType::VARCHAR, LogicalType::VARCHAR},	// secret_name, tenant_id
 						 LogicalType::VARCHAR,							// return type
 						 AzureAuthTestFunctionWithTenant);
+	func2.SetVolatile();
 	loader.RegisterFunction(func2);
 }
 

--- a/src/catalog/mssql_preload_catalog.cpp
+++ b/src/catalog/mssql_preload_catalog.cpp
@@ -161,6 +161,8 @@ void RegisterMSSQLPreloadCatalogFunction(ExtensionLoader &loader) {
 						MSSQLPreloadCatalogExecute, MSSQLPreloadCatalogBind);
 	func.varargs = LogicalType::VARCHAR;  // Optional schema_name
 	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	// Mutates the metadata cache: never constant-fold at plan time (issue #178 D1)
+	func.SetVolatile();
 	loader.RegisterFunction(func);
 }
 

--- a/src/catalog/mssql_refresh_function.cpp
+++ b/src/catalog/mssql_refresh_function.cpp
@@ -167,10 +167,16 @@ static void MSSQLInvalidateCacheExecute(DataChunk &args, ExpressionState &state,
 //===----------------------------------------------------------------------===//
 
 void RegisterMSSQLRefreshCacheFunction(ExtensionLoader &loader) {
+	// Both functions mutate the metadata cache: VOLATILE keeps the optimizer
+	// from constant-folding the call at plan time (which executed the side
+	// effect during optimization and tripped ExpressionExecutor's
+	// CONSTANT_VECTOR assertion in debug builds — issue #178 finding D1).
+
 	// mssql_refresh_cache(catalog_name VARCHAR) -> BOOLEAN
 	ScalarFunction func("mssql_refresh_cache", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, MSSQLRefreshCacheExecute,
 						MSSQLRefreshCacheBind);
 	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	func.SetVolatile();
 	loader.RegisterFunction(func);
 
 	// mssql_invalidate_cache(catalog [, schema [, table]]) -> BOOLEAN
@@ -180,6 +186,7 @@ void RegisterMSSQLRefreshCacheFunction(ExtensionLoader &loader) {
 		  vector<LogicalType>{LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}}) {
 		ScalarFunction overload("mssql_invalidate_cache", arg_types, LogicalType::BOOLEAN, MSSQLInvalidateCacheExecute);
 		overload.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+		overload.SetVolatile();
 		invalidate.AddFunction(overload);
 	}
 	loader.RegisterFunction(invalidate);

--- a/src/connection/mssql_diagnostic.cpp
+++ b/src/connection/mssql_diagnostic.cpp
@@ -353,18 +353,27 @@ void RegisterMSSQLDiagnosticFunctions(ExtensionLoader &loader) {
 	//   - Connection string: "Server=host,port;Database=db;User Id=user;Password=pass"
 	//   - URI format: "mssql://user:password@host:port/database"
 	//   - Secret name (for backward compatibility)
+	// All four diagnostic functions are side-effecting (open/close sockets,
+	// network ping): VOLATILE keeps the optimizer from constant-folding them
+	// at plan time or caching results per row.
 	ScalarFunctionSet open_func("mssql_open");
-	open_func.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT, MSSQLOpenFunction));
+	ScalarFunction open_fn({LogicalType::VARCHAR}, LogicalType::BIGINT, MSSQLOpenFunction);
+	open_fn.SetVolatile();
+	open_func.AddFunction(open_fn);
 	loader.RegisterFunction(open_func);
 
 	// [DEPRECATED] mssql_close(handle BIGINT) -> BOOLEAN  (spec 047 FR-010, same group as mssql_open)
 	ScalarFunctionSet close_func("mssql_close");
-	close_func.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::BOOLEAN, MSSQLCloseFunction));
+	ScalarFunction close_fn({LogicalType::BIGINT}, LogicalType::BOOLEAN, MSSQLCloseFunction);
+	close_fn.SetVolatile();
+	close_func.AddFunction(close_fn);
 	loader.RegisterFunction(close_func);
 
 	// [DEPRECATED] mssql_ping(handle BIGINT) -> BOOLEAN  (spec 047 FR-010, same group as mssql_open)
 	ScalarFunctionSet ping_func("mssql_ping");
-	ping_func.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::BOOLEAN, MSSQLPingFunction));
+	ScalarFunction ping_fn({LogicalType::BIGINT}, LogicalType::BOOLEAN, MSSQLPingFunction);
+	ping_fn.SetVolatile();
+	ping_func.AddFunction(ping_fn);
 	loader.RegisterFunction(ping_func);
 
 	// [DEPRECATED] mssql_close_all() -> INTEGER  (spec 047 FR-013)
@@ -376,7 +385,9 @@ void RegisterMSSQLDiagnosticFunctions(ExtensionLoader &loader) {
 	// comment until the diagnostic API is retired and the singleton
 	// MSSQLConnectionHandleManager goes with it.
 	ScalarFunctionSet close_all_func("mssql_close_all");
-	close_all_func.AddFunction(ScalarFunction({}, LogicalType::INTEGER, MSSQLCloseAllFunction));
+	ScalarFunction close_all_fn({}, LogicalType::INTEGER, MSSQLCloseAllFunction);
+	close_all_fn.SetVolatile();
+	close_all_func.AddFunction(close_all_fn);
 	loader.RegisterFunction(close_all_func);
 
 	// mssql_pool_stats([context_name] VARCHAR) -> TABLE

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -450,6 +450,9 @@ ScalarFunction MSSQLExecScalarFunction::GetFunction() {
 	ScalarFunction func(NAME, {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BIGINT, MSSQLExecExecute,
 						MSSQLExecBind);
 	func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	// Side-effecting (runs T-SQL on the server): VOLATILE stops the optimizer
+	// from constant-folding the call at plan time or caching it per row.
+	func.SetVolatile();
 	return func;
 }
 

--- a/src/tds/auth/krb5_test_function.cpp
+++ b/src/tds/auth/krb5_test_function.cpp
@@ -227,18 +227,24 @@ static void Krb5TestSecret(DataChunk &args, ExpressionState & /*state*/, Vector 
 #endif	// MSSQL_ENABLE_KRB5
 
 void RegisterKrb5TestFunction(ExtensionLoader &loader) {
+	// All variants perform GSSAPI/network work and are non-deterministic:
+	// VOLATILE prevents plan-time constant folding (issue #178 D1).
+
 	// mssql_kerberos_auth_test(host)
 	ScalarFunction func1("mssql_kerberos_auth_test", {LogicalType::VARCHAR}, LogicalType::VARCHAR, Krb5TestHost);
+	func1.SetVolatile();
 	loader.RegisterFunction(func1);
 
 	// mssql_kerberos_auth_test(host, port)
 	ScalarFunction func2("mssql_kerberos_auth_test", {LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR,
 						 Krb5TestHostPort);
+	func2.SetVolatile();
 	loader.RegisterFunction(func2);
 
 	// mssql_kerberos_auth_test_secret(secret_name)
 	ScalarFunction func3("mssql_kerberos_auth_test_secret", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 						 Krb5TestSecret);
+	func3.SetVolatile();
 	loader.RegisterFunction(func3);
 }
 

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -200,17 +200,23 @@ static void WinSspiTestSpn(DataChunk &args, ExpressionState & /*state*/, Vector 
 #endif	// MSSQL_ENABLE_SSPI
 
 void RegisterWinSspiTestFunction(ExtensionLoader &loader) {
+	// All variants perform SSPI/network work and are non-deterministic:
+	// VOLATILE prevents plan-time constant folding (issue #178 D1).
+
 	// mssql_winsspi_auth_test(host)
 	ScalarFunction f1("mssql_winsspi_auth_test", {LogicalType::VARCHAR}, LogicalType::VARCHAR, WinSspiTestHost);
+	f1.SetVolatile();
 	loader.RegisterFunction(f1);
 
 	// mssql_winsspi_auth_test(host, port)
 	ScalarFunction f2("mssql_winsspi_auth_test", {LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR,
 					  WinSspiTestHostPort);
+	f2.SetVolatile();
 	loader.RegisterFunction(f2);
 
 	// mssql_winsspi_auth_test_spn(spn)
 	ScalarFunction f3("mssql_winsspi_auth_test_spn", {LogicalType::VARCHAR}, LogicalType::VARCHAR, WinSspiTestSpn);
+	f3.SetVolatile();
 	loader.RegisterFunction(f3);
 }
 

--- a/test/sql/integration/issue178_concurrent_same_table.test
+++ b/test/sql/integration/issue178_concurrent_same_table.test
@@ -31,9 +31,13 @@ BEGIN
 END
 ');
 
-# NOTE: no cache invalidation needed — a fresh unittest process binds cold.
-# (mssql_invalidate_cache also trips a debug-only ExpressionExecutor assertion
-# about CONSTANT_VECTOR folding — tracked separately from #178.)
+# Cold binds for every connection in the loop. This statement doubles as the
+# regression check for issue #178 finding D1: before mssql_invalidate_cache was
+# marked VOLATILE, the optimizer constant-folded it at plan time, which ran the
+# side effect during optimization and tripped ExpressionExecutor's
+# CONSTANT_VECTOR assertion on debug builds.
+statement ok
+SELECT mssql_invalidate_cache('mss');
 
 concurrentloop i 0 8
 


### PR DESCRIPTION
## Summary

Follow-up **D1** from the #178 investigation (`docs/proposals/issue-178-concurrent-crash-analysis.md`).

No scalar function in the extension set `FunctionStability`, so every side-effecting scalar defaulted to `CONSISTENT` and was **constant-folded by the optimizer** when called with constant arguments (the common case — these functions are almost always called as `SELECT mssql_exec('ctx', '...')`):

- the side effect executed at **plan time**, once, during optimization — not at execution;
- on debug builds the fold trips `D_ASSERT(allow_unfoldable || result.GetVectorType() == CONSTANT_VECTOR)` in `expression_executor.cpp:136` (reproduced with `SELECT mssql_invalidate_cache('x')` on a Linux debug build — hard abort).

## Change

`SetVolatile()` on every scalar with side effects or non-deterministic results:

| Group | Functions |
|---|---|
| Server side effects | `mssql_exec` |
| Cache mutation | `mssql_refresh_cache`, `mssql_invalidate_cache` ×3 overloads, `mssql_preload_catalog` |
| Diagnostic sockets | `mssql_open`, `mssql_close`, `mssql_ping`, `mssql_close_all` |
| Network auth tests | `mssql_azure_auth_test` ×2, `mssql_kerberos_auth_test` ×2, `mssql_kerberos_auth_test_secret`, `mssql_winsspi_auth_test` ×2, `mssql_winsspi_auth_test_spn` |

`mssql_version` stays `CONSISTENT` (pure constant).

## Regression test

`test/sql/integration/issue178_concurrent_same_table.test` now calls `mssql_invalidate_cache` with constant args — on pre-fix **debug** builds that exact statement aborts with the assertion; post-fix it passes (verified on the Linux debug build where the assert originally reproduced).

## Verification

- Debug build (Linux container): test passes where it previously asserted; TSan clean (0 reports)
- Release build: `make test`, issue-178 integration test green

Refs #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)