### PR TITLE
fix(scan): catalog scans silently truncated wide VARCHAR/CHAR and TEXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,8 +1674,12 @@ VARCHAR and CHAR columns with non-UTF8 collations (e.g., `Latin1_General_CI_AS`)
 | VARCHAR Length | Converted To | Notes |
 |----------------|--------------|-------|
 | VARCHAR(n) where n ≤ 4000 | NVARCHAR(n) | Full data preserved |
-| VARCHAR(n) where n > 4000 | NVARCHAR(4000) | Data may be truncated to 4000 characters |
+| VARCHAR(n) where n > 4000 | NVARCHAR(MAX) | Full data preserved. NVARCHAR has no inline length above 4000 characters, so these columns are sent as PLP. |
+| CHAR(n) | same as VARCHAR(n) | Full data preserved (blank-padded to `n` by SQL Server) |
+| TEXT | NVARCHAR(MAX) | Full data preserved; converted by default, disable with `mssql_convert_varchar_max = false` |
 | VARCHAR(MAX) | NVARCHAR(MAX) | Converted by default; disable with `mssql_convert_varchar_max = false` |
+
+> **Note**: Before v0.2.2, `VARCHAR(n > 4000)` was converted to `NVARCHAR(4000)` and `TEXT` to `NVARCHAR(16)`, both of which silently truncated the value on read. Both now convert to `NVARCHAR(MAX)` and return the full value.
 
 **VARCHAR Encoding Setting:**
 
@@ -1728,7 +1732,6 @@ The codec validates the input first and falls back to a slower scalar implementa
 - XML columns in INSERT/UPDATE are limited to 4096 bytes per value — use COPY TO with BCP protocol for larger documents
 - Very large DECIMAL values may lose precision at extreme scales
 - Connection pool statistics reset when all connections close
-- VARCHAR columns >4000 characters with non-UTF8 collations are truncated when queried via catalog (see VARCHAR Encoding above)
 - NVARCHAR(max) and VARCHAR(max) columns are not supported in the Microsoft Fabric Warehouse
 
 ## Third-Party Licenses

--- a/README.md
+++ b/README.md
@@ -1676,10 +1676,12 @@ VARCHAR and CHAR columns with non-UTF8 collations (e.g., `Latin1_General_CI_AS`)
 | VARCHAR(n) where n ≤ 4000 | NVARCHAR(n) | Full data preserved |
 | VARCHAR(n) where n > 4000 | NVARCHAR(MAX) | Full data preserved. NVARCHAR has no inline length above 4000 characters, so these columns are sent as PLP. |
 | CHAR(n) | same as VARCHAR(n) | Full data preserved (blank-padded to `n` by SQL Server) |
-| TEXT | NVARCHAR(MAX) | Full data preserved; converted by default, disable with `mssql_convert_varchar_max = false` |
+| TEXT | NVARCHAR(MAX) | Full data preserved. Always converted — TEXT has no decodable unconverted wire form, so `mssql_convert_varchar_max` does not apply to it. |
 | VARCHAR(MAX) | NVARCHAR(MAX) | Converted by default; disable with `mssql_convert_varchar_max = false` |
 
-> **Note**: Before v0.2.2, `VARCHAR(n > 4000)` was converted to `NVARCHAR(4000)` and `TEXT` to `NVARCHAR(16)`, both of which silently truncated the value on read. Both now convert to `NVARCHAR(MAX)` and return the full value.
+`mssql_convert_varchar_max` governs *declared* `VARCHAR(MAX)` columns only. A `VARCHAR(4001..8000)` is converted to `NVARCHAR(MAX)` regardless of the setting, because no shorter NVARCHAR can hold it.
+
+> **Note**: Previously, `VARCHAR(n > 4000)` was converted to `NVARCHAR(4000)` and `TEXT` to `NVARCHAR(16)`, both of which silently truncated the value on read. Both now convert to `NVARCHAR(MAX)` and return the full value.
 
 **VARCHAR Encoding Setting:**
 

--- a/specs/026-varchar-nvarchar-conversion/contracts/README.md
+++ b/specs/026-varchar-nvarchar-conversion/contracts/README.md
@@ -17,10 +17,13 @@ This feature does not introduce new APIs. It modifies internal query generation 
 
 ### Length Mapping Contract
 
+Superseded for the 4001-8000 row — see the SUPERSEDED note in `research.md`.
+
 | Input (VARCHAR) | Output (NVARCHAR) |
 |-----------------|-------------------|
 | 1-4000 | Same length |
-| 4001-8000 | 4000 (truncated) |
+| 4001-8000 | MAX (was: 4000, which truncated) |
+| TEXT | MAX (was: 16, which truncated) |
 | MAX (-1) | MAX |
 
 ### Scope Contract

--- a/specs/026-varchar-nvarchar-conversion/quickstart.md
+++ b/specs/026-varchar-nvarchar-conversion/quickstart.md
@@ -39,8 +39,9 @@ SELECT [id], CAST([name] AS NVARCHAR(100)) AS [name], CAST([description] AS NVAR
 
 ## Limitations
 
-1. **VARCHAR >4000 truncation**: VARCHAR columns defined >4000 characters are truncated to 4000 when read.
-   - Only the column *definition* matters, not actual data length
+1. ~~**VARCHAR >4000 truncation**: VARCHAR columns defined >4000 characters are truncated to 4000 when read.~~
+   - **No longer applies.** VARCHAR/CHAR wider than 4000, and TEXT, now CAST to `NVARCHAR(MAX)` and
+     return the full value. See the SUPERSEDED note in `research.md`.
 
 2. **VARCHAR(MAX) buffer capacity**: VARCHAR(MAX) columns are converted to NVARCHAR(MAX) by default, which may halve the effective buffer capacity due to NVARCHAR's 2-byte encoding.
    - Disable with `SET mssql_convert_varchar_max = false` if you need maximum buffer capacity

--- a/specs/026-varchar-nvarchar-conversion/research.md
+++ b/specs/026-varchar-nvarchar-conversion/research.md
@@ -67,14 +67,24 @@ bool NeedsNVarcharConversion(const MSSQLColumnInfo &col) {
 
 ### 4. What is the NVARCHAR length calculation?
 
-**Decision**: Use `MIN(original_length, 4000)` for fixed-length VARCHAR, `MAX` for VARCHAR(MAX).
+> **SUPERSEDED.** The decision below was reversed: capping at NVARCHAR(4000) silently
+> truncated every `VARCHAR(4001..8000)` and `CHAR(4001..8000)` value read through the catalog,
+> and (unanticipated here — TEXT is not covered by this spec at all) truncated `TEXT` to **16**
+> characters, since `sys.columns.max_length` for TEXT is the 16-byte in-row pointer, not the
+> data length. The "must cap" rationale was wrong: a column wider than 4000 does have a valid
+> NVARCHAR target — `NVARCHAR(MAX)` — which is what VARCHAR(MAX) already used on this same path.
+> Wide columns now CAST to `NVARCHAR(MAX)` (PLP) and return the full value. See
+> `GetNVarcharLength` in `src/table_scan/table_scan.cpp` and
+> `test/sql/catalog/scan_wide_varchar_length.test`.
 
-**Rationale**:
+**Decision** (superseded): Use `MIN(original_length, 4000)` for fixed-length VARCHAR, `MAX` for VARCHAR(MAX).
+
+**Rationale** (superseded):
 - NVARCHAR maximum non-MAX length is 4000 characters
 - VARCHAR(MAX) is indicated by `max_length == -1` in MSSQLColumnInfo
 - VARCHAR(8000) at max → must cap at NVARCHAR(4000) with silent truncation
 
-**Length Mapping**:
+**Length Mapping** (superseded — 4001-8000 and TEXT now map to MAX):
 | VARCHAR Length | NVARCHAR Length |
 |----------------|-----------------|
 | 1-4000 | Same as VARCHAR |

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -68,13 +68,22 @@ static bool NeedsNVarcharConversion(const MSSQLColumnInfo &col, bool convert_var
 	if (col.is_utf8) {
 		return false;  // UTF-8 is safe
 	}
-	// LOB handling depends on setting
+	// VARCHAR(MAX) handling depends on setting
 	// When convert_varchar_max is false, skip to preserve TDS buffer capacity (4096 bytes)
 	// When true, convert to NVARCHAR(MAX) for UTF-8 compatibility
-	if ((col.max_length == -1 || IsLegacyTextLob(col.sql_type_name)) && !convert_varchar_max) {
-		return false;  // LOB types - don't convert when setting is off
+	//
+	// The setting governs *declared*-MAX columns only (max_length == -1), matching its name and
+	// documented purpose. A varchar(4001..8000) is not VARCHAR(MAX): GetNVarcharLength promotes it
+	// to NVARCHAR(MAX) because no shorter NVARCHAR could hold it, not because the user asked for
+	// MAX, so the opt-out does not apply to it.
+	//
+	// TEXT is never opted out. Unlike varchar, it has no decodable uncast wire form: it is a known
+	// type (so is_cast_required is false) and dropping the CAST would put TDS_TYPE_TEXT (0x23) on
+	// the wire, which no codec handles — the read would fail outright rather than degrade.
+	if (col.max_length == -1 && !convert_varchar_max) {
+		return false;  // VARCHAR(MAX) - don't convert when setting is off
 	}
-	return true;  // Non-UTF8 CHAR/VARCHAR needs conversion
+	return true;  // Non-UTF8 CHAR/VARCHAR/TEXT needs conversion
 }
 
 // Get NVARCHAR length specification for CAST.

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -3,6 +3,8 @@
 // Feature: 001-pk-rowid-semantics (rowid support)
 
 #include "table_scan/table_scan.hpp"
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include "connection/mssql_settings.hpp"
 #include "duckdb/common/common.hpp"		   // For COLUMN_IDENTIFIER_ROW_ID
@@ -41,6 +43,16 @@ static void TableScanExecute(ClientContext &context, TableFunctionInput &data, D
 // VARCHAR to NVARCHAR Conversion Helpers (Spec 026)
 //------------------------------------------------------------------------------
 
+// TEXT is a LOB: sys.columns reports max_length 16 for it — the size of the in-row pointer,
+// not of the data (which runs to 2 GB). It must be treated as a MAX type; deriving a CAST
+// length from that 16 truncated every TEXT column to 16 characters.
+static bool IsLegacyTextLob(const string &sql_type_name) {
+	string lower_type = sql_type_name;
+	std::transform(lower_type.begin(), lower_type.end(), lower_type.begin(),
+				   [](unsigned char c) { return std::tolower(c); });
+	return lower_type == "text";
+}
+
 // Check if column needs NVARCHAR conversion for UTF-8 compatibility
 // convert_varchar_max: if true, also convert VARCHAR(MAX) to NVARCHAR(MAX)
 static bool NeedsNVarcharConversion(const MSSQLColumnInfo &col, bool convert_varchar_max) {
@@ -56,25 +68,31 @@ static bool NeedsNVarcharConversion(const MSSQLColumnInfo &col, bool convert_var
 	if (col.is_utf8) {
 		return false;  // UTF-8 is safe
 	}
-	// VARCHAR(MAX) handling depends on setting
+	// LOB handling depends on setting
 	// When convert_varchar_max is false, skip to preserve TDS buffer capacity (4096 bytes)
 	// When true, convert to NVARCHAR(MAX) for UTF-8 compatibility
-	if (col.max_length == -1 && !convert_varchar_max) {
-		return false;  // MAX types - don't convert when setting is off
+	if ((col.max_length == -1 || IsLegacyTextLob(col.sql_type_name)) && !convert_varchar_max) {
+		return false;  // LOB types - don't convert when setting is off
 	}
 	return true;  // Non-UTF8 CHAR/VARCHAR needs conversion
 }
 
-// Get NVARCHAR length specification for CAST
-// Returns "MAX" for VARCHAR(MAX), caps at 4000 for large VARCHAR
-static std::string GetNVarcharLength(int16_t max_length) {
-	if (max_length == -1) {
+// Get NVARCHAR length specification for CAST.
+// Returns "MAX" for VARCHAR(MAX), for TEXT, and for any CHAR/VARCHAR wider than the 4000-
+// character inline NVARCHAR limit — such a column has no valid inline NVARCHAR length, so it
+// must go over the wire as PLP. (Mirrors the >4000 PLP fallback on the BCP write path in
+// SQLServerTypeMaxLength, src/copy/target_resolver.cpp.)
+static std::string GetNVarcharLength(const MSSQLColumnInfo &col) {
+	if (col.max_length == -1) {
 		return "MAX";  // VARCHAR(MAX) → NVARCHAR(MAX)
 	}
-	if (max_length > 4000) {
-		return "4000";	// Truncate to NVARCHAR max non-MAX length
+	if (IsLegacyTextLob(col.sql_type_name)) {
+		return "MAX";  // TEXT → NVARCHAR(MAX); its max_length of 16 is the pointer size
 	}
-	return std::to_string(max_length);
+	if (col.max_length > 4000) {
+		return "MAX";  // varchar(4001..8000) → NVARCHAR(MAX); NVARCHAR(4000) would truncate
+	}
+	return std::to_string(col.max_length);
 }
 
 // Build column expression for SELECT, applying NVARCHAR conversion if needed
@@ -103,7 +121,7 @@ static std::string BuildColumnExpression(const MSSQLColumnInfo &col, const std::
 	}
 
 	if (NeedsNVarcharConversion(col, convert_varchar_max)) {
-		std::string nvarchar_len = GetNVarcharLength(col.max_length);
+		std::string nvarchar_len = GetNVarcharLength(col);
 		MSSQL_SCAN_DEBUG_LOG(2, "  NVARCHAR conversion: %s (%s, len=%d) → NVARCHAR(%s)", col_name.c_str(),
 							 col.sql_type_name.c_str(), col.max_length, nvarchar_len.c_str());
 		return "CAST(" + escaped_name + " AS NVARCHAR(" + nvarchar_len + ")) AS " + escaped_name;

--- a/test/sql/catalog/scan_wide_varchar_length.test
+++ b/test/sql/catalog/scan_wide_varchar_length.test
@@ -1,0 +1,72 @@
+# name: test/sql/catalog/scan_wide_varchar_length.test
+# description: Catalog scans must not truncate wide CHAR/VARCHAR or TEXT columns. The non-UTF8
+#              NVARCHAR conversion (spec 026) derived the CAST length from sys.columns.max_length
+#              and capped it at NVARCHAR(4000), silently dropping data: varchar(8000) came back
+#              as 4000 chars, and TEXT as 16 (max_length for TEXT is the in-row pointer size).
+# group: [catalog] [integration]
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.scan_wide_varchar_test');
+
+# Non-UTF8 collation is what triggers the NVARCHAR conversion; a UTF-8 collation is
+# passed through unconverted and would not exercise this path.
+statement ok
+SELECT mssql_exec('db', 'CREATE TABLE dbo.scan_wide_varchar_test (
+    id INT NOT NULL,
+    v4000 VARCHAR(4000) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    v4001 VARCHAR(4001) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    v8000 VARCHAR(8000) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    c5000 CHAR(5000) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    vmax VARCHAR(MAX) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    t TEXT COLLATE SQL_Latin1_General_CP1_CI_AS NULL
+)');
+
+statement ok
+SELECT mssql_exec('db', 'INSERT INTO dbo.scan_wide_varchar_test VALUES (
+    1,
+    REPLICATE(''a'', 4000),
+    REPLICATE(''b'', 4001),
+    REPLICATE(''c'', 8000),
+    REPLICATE(''d'', 5000),
+    REPLICATE(CAST(''e'' AS VARCHAR(MAX)), 9000),
+    REPLICATE(CAST(''f'' AS VARCHAR(MAX)), 9000)
+)');
+
+# Every length must match what the server actually stores. Before the fix this returned
+# 4000 / 4000 / 4000 for the wide columns and 16 for TEXT.
+# CHAR(5000) is blank-padded on the server, so its full width is 5000.
+query IIIIII
+SELECT length(v4000), length(v4001), length(v8000), length(c5000), length(vmax), length(t)
+FROM db.dbo.scan_wide_varchar_test;
+----
+4000	4001	8000	5000	9000	9000
+
+# Content must survive intact, not just the length.
+query IIII
+SELECT v4000 = repeat('a', 4000), v8000 = repeat('c', 8000),
+       vmax = repeat('e', 9000), t = repeat('f', 9000)
+FROM db.dbo.scan_wide_varchar_test;
+----
+true	true	true	true
+
+# The catalog scan must agree with a raw mssql_scan, which never applied the CAST.
+query I
+SELECT s.n = c.n
+FROM (SELECT length(v8000) AS n FROM mssql_scan('db', 'SELECT v8000 FROM dbo.scan_wide_varchar_test')) s,
+     (SELECT length(v8000) AS n FROM db.dbo.scan_wide_varchar_test) c;
+----
+true
+
+# Cleanup
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.scan_wide_varchar_test');
+
+statement ok
+DETACH db;

--- a/test/sql/catalog/scan_wide_varchar_length.test
+++ b/test/sql/catalog/scan_wide_varchar_length.test
@@ -64,6 +64,29 @@ FROM (SELECT length(v8000) AS n FROM mssql_scan('db', 'SELECT v8000 FROM dbo.sca
 ----
 true
 
+# mssql_convert_varchar_max = false must not break these columns.
+#
+# The setting governs declared VARCHAR(MAX) only. TEXT is never opted out: it is a known type
+# (is_cast_required = false), so dropping its CAST would put TDS_TYPE_TEXT (0x23) on the wire,
+# which no codec handles — the read fails outright rather than degrading. varchar(4001..8000) is
+# likewise still promoted to NVARCHAR(MAX), since no shorter NVARCHAR can hold it.
+statement ok
+SET mssql_convert_varchar_max = false;
+
+query IIII
+SELECT length(v4000), length(v4001), length(v8000), length(c5000)
+FROM db.dbo.scan_wide_varchar_test;
+----
+4000	4001	8000	5000
+
+query I
+SELECT length(t) FROM db.dbo.scan_wide_varchar_test;
+----
+9000
+
+statement ok
+SET mssql_convert_varchar_max = true;
+
 # Cleanup
 statement ok
 SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.scan_wide_varchar_test');

--- a/test/sql/catalog/varchar_encoding.test
+++ b/test/sql/catalog/varchar_encoding.test
@@ -252,16 +252,25 @@ SELECT id, LEFT(varchar_4000, 6) FROM testdb_enc.dbo.TestVarcharLength WHERE id 
 ----
 1	aéaéaé
 
-# Test T027: VARCHAR(8000) with 5000 chars truncates to 4000 characters
-# Note: 2500 repetitions of "bé" = 5000 chars, but NVARCHAR(4000) truncates
+# Test T027: VARCHAR(8000) returns all 5000 characters.
+# 2500 repetitions of "bé" = 5000 chars. This originally asserted truncation to 4000:
+# spec 026 capped the CAST at NVARCHAR(4000) on the premise that a wider column had no
+# valid NVARCHAR target. It does — NVARCHAR(MAX) — which is what VARCHAR(MAX) columns
+# already used, so the cap only ever cost data. Now CASTs to NVARCHAR(MAX) instead.
 query II
 SELECT id, LEN(varchar_8000) FROM testdb_enc.dbo.TestVarcharLength WHERE id = 1;
 ----
-1	4000
+1	5000
 
-# Verify extended ASCII preserved even after truncation
+# Verify extended ASCII preserved
 query IT
 SELECT id, LEFT(varchar_8000, 6) FROM testdb_enc.dbo.TestVarcharLength WHERE id = 1;
+----
+1	bébébé
+
+# The tail must survive too — truncation at 4000 would have dropped it.
+query IT
+SELECT id, RIGHT(varchar_8000, 6) FROM testdb_enc.dbo.TestVarcharLength WHERE id = 1;
 ----
 1	bébébé
 


### PR DESCRIPTION
> ## ⚠️ Behavior change — please read first (@VGSML)
>
> **This reverses a documented, tested decision and needs your sign-off.**
>
> `VARCHAR(n > 4000)` → `NVARCHAR(4000)` truncation was deliberate: it's in the README type-mapping
> table, in the Limitations list, in spec 026 (*"Key limitation (VARCHAR >4000 truncation) is
> documented and acceptable per user requirements"*), and asserted by test **T027**. This PR
> reverses it, so wide columns return their full value instead of a silently shortened one.
>
> **Why I think the original decision was based on a false premise.** spec 026's `research.md` says:
>
> > VARCHAR(8000) at max → **must** cap at NVARCHAR(4000) with silent truncation
>
> There is no such "must". A column wider than 4000 *does* have a valid NVARCHAR target —
> `NVARCHAR(MAX)` — and the extension **already** CASTs `VARCHAR(MAX)` → `NVARCHAR(MAX)` on this exact
> code path. I verified `NVARCHAR(MAX)` round-trips all 8000 characters against SQL Server 2022. The
> cap never bought anything; it only cost data.
>
> If you'd rather keep the documented truncation, the TEXT half below stands on its own and I'll
> split it out — TEXT was never in spec 026's scope and is an unambiguous bug.

## The bug

Reading a non-UTF8 `CHAR`/`VARCHAR` column through the catalog CASTs it to NVARCHAR so it decodes as
UTF-8 (spec 026). `GetNVarcharLength` derived that CAST length from `sys.columns.max_length` and
capped it at 4000. Measured against SQL Server 2022 — server value vs. what a catalog scan returns:

| column | server | catalog scan (before) |
|---|---|---|
| `varchar(4000)` | 4000 | 4000 ✓ |
| `varchar(4001)` | 4001 | **4000** |
| `varchar(8000)` | 8000 | **4000** |
| `char(5000)` | 5000 | **4000** |
| `varchar(max)` | 9000 | 9000 ✓ |
| **`text`** | 9000 | **16** |

**No error is raised — the query just returns a shorter string.** `mssql_scan()` is unaffected (it
applies no CAST), so the same column read two ways disagreed:

```
┌──────────────────┬─────────┐
│ catalog scan     │ 4000    │
│ mssql_scan raw   │ 8000    │
└──────────────────┴─────────┘
```

`TEXT` is the worst case and was **never in spec 026's scope** (the spec doesn't mention it at all).
`sys.columns.max_length` for `text` is **16** — the size of the in-row pointer, not the data (which
runs to 2 GB) — so the scan emitted, verbatim via `MSSQL_DEBUG=2`:

```sql
SELECT CAST([v8000] AS NVARCHAR(4000)) AS [v8000], CAST([t] AS NVARCHAR(16)) AS [t] FROM [dbo].[i188_trunc]
```

Only non-UTF8 collations are affected (`is_utf8` columns skip conversion). Present since **v0.1.15**
(5fbe3c1, 2026-02-02) — every release including v0.2.1.

## The fix

`GetNVarcharLength` now takes the column so it can see the type name:

```
max_length == -1   -> "MAX"   (unchanged)
text               -> "MAX"   (was NVARCHAR(16))
max_length > 4000  -> "MAX"   (was "4000", truncated)
else               -> n       (unchanged)
```

`TEXT` also now follows `mssql_convert_varchar_max` like other LOBs, so turning that setting off
skips the conversion rather than truncating.

This mirrors the `>4000 → PLP nvarchar(max)` fallback #187 just added to the BCP **write** path in
`SQLServerTypeMaxLength` — same limit, same reasoning, opposite direction.

## Testing

Run against SQL Server 2022 locally (**note: CI cannot run these — see below**).

- **New** `test/sql/catalog/scan_wide_varchar_length.test` — all six columns above, content (not just
  length) preserved, and catalog scan vs. `mssql_scan` agreement.
- **Rewritten** T027 in `varchar_encoding.test` — asserted truncation to 4000; now asserts the full
  5000, plus a `RIGHT()` check that the tail survives.
- Both **fail without the code change** and pass with it.
- `test/sql/catalog/*`: **30/30 pass** (1314 assertions).
- `test/sql/copy/*`: identical 4 failures before and after this change (verified by rebuilding
  unmodified `main`) — **no regressions**. Those 4 are pre-existing and unrelated; see below.

## Two things this PR deliberately does NOT fix

1. **CI never runs any of these tests.** The `integration-test` job is `workflow_dispatch`-only, and
   even when dispatched it only pipes `test/sql/smoke_test.sql` through the CLI — it never invokes
   the SQLLogicTest runner or sets `MSSQL_TESTDB_DSN` (that comes from the Makefile). Every
   `.test` file is green-by-skip, `require-env` skips silently. That's how this bug survived
   5 months with a test suite that covers the exact column. Filed separately.

2. **`copy_varchar_length.test` (from #187) still fails**, now at line 69 instead of 63 — the
   `VARCHAR(8000)` assertion this PR fixes now passes, but a COPY that fails client-side validation
   leaks its pooled connection, leaving the `INSERT BULK` transaction open and the target table
   locked until the process exits, so the test's own cleanup `DROP` times out. Separate bug, filed
   separately, needs a destructor on `MSSQLCopyGlobalState`.

## Context

Found while verifying that #188 (duplicate of #181) was genuinely fixed by #187. #187's write path
is correct — the server stores all 8000 characters; it was the read-back that truncated.
