### PR TITLE
chore(deps): move OpenSSL 3.4.1 → 3.5.4 (LTS) ahead of 3.4 EOL

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,11 +6,17 @@
     "openssl",
     "simdutf"
   ],
-  "builtin-baseline": "5ee5eee0d3e9c6098b24d263e9099edcdcef6631",
+  "$comment-builtin-baseline": "vcpkg 2026.06.24. Moved off 5ee5eee (openssl 3.4.1) because that baseline's version DB tops out at 3.4.1 -- vcpkg never packaged 3.4.2-3.4.6, so reaching a patched OpenSSL requires moving the baseline, not just the override.",
+  "builtin-baseline": "52c9e08cdf8580d2d9762f547d22b96fd81e82f2",
+  "$comment-overrides": "Both deps are pinned so that moving the baseline changes exactly one thing: OpenSSL. simdutf stays at 6.1.1 (the old baseline's version) even though the new baseline offers 8.2.0 -- a two-major-version codec jump does not belong in a security bump and would confound the MinGW result this change exists to test. openssl 3.5.4 is the newest 3.5.x in vcpkg; 3.5 is LTS (supported to 2030-04-08) whereas 3.4 goes EOL 2026-10-22.",
   "overrides": [
     {
       "name": "openssl",
-      "version": "3.4.1"
+      "version": "3.5.4"
+    },
+    {
+      "name": "simdutf",
+      "version": "6.1.1"
     }
   ]
 }


### PR DESCRIPTION
## Why now

**OpenSSL 3.4 is not LTS and goes end-of-life on 2026-10-22 — 97 days away.** After that it gets no security fixes at all. 3.5 is the LTS line, supported through 2030-04-08.

We're pinned to **3.4.1** (Feb 2025), five patch releases behind 3.4.6.

## Reachability — read this before treating it as urgent

I checked what the extension actually calls rather than counting CVEs. The scary ones **do not apply**:

- The High-severity 3.4.x CVEs are **CVE-2026-45447** (heap UAF in `PKCS7_verify`) and **CVE-2025-15467** (stack overflow in CMS `(Auth)EnvelopedData` parsing). Both are in CMS/PKCS7 code.
- The extension's OpenSSL surface is a **pure TLS client** — `SSL_read`, `SSL_get_error`, `SSL_new/free`, `BIO_set_retry_*`, custom BIO callbacks.
- Grepped `src/` for `PKCS7`, `CMS_`, `PKCS12`, `SM2`, `QUIC`, `OCB`, `GCM_SIV`, `CRMF`, `_CMP_`, `BIO_f_linebuffer`: **zero hits.**

What *is* plausibly reachable is ASN.1 certificate parsing (CVE-2026-34180 over-read, CVE-2026-7383 multibyte overflow) plus a couple of TLS-path issues — all rated **Low/Moderate**.

**So this is EOL-driven hygiene, not incident response.** Please don't merge it in a panic; merge it when the MinGW job is green.

## Why the baseline has to move (you can't just bump the override)

vcpkg's version database **only ever contained openssl `3.4.0` and `3.4.1`** for that series — 3.4.2–3.4.6 were never packaged. And the current baseline is not arbitrary:

| commit | date | what it is |
|---|---|---|
| `5ee5eee` | 2025-02-12 | current baseline — *literally* the `[openssl] Update to 3.4.1` commit |
| `52c9e08` | 2026-06-24 | this PR's baseline (vcpkg 2026.06.24) |

The old baseline's version DB tops out at 3.4.1, so a supported OpenSSL requires moving the baseline.

## Keeping the blast radius to exactly one thing

Moving the baseline would also drag **simdutf 6.1.1 → 8.2.0** (two major versions, right through the spec 043/044 codec layer). So simdutf is **explicitly pinned at 6.1.1**. Verified both are resolvable at the new baseline (`simdutf` uses the `version-semver` scheme; per the vcpkg docs plain `"version"` is the correct non-deprecated override key for every scheme).

**The only thing this PR actually changes is the OpenSSL version.**

`vcpkgGitCommitId` is deliberately **not** touched, and I verified why rather than assuming. run-vcpkg's bundle does:

```js
gitTool.arg(['clone', this.vcpkgUrl, '-n', '.']);        // no --depth → FULL clone
gitTool.arg(['checkout', '--force', this.vcpkgGitCommitId]);
```

A full clone, then checkout. So the Jan-2026 pinned checkout (`65604f5`) still has the Jun-2026 baseline's objects locally and resolves it with no network fetch. Leaving the vcpkg tool where it is keeps OpenSSL the single variable under test.

## This needs the MinGW job to be green before merge

**The pin is load-bearing.** `3d1277e` (vgsml, Jan 2026): *"Pin OpenSSL to 3.4.1 for MinGW compatibility — to resolve MinGW (x64-mingw-static) build failures in community-extensions CI."* MinGW is exactly where OpenSSL builds break, so 3.5.4 could reintroduce it.

`vcpkg.json` is part of the MinGW cache key (`vcpkg-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}`), so this bump **forces a real OpenSSL rebuild** rather than a cache hit — the job genuinely tests the thing we care about.

Dispatched against this branch: run [29540869000](https://github.com/hugr-lab/mssql-extension/actions/runs/29540869000). I'll report the result here.

Note the dispatch also runs the MSVC job, which is independently red per #165 — ignore that one.

## If MinGW fails

Fallback order:
1. Try `3.5.x` at a different patch level.
2. Bump `vcpkgGitCommitId` to match the baseline (newer vcpkg may carry MinGW fixes for the OpenSSL port) — costs coherence with `release.yml`, which pins the same SHA in two places.
3. If 3.5 can't build on Rtools 4.2 MinGW at all, that's a real decision to surface: MinGW support vs. a supported TLS library after October.