### PR TITLE
ci(codeql): filter vendored dependencies out of code scanning results

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -106,3 +106,52 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: cpp
+          # Write SARIF to disk instead of uploading: the filter step below
+          # runs first. `failure-only` still uploads debug artifacts when the
+          # analysis itself fails, so we don't lose diagnostics.
+          output: sarif-results
+          upload: failure-only
+
+      - name: Keep unfiltered SARIF for debugging
+        # The filter is a denylist; if it ever drops something it shouldn't,
+        # the raw results are needed to prove it. Cheap insurance.
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: codeql-sarif-unfiltered
+          path: sarif-results/
+          retention-days: 14
+
+      - name: Filter vendored dependencies out of the results
+        # CodeQL analyzes every translation unit the build traces, which means
+        # the whole DuckDB submodule and everything vcpkg compiles from source
+        # (OpenSSL, simdutf). Those are upstream's bugs to fix, not ours, and
+        # they bury our own findings: at the time of writing 225 of 226 open
+        # alerts were vendored and exactly 1 was in src/.
+        #
+        # `paths-ignore` in a CodeQL config file does NOT work here -- it only
+        # applies to interpreted languages or to compiled languages analyzed
+        # without a build, and we must build DuckDB to link the extension. See
+        # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
+        # Filtering the SARIF before upload is the supported alternative.
+        #
+        # This is deliberately a denylist (drop known-vendored trees) rather
+        # than an allowlist (`-**/*` then `+src/**`). An allowlist would
+        # silently discard findings in any future first-party directory; a
+        # denylist fails loud -- new vendored noise shows up and we add it here.
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -duckdb/**
+            -vcpkg/**
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-results/cpp.sarif
+          # Must match the analyze category above, otherwise the upload is
+          # treated as a separate configuration and the vendored alerts stay
+          # open instead of being superseded by this filtered run.
+          category: cpp


### PR DESCRIPTION
## Problem

Code scanning currently shows **226 open alerts. 225 of them are in vendored code.**

| Location | Open alerts |
|---|---|
| `vcpkg/` (OpenSSL, simdutf) | 119 |
| `duckdb/` (zstd, jemalloc, catch, CSV scanner) | 106 |
| **`src/` (ours)** | **1** |

CodeQL analyzes every translation unit the build traces, and we must build DuckDB to link the extension — so the whole submodule plus everything vcpkg compiles from source gets analyzed. Those are upstream's bugs to fix, not ours. The practical cost is that a real finding in `src/` is one line in a 226-row list, which is the same as having no code scanning at all.

## Why not `paths-ignore`?

Because it doesn't work for this case. Per [GitHub's docs](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning), `paths`/`paths-ignore` in a CodeQL config apply only to interpreted languages, or to compiled languages analyzed **without building**:

> "For analysis where code is built, if you want to limit code scanning to specific directories in your project, you must specify appropriate build steps in the workflow."

We can't drop DuckDB from the build. Filtering the SARIF before upload is the supported alternative, via [`advanced-security/filter-sarif`](https://github.com/advanced-security/filter-sarif) (GitHub's own `advanced-security` org, actively maintained).

## Change

`analyze` writes SARIF to disk (`upload: failure-only` — still uploads debug artifacts if the *analysis* fails) → filter → `upload-sarif`.

Three details worth reviewing:

- **Category must stay `cpp`** on the upload. If it differs from the analyze category, GitHub treats it as a separate configuration and the 225 vendored alerts stay open forever instead of being superseded and closed by this run.
- **Denylist, not allowlist.** `-duckdb/**` + `-vcpkg/**` rather than `-**/*` + `+src/**`. An allowlist would *silently* discard findings in any future first-party directory (`tools/`, a new top-level source dir); a denylist fails loud — new vendored noise shows up in the list and we add a line here. Failing noisy beats failing silent for a security control.
- **Unfiltered SARIF kept as an artifact** (14d retention). The filter is the thing most likely to be wrong; if it ever drops something it shouldn't, the raw results are needed to prove it.

## Verification

Not just "the YAML parses" — I ran the real filter against the real data:

1. Downloaded the repo's **actual SARIF** (analysis `1489801417`, `refs/heads/main`, 1.8 MB, 226 results).
2. Cloned `advanced-security/filter-sarif` at **`v1` (`f3b8118`)** — the exact ref this workflow pins.
3. Ran its `filter_sarif.py` with the **exact patterns** from this PR.

Result: **226 results in → 1 out**, and the survivor is exactly the expected one:

```
cpp/potentially-dangerous-function -> src/azure/jwt_parser.cpp:216
```

That remaining alert is fixed by #194. With both merged, code scanning should sit at **0 open alerts** and stay meaningful.

Workflow YAML re-validated after the edit (parses, 11 steps, inputs as intended). `actions/upload-artifact@v7` matches the version already used elsewhere in the repo; `filter-sarif@v1` follows the major-tag pinning convention documented in `.github/dependabot.yml`.

## Note

This does **not** silence real problems in our dependencies — it only stops CodeQL from reporting upstream's source as our alerts. Dependency currency is a separate matter, and there's a live one: `vcpkg.json` hard-pins `openssl` to **3.4.1**, which is five patch releases behind **3.4.6**. Raising that separately.