### PR TITLE
fix(azure): use reentrant gmtime_r/gmtime_s in FormatTimestamp

### DIFF
--- a/src/azure/jwt_parser.cpp
+++ b/src/azure/jwt_parser.cpp
@@ -213,13 +213,22 @@ JwtClaims ParseJwtClaims(const std::string &token) {
 
 std::string FormatTimestamp(int64_t unix_timestamp) {
 	std::time_t time = static_cast<std::time_t>(unix_timestamp);
-	std::tm *utc_tm = std::gmtime(&time);
-	if (!utc_tm) {
+
+	// std::gmtime returns a pointer into a shared static buffer; connection
+	// setup runs on pool worker threads, so use the reentrant variant.
+	std::tm utc_tm;
+#ifdef _WIN32
+	if (gmtime_s(&utc_tm, &time) != 0) {
 		return "invalid timestamp";
 	}
+#else
+	if (gmtime_r(&time, &utc_tm) == nullptr) {
+		return "invalid timestamp";
+	}
+#endif
 
 	char buffer[32];
-	std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S UTC", utc_tm);
+	std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S UTC", &utc_tm);
 	return std::string(buffer);
 }
 


### PR DESCRIPTION
## What

`FormatTimestamp` in `src/azure/jwt_parser.cpp` called `std::gmtime`, which returns a pointer into a **shared static buffer** rather than storage the caller owns. Two threads calling it concurrently race on that buffer.

This is reachable: `FormatTimestamp` is called from `ManualTokenAuthStrategy::GetFedAuthToken` (`src/tds/auth/manual_token_strategy.cpp:59`), which runs on connection-setup threads. Two pool threads hitting an expired token at the same time race.

Fix is the reentrant variant — `gmtime_r` on POSIX, `gmtime_s` on Windows (also covers MinGW/Rtools, which declares it via `MINGW_HAS_SECURE_API`).

## Severity — read before prioritising

CodeQL labels this **critical**, which oversells it. That's the rule's generic rating, not an assessment of this call site. In practice:

- the only reachable path is the **token-expired error message**;
- the worst realistic outcome is a **garbled timestamp inside an exception string**.

It is a genuine data race and technically UB, so it's worth fixing — but it's cheap, not urgent. Please don't read the red label as an incident.

## Verification

- Compiles clean at **C++11** (the project's ODR-safe standard per CLAUDE.md) with `-Wall -Wextra`.
- Existing `test/cpp/test_jwt_parser.cpp` builds standalone and **all 17 tests pass, exit 0** — re-run against current `main` after it moved.
- `clang-format-14` (the CI-pinned version) reports no diff.
- Behaviour is unchanged for valid inputs; verified `0` → `1970-01-01 00:00:00 UTC`, `1707228600` → `2024-02-06 14:10:00 UTC`, and the 2038 boundary `2147483647` → `2038-01-19 03:14:07 UTC`.

## Context

This resolves the **only CodeQL alert in `src/`** (alert #90, `cpp/potentially-dangerous-function`). The other 225 open alerts are all in vendored code (`vcpkg/` 119, `duckdb/` 106) — a separate PR adds SARIF path filtering so that noise stops burying real findings.