### PR TITLE
fix(copy): BCP COPY to VARCHAR(n) rejects valid strings (#181)

### DIFF
--- a/src/copy/target_resolver.cpp
+++ b/src/copy/target_resolver.cpp
@@ -717,12 +717,25 @@ static uint16_t SQLServerTypeMaxLength(const string &type_name, int16_t max_leng
 		return 8;
 	} else if (type_lower == "smallmoney") {
 		return 4;
-	} else if (type_lower == "varchar" || type_lower == "nvarchar" || type_lower == "char" || type_lower == "nchar") {
+	} else if (type_lower == "varchar" || type_lower == "char") {
 		// For (max), max_length is -1 in sys.columns
 		if (max_length == -1) {
 			return 0xFFFF;	// MAX indicator
 		}
-		// For nvarchar/nchar, max_length is in bytes (2 bytes per char)
+		// varchar/char data is transmitted as NVARCHAR over the BCP wire, so the
+		// declared length must be UTF-16 bytes: sys.columns reports single-byte
+		// characters, hence 2x. varchar(n) with n > 4000 exceeds the 8000-byte
+		// inline NVARCHAR limit and must be sent as nvarchar(max) (PLP).
+		if (max_length > 4000) {
+			return 0xFFFF;	// MAX indicator (PLP)
+		}
+		return static_cast<uint16_t>(max_length * 2);
+	} else if (type_lower == "nvarchar" || type_lower == "nchar") {
+		// For (max), max_length is -1 in sys.columns
+		if (max_length == -1) {
+			return 0xFFFF;	// MAX indicator
+		}
+		// For nvarchar/nchar, sys.columns max_length is already in bytes (2 bytes per char)
 		return static_cast<uint16_t>(max_length);
 	} else if (type_lower == "text" || type_lower == "ntext") {
 		return 0xFFFF;	// MAX indicator

--- a/test/sql/copy/copy_varchar_length.test
+++ b/test/sql/copy/copy_varchar_length.test
@@ -1,0 +1,76 @@
+# name: test/sql/copy/copy_varchar_length.test
+# description: Issue #181 regression — BCP COPY into an existing VARCHAR(n) column must
+#              accept n characters. The BCP wire declares varchar data as NVARCHAR
+#              (UTF-16), so the declared wire length must be 2x the sys.columns byte
+#              length, not the raw value (which halved the effective capacity).
+# group: [copy] [integration]
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_varchar_len_test');
+
+statement ok
+SELECT mssql_exec('db', 'CREATE TABLE dbo.copy_varchar_len_test (
+    id INT NOT NULL,
+    s VARCHAR(10) NOT NULL,
+    c CHAR(10) NOT NULL,
+    ns NVARCHAR(10) NOT NULL
+)');
+
+# The issue #181 repro: 6 ASCII chars into VARCHAR(10) (failed before the fix
+# because the wire declared nvarchar(5)), plus the exact-capacity boundary.
+statement ok
+COPY (SELECT * FROM (VALUES
+    (1, 'aaaaaa', 'bbbbbb', 'cccccc'),
+    (2, '1234567890', 'abcdefghij', 'klmnopqrst')
+) AS t(id, s, c, ns)) TO 'mssql://db/dbo/copy_varchar_len_test' (FORMAT 'bcp', CREATE_TABLE false);
+
+# CHAR(10) pads with trailing spaces on the server; trim for comparison.
+query ITTT
+SELECT id, s, rtrim(c), ns FROM db.dbo.copy_varchar_len_test ORDER BY id;
+----
+1	aaaaaa	bbbbbb	cccccc
+2	1234567890	abcdefghij	klmnopqrst
+
+# A value that genuinely exceeds VARCHAR(10) must still be rejected (by the
+# server, not by the halved client-side wire declaration).
+statement error
+COPY (SELECT 3 AS id, '12345678901' AS s, 'x' AS c, 'x' AS ns)
+TO 'mssql://db/dbo/copy_varchar_len_test' (FORMAT 'bcp', CREATE_TABLE false);
+----
+
+# varchar(n) with n > 4000 exceeds the 8000-byte inline NVARCHAR wire limit
+# and must fall back to PLP (nvarchar(max)) transmission.
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_varchar_wide_test');
+
+statement ok
+SELECT mssql_exec('db', 'CREATE TABLE dbo.copy_varchar_wide_test (
+    id INT NOT NULL,
+    s VARCHAR(8000) NOT NULL
+)');
+
+statement ok
+COPY (SELECT 1 AS id, repeat('x', 8000) AS s)
+TO 'mssql://db/dbo/copy_varchar_wide_test' (FORMAT 'bcp', CREATE_TABLE false);
+
+query II
+SELECT id, length(s) FROM db.dbo.copy_varchar_wide_test;
+----
+1	8000
+
+# Cleanup
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_varchar_len_test');
+
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_varchar_wide_test');
+
+statement ok
+DETACH db;


### PR DESCRIPTION
Fixes #181.

## Root cause

The BCP path transmits all character data as NVARCHAR (UTF-16) and lets SQL Server convert to the target column type. For an **existing** target table, `TargetResolver::GetExistingTableColumnMetadata` passed `sys.columns.max_length` through unchanged as the declared NVARCHAR wire length:

- `varchar(10)` → `sys.columns.max_length = 10` (single-byte characters)
- declared on the wire as NVARCHAR with `max_length = 10` **UTF-16 bytes** = 5 characters
- `INSERT BULK` declaration became `nvarchar(5)`

So the server rejected any value longer than n/2 characters — `'aaaaaa'` (6 ASCII chars) into `VARCHAR(10)` failed.

## Fix

In `SQLServerTypeMaxLength` (src/copy/target_resolver.cpp), split the char-type branch:

- **varchar/char**: declare `2 × sys.columns.max_length` UTF-16 bytes; when `n > 4000` (would exceed the 8000-byte inline NVARCHAR limit), fall back to PLP `nvarchar(max)`.
- **nvarchar/nchar**: unchanged — `sys.columns.max_length` is already in UTF-16 bytes.

The 2× declaration is an upper bound on what the client may send per row; the server still enforces the target column's real capacity at conversion time, so genuinely over-long values keep failing with the normal truncation error (covered by the test).

## Test

`test/sql/copy/copy_varchar_length.test` (integration, requires SQL Server):
- the exact #181 repro (6 chars into `VARCHAR(10)`, `CREATE_TABLE false`)
- exact-capacity boundary (10 chars into `VARCHAR(10)`, `CHAR(10)`, `NVARCHAR(10)`)
- over-capacity value still rejected
- `VARCHAR(8000)` with an 8000-char value exercising the PLP fallback

Not run locally (fresh worktree, no local build) — relying on CI integration tests.