### PR TITLE
fix(copy): release the BCP connection when a COPY fails client-side (#191)

### DIFF
--- a/src/copy/copy_function.cpp
+++ b/src/copy/copy_function.cpp
@@ -97,6 +97,54 @@ void RegisterMSSQLCopyFunctions(ExtensionLoader &loader) {
 	CopyDebugLog(1, "Registered 'bcp' COPY function");
 }
 
+//===----------------------------------------------------------------------===//
+// MSSQLCopyGlobalState destructor - last-resort connection release (issue #191)
+//===----------------------------------------------------------------------===//
+
+MSSQLCopyGlobalState::~MSSQLCopyGlobalState() {
+	// No-op on every path that already released: BCPCopyInitGlobal's error helper and
+	// BCPCopyFinalize (both success and error) reset() `connection`. This only fires when the sink
+	// threw and copy_to_finalize was never called — see the contract note on the declaration.
+	//
+	// Touch no ClientContext here (issue #178 / PR #179): this can run on a worker thread while
+	// the client thread commits the query's transaction.
+	if (!connection) {
+		return;
+	}
+
+	// A COPY that died mid-stream leaves the server awaiting bulk data on this session, so the
+	// connection is not reusable: closing it is what ends the session, rolls back the INSERT BULK
+	// transaction, and drops the locks it held on the target table. Returning it to the pool in
+	// that state would hand the next caller a connection stuck mid-bulk-load.
+	auto conn_state = connection->GetState();
+	if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
+		try {
+			connection->Close();
+		} catch (...) {
+			// Ignore - the shared_ptr destructor closes the socket regardless.
+		}
+	}
+
+	if (transaction_pinned) {
+		// The MSSQLTransaction owns the pin; just drop our reference.
+		connection.reset();
+		return;
+	}
+
+	if (auto pool = pool_handle.lock()) {
+		try {
+			connection->SetNeedsReset(true);
+			pool->Release(std::move(connection));
+		} catch (...) {
+			// Release failed - drop it; the shared_ptr destructor closes the socket.
+			connection.reset();
+		}
+	} else {
+		// Catalog torn down - dropping is the safe failure mode.
+		connection.reset();
+	}
+}
+
 namespace mssql {
 
 // Forward declarations
@@ -250,6 +298,12 @@ unique_ptr<GlobalFunctionData> BCPCopyInitGlobal(ClientContext &context, Functio
 		throw IOException("MSSQL COPY: Failed to acquire connection from pool");
 	}
 	CopyDebugLog(2, "BCPCopyInitGlobal: connection acquired");
+
+	// Capture the destructor's release targets here, on the client thread — it must not touch a
+	// ClientContext itself (issue #178 / PR #179). Covers the sink-throw path, where neither the
+	// helper below nor BCPCopyFinalize runs (issue #191).
+	gstate->pool_handle = mssql_catalog.GetConnectionPoolHandle();
+	gstate->transaction_pinned = ConnectionProvider::IsInTransaction(context, mssql_catalog);
 
 	// Helper to release connection on error
 	auto release_connection_on_error = [&]() {

--- a/src/include/copy/copy_function.hpp
+++ b/src/include/copy/copy_function.hpp
@@ -19,6 +19,7 @@ class ExtensionLoader;
 
 namespace tds {
 class TdsConnection;
+class ConnectionPool;
 }  // namespace tds
 
 //===----------------------------------------------------------------------===//
@@ -67,8 +68,33 @@ struct MSSQLCopyBindData : public TableFunctionData {
 //===----------------------------------------------------------------------===//
 
 struct MSSQLCopyGlobalState : public GlobalFunctionData {
+	// Last-resort connection release (issue #191).
+	//
+	// BCPCopyInitGlobal and BCPCopyFinalize each release `connection` on the paths they own, and
+	// both reset() it, so this destructor is a no-op whenever either ran. It exists for the path
+	// neither covers: a throw from the sink (e.g. ValidateNVarcharLength rejecting an over-long
+	// value). DuckDB does not call copy_to_finalize on an errored COPY, so nothing released the
+	// connection — the pool kept it checked out in Executing state with the INSERT BULK
+	// transaction open, holding locks on the target table until the pool was torn down at process
+	// exit.
+	//
+	// Follows MSSQLResultStream's destructor contract (issue #178 / PR #179): touch NO
+	// ClientContext here — it can run on a worker thread while the client thread commits the
+	// query's transaction. The release targets below are captured on the client thread in
+	// BCPCopyInitGlobal instead.
+	~MSSQLCopyGlobalState();
+
 	// Pinned TDS connection for BulkLoad operations
 	std::shared_ptr<tds::TdsConnection> connection;
+
+	// Release targets captured in BCPCopyInitGlobal (see destructor note above).
+	//   pool_handle        — weak_ptr to the catalog's pool; a failed lock() (catalog torn down)
+	//                        degrades to dropping the connection, never a dangling dereference.
+	//   transaction_pinned — true when the connection is pinned to an explicit DuckDB
+	//                        transaction; the destructor then only drops its reference, since the
+	//                        MSSQLTransaction owns the pin.
+	weak_ptr<tds::ConnectionPool> pool_handle;
+	bool transaction_pinned = false;
 
 	// BCP packet writer (thread-safe)
 	unique_ptr<mssql::BCPWriter> writer;

--- a/test/sql/copy/copy_failed_bcp_releases_connection.test
+++ b/test/sql/copy/copy_failed_bcp_releases_connection.test
@@ -1,0 +1,56 @@
+# name: test/sql/copy/copy_failed_bcp_releases_connection.test
+# description: Issue #191 regression — a COPY that fails client-side must not leave its pooled
+#              connection checked out. The sink throws after INSERT BULK is on the wire, and
+#              DuckDB does not call copy_to_finalize on an errored COPY, so nothing released the
+#              connection: the pool kept it in Executing state with the bulk-load transaction
+#              open, holding locks on the target table until process exit. Every later statement
+#              touching that table then blocked until the query timeout.
+# group: [copy] [integration]
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_fail_release_test');
+
+statement ok
+SELECT mssql_exec('db', 'CREATE TABLE dbo.copy_fail_release_test (
+    s VARCHAR(10) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL
+)');
+
+# No connection is checked out before the COPY.
+query I
+SELECT active_connections FROM mssql_pool_stats('db');
+----
+0
+
+# 11 characters into VARCHAR(10): rejected by the client-side length check in the sink, which is
+# the path that leaked. The error itself is correct and expected.
+statement error
+COPY (SELECT '12345678901' AS s) TO 'mssql://db/dbo/copy_fail_release_test' (FORMAT 'bcp', CREATE_TABLE false);
+----
+overflow
+
+# The failed COPY must not have left a connection checked out.
+query I
+SELECT active_connections FROM mssql_pool_stats('db');
+----
+0
+
+# The real symptom: this DROP timed out before the fix, because the leaked connection still held
+# the bulk-load lock on the table.
+statement ok
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_fail_release_test');
+
+# The pool is still usable afterwards.
+query I
+SELECT 1 FROM mssql_scan('db', 'SELECT 1 AS x');
+----
+1
+
+statement ok
+DETACH db;


### PR DESCRIPTION
Fixes #191. @VGSML — flagging you since this touches connection-pool ownership (spec 047) and follows the destructor contract you reviewed in #179.

## The bug

A `COPY ... (FORMAT 'bcp')` that fails **client-side** leaked its pooled connection, leaving the target table locked for the rest of the process:

```sql
COPY (SELECT '12345678901' AS s) TO 'mssql://db/dbo/t' (FORMAT 'bcp', CREATE_TABLE false);
-- Invalid Input Error: MSSQL: NVARCHAR column 's' overflow: ...          <- correct, expected
SELECT mssql_exec('db','DROP TABLE IF EXISTS dbo.t');
-- Invalid Input Error: MSSQL execution error: SQL Server error 0: Query timeout   <- the bug
```

A *new* process could drop the table; the same one could not. At teardown the pool confirms it:

```
[MSSQL POOL] LEAKED active conn id=1 spid=0 state=3 use_count=1 pool='db'
[MSSQL POOL] WARNING: ~ConnectionPool 'db' shut down with 1 connection(s) still checked out
```

## Root cause

`ValidateNVarcharLength` throws from the **sink** — after `INSERT BULK` is on the wire and the connection is in `Executing` state. DuckDB does not call `copy_to_finalize` on an errored COPY, and `BCPCopyInitGlobal`'s `release_connection_on_error` only covers failures *during init*. `MSSQLCopyGlobalState` held the connection as a `shared_ptr` with no destructor, so on that path nothing released it: the pool kept it checked out with the bulk-load transaction open, holding locks on the target table until the pool was torn down at process exit.

## The fix

Give `MSSQLCopyGlobalState` a destructor as the last-resort release. It's a no-op whenever `InitGlobal` or `Finalize` ran (both `reset()` the connection), so it only fires on the sink-throw path.

**It closes the connection rather than returning it to the pool.** A connection that died mid-stream isn't reusable — the server is still awaiting bulk data — and closing is precisely what ends the session, rolls back the `INSERT BULK` transaction, and drops its locks. Returning it would hand the next caller a connection stuck mid-bulk-load.

Follows `MSSQLResultStream`'s destructor contract (#178 / #179): **no `ClientContext` is touched in the destructor**, since it can run on a worker thread while the client thread commits the query's transaction. The release targets (pool `weak_ptr`, transaction-pinned flag) are captured on the client thread in `BCPCopyInitGlobal`, and a failed `lock()` degrades to dropping the connection rather than dangling.

## Testing

Against SQL Server 2022 (**note: CI runs no `.test` file — see #192**).

- **New** `test/sql/copy/copy_failed_bcp_releases_connection.test`: asserts `active_connections` is 0 after a failed COPY, that the previously-timing-out `DROP` succeeds, and that the pool still works afterwards. **Fails without this change** (`active_connections` stays 1), passes with it.
- Copy suite: 4 → 3 failures. The remaining 3 are pre-existing and unrelated — I verified them against unmodified `main`: stale expected-error text in `copy_connection_leak.test` (`"not found"` vs DuckDB's current `Catalog "..." does not exist!` — despite the name, nothing to do with connections), `mssql_exec` called as a table function in `copy_type_mismatch.test`, and an INT/BIGINT mismatch in `copy_existing_temp.test`.

## Relationship to #190

Independent, disjoint files — this touches only `src/copy/`, #190 only `src/table_scan/`. Verified standalone on `main`.

Together they turn `copy_varchar_length.test` (shipped red in #187, never run by CI) green. It needs both: on this branch alone it still fails at line 63 (the VARCHAR(8000) read-back truncation, #190's half); with both, 21/21 pass. Either order merges cleanly.
