### PR TITLE
ci: make vcpkg binary caching actually work (x-gha is gone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,22 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
+          # The primary key MUST be unique per run. actions/cache skips the
+          # post-run save on an exact primary-key hit (saveImpl.ts: "Cache hit
+          # occurred on the primary key ..., not saving cache."). With a stable
+          # key the cache would freeze after the first save: once the ABI hash
+          # drifts -- a runner-image compiler bump, or vcpkg master churn, since
+          # the clone above is unpinned -- vcpkg would rebuild every run and the
+          # fresh archives would never be persisted. That is the same silent
+          # no-op this whole change exists to kill.
+          #
+          # hashFiles('vcpkg.json') is kept only as a readable namespace marker;
+          # it is NOT sufficient on its own, because vcpkg.json's `version` is
+          # the extension's own version (rotates for the wrong reason) and it
+          # says nothing about compiler/triplet/vcpkg-tool (fails to rotate for
+          # the right one). The prefix restore-key below is what actually seeds
+          # each run, and it matches across hashes.
+          key: vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
             vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-
 
@@ -519,13 +534,17 @@ jobs:
       # Caches the binary-cache dir named by VCPKG_BINARY_SOURCES above, not
       # the install tree -- see the linux/macos build job for why the old
       # vcpkg/installed + vcpkg/packages paths never elided a rebuild.
+      # Namespace is the vcpkg triplet, deliberately NOT job- or workflow-scoped:
+      # release.yml's MSVC job uses the same triplet and shares this namespace,
+      # so a Windows build dispatched on main can seed the release build. See
+      # the linux/macos job for why the primary key carries github.run_id.
       - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-windows-msvc-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-bincache-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-windows-msvc-x64-windows-static-release-
+            vcpkg-bincache-x64-windows-static-release-
 
       - name: Setup Visual Studio Environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -627,9 +646,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-bincache-x64-mingw-static-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-windows-mingw-x64-mingw-static-
+            vcpkg-bincache-x64-mingw-static-
 
       - name: Build Release
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,13 @@ jobs:
             docker_available: false
             vcpkg_triplet: arm64-osx
 
+    env:
+      # Send vcpkg's binary cache to a directory actions/cache persists (see
+      # the "Cache vcpkg binary packages" step). Without this, vcpkg falls back
+      # to its default files provider under $HOME/.cache/vcpkg/archives, which
+      # nothing caches -- so every run rebuilt OpenSSL from source.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
+
     steps:
       - uses: actions/checkout@v7
 
@@ -213,17 +220,28 @@ jobs:
             ./vcpkg/bootstrap-vcpkg.sh
           fi
 
-      # Cache vcpkg installed packages
-      - name: Cache vcpkg packages
+      # Cache vcpkg's BINARY cache (the archives dir), not the install tree.
+      #
+      # The previous version cached vcpkg/installed + vcpkg/packages +
+      # vcpkg/buildtrees, which never worked: in manifest mode vcpkg installs
+      # into build/release/vcpkg_installed and looks for prebuilt archives in
+      # its binary cache, so none of those three paths were ever consulted.
+      # Runs 29339658347 and 29345077972 both logged
+      #   "Cache restored from key: vcpkg-x64-linux-..."   (a HIT)
+      #   "Building openssl:x64-linux@3.4.1..."            (rebuilt anyway)
+      # i.e. ~2 min of OpenSSL rebuild per run despite a green cache hit.
+      #
+      # Pointing VCPKG_BINARY_SOURCES at a `files` dir and caching THAT dir is
+      # what actually elides the rebuild. Archives are keyed by vcpkg's ABI
+      # hash, so a stale restore can't produce a wrong binary -- vcpkg simply
+      # misses and rebuilds. That makes the prefix restore-key safe.
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-            vcpkg/buildtrees
-          key: vcpkg-${{ matrix.platform.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ matrix.platform.vcpkg_triplet }}-
+            vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-
 
       - name: Build Release
         env:
@@ -462,6 +480,15 @@ jobs:
     runs-on: windows-latest
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_windows_build }}
 
+    env:
+      # Must be set explicitly: run-vcpkg otherwise forces the dead x-gha
+      # provider on GitHub runners. Its own source says
+      #   "Allow users to define the vcpkg's binary source explicitly in the
+      #    workflow, in that case do not override it."
+      #   setVariableIfUndefined(VCPKG_BINARY_SOURCES, 'clear;x-gha,readwrite')
+      # so defining it here is the supported opt-out.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
+
     steps:
       - uses: actions/checkout@v7
 
@@ -489,16 +516,16 @@ jobs:
         with:
           vcpkgGitCommitId: '65604f5075c64b18a84c30de400def13aad2e0ec'
 
-      # Cache vcpkg installed packages
-      - name: Cache vcpkg packages
+      # Caches the binary-cache dir named by VCPKG_BINARY_SOURCES above, not
+      # the install tree -- see the linux/macos build job for why the old
+      # vcpkg/installed + vcpkg/packages paths never elided a rebuild.
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-          key: vcpkg-windows-msvc-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-windows-msvc-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-windows-msvc-x64-windows-static-release-
+            vcpkg-bincache-windows-msvc-x64-windows-static-release-
 
       - name: Setup Visual Studio Environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -547,6 +574,9 @@ jobs:
     env:
       CC: gcc
       CXX: g++
+      # See the MSVC job: defining this is the supported way to stop run-vcpkg
+      # forcing the removed x-gha provider.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
 
     steps:
       - uses: actions/checkout@v7
@@ -590,16 +620,16 @@ jobs:
         with:
           vcpkgGitCommitId: '65604f5075c64b18a84c30de400def13aad2e0ec'
 
-      # Cache vcpkg installed packages
-      - name: Cache vcpkg packages
+      # Caches the binary-cache dir named by VCPKG_BINARY_SOURCES above. This
+      # is the job that pays most for the old broken setup: run 29540869000
+      # spent 6.9 min compiling OpenSSL for x64-mingw-static from scratch.
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-          key: vcpkg-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-windows-mingw-x64-mingw-static-
+            vcpkg-bincache-windows-mingw-x64-mingw-static-
 
       - name: Build Release
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,12 +82,21 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          # vcpkg.json pins the dependency versions, so it is the right cache
-          # key. The prefix restore-key lets an older cache seed a run whose
-          # vcpkg.json changed -- safe because vcpkg validates by ABI hash.
-          key: vcpkg-bincache-codeql-ubuntu-22.04-${{ hashFiles('vcpkg.json') }}
+          # Namespaced by triplet (x64-linux), shared with ci.yml's linux build
+          # rather than scoped to this workflow: both run on ubuntu-22.04, and
+          # this job runs on push to main, so it seeds the default-branch cache
+          # that PR and dispatch runs are allowed to restore from.
+          #
+          # github.run_id keeps the primary key unique per run -- actions/cache
+          # skips the save on an exact primary hit, so a stable key would freeze
+          # the cache the first time the ABI hash drifts. hashFiles('vcpkg.json')
+          # is only a readable marker: vcpkg.json's `version` is the extension's
+          # own version, and it says nothing about compiler or vcpkg-tool, so it
+          # neither rotates when it should nor stays put when it should. The
+          # prefix restore-key is what seeds each run; it matches across hashes.
+          key: vcpkg-bincache-x64-linux-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-codeql-ubuntu-22.04-
+            vcpkg-bincache-x64-linux-
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,13 +35,29 @@ jobs:
       security-events: write
 
     env:
-      # Route vcpkg's binary cache through GitHub Actions' built-in cache so
-      # OpenSSL / libcurl / simdutf etc. aren't rebuilt from source on every
-      # run. Cold runs save ~10-15 min; warm runs save the entire vcpkg-install
-      # phase. Note: ccache is intentionally NOT used here because it
-      # short-circuits compiler invocations and CodeQL's tracer would miss
-      # those translation units, leaving holes in the analysis.
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      # Route vcpkg's binary cache through a plain directory that actions/cache
+      # persists, so OpenSSL / simdutf aren't rebuilt from source every run.
+      #
+      # This used to say `clear;x-gha,readwrite`, which silently did nothing:
+      # vcpkg REMOVED the x-gha provider in vcpkg-tool#1662 (2025-04-29) after
+      # GitHub shut down the internal Actions Cache API it depended on. Because
+      # `clear` drops the default `files` provider and x-gha then resolves to
+      # nothing, the net effect was *zero* binary caching -- vcpkg emitted only
+      # a warning, so it looked fine.
+      #
+      # vcpkg-tool#1662 offers two migrations: GitHub Packages via NuGet, or
+      # actions/cache. We use the `files` provider + actions/cache: no PAT, no
+      # packages:write, and per-port granularity is preserved inside the dir.
+      # Archives are named by vcpkg's ABI hash, so a stale or partial restore
+      # can never yield a wrong binary -- worst case vcpkg misses and rebuilds.
+      # That is what makes the prefix `restore-keys` below safe.
+      #
+      # Note: ccache is intentionally NOT used here because it short-circuits
+      # compiler invocations and CodeQL's tracer would miss those translation
+      # units, leaving holes in the analysis. vcpkg binary caching is different
+      # in kind: it only elides *dependency* compilation, never the extension's
+      # own translation units, which are what this analysis is about.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
 
     steps:
       - name: Checkout
@@ -56,15 +72,22 @@ jobs:
         # build needs (parquet decoders, etc.). extension-ci-tools is skipped.
         run: git submodule update --init --recursive duckdb
 
-      - name: Expose GitHub Actions cache env vars for vcpkg x-gha provider
-        # vcpkg's x-gha binary-source provider needs ACTIONS_CACHE_URL and
-        # ACTIONS_RUNTIME_TOKEN. GitHub injects them into actions/* steps but
-        # not into plain `run:` steps, so we re-export them via the toolkit.
-        uses: actions/github-script@v9
+      # The step that used to live here re-exported ACTIONS_CACHE_URL and
+      # ACTIONS_RUNTIME_TOKEN into the environment so vcpkg's x-gha provider
+      # could reach the Actions Cache service directly. x-gha is gone (see the
+      # VCPKG_BINARY_SOURCES comment above), and those variables feed nothing
+      # else here, so the step was pure dead weight and is removed.
+
+      - name: Cache vcpkg binary packages
+        uses: actions/cache@v6
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          path: vcpkg_bincache
+          # vcpkg.json pins the dependency versions, so it is the right cache
+          # key. The prefix restore-key lets an older cache seed a run whose
+          # vcpkg.json changed -- safe because vcpkg validates by ABI hash.
+          key: vcpkg-bincache-codeql-ubuntu-22.04-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-bincache-codeql-ubuntu-22.04-
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -65,6 +65,9 @@ jobs:
       ASAN_OPTIONS: detect_stack_use_after_return=1:abort_on_error=1
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
       GEN: ninja
+      # Point vcpkg's binary cache at a directory actions/cache persists; the
+      # default ($HOME/.cache/vcpkg/archives) is cached by nothing.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
 
     steps:
       - name: Checkout
@@ -114,16 +117,16 @@ jobs:
           ccache --set-config=compression=true
           ccache -z
 
-      - name: Cache vcpkg packages
+      # Caches vcpkg's binary cache (archives), not the install tree -- see
+      # ci.yml for why the old vcpkg/installed + vcpkg/packages +
+      # vcpkg/buildtrees paths restored cleanly and rebuilt anyway.
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-            vcpkg/buildtrees
-          key: vcpkg-concurrency-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-concurrency-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-concurrency-
+            vcpkg-bincache-concurrency-
 
       - name: Bootstrap vcpkg
         run: make vcpkg-setup

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -120,13 +120,26 @@ jobs:
       # Caches vcpkg's binary cache (archives), not the install tree -- see
       # ci.yml for why the old vcpkg/installed + vcpkg/packages +
       # vcpkg/buildtrees paths restored cleanly and rebuilt anyway.
+      # Namespaced by triplet (x64-linux) and shared with ci.yml/codeql.yml
+      # rather than scoped to this workflow. This workflow only ever runs on
+      # pull_request + workflow_dispatch, so it never writes a cache on the
+      # default branch -- and a cache written from refs/pull/N/merge can only
+      # be restored by re-runs of that same PR. A workflow-private namespace
+      # would therefore be cold on the first run of every PR, forever. Sharing
+      # the triplet namespace lets codeql.yml's push-to-main run seed it.
+      #
+      # Caveat: this job runs on ubuntu-latest while ci.yml/codeql.yml pin
+      # ubuntu-22.04, so a different compiler may make the seeded archives miss
+      # on ABI hash and rebuild. That is no worse than today and still correct
+      # (archives are ABI-named); aligning the runner images would make the
+      # seeding actually land, but that is a behaviour change for another PR.
       - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-concurrency-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-bincache-x64-linux-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-concurrency-
+            vcpkg-bincache-x64-linux-
 
       - name: Bootstrap vcpkg
         run: make vcpkg-setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ jobs:
             runner: macos-14
             docker_available: false
 
+    env:
+      # Point vcpkg's binary cache at a directory actions/cache persists.
+      # The default is $HOME/.cache/vcpkg/archives, which nothing caches.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
+
     steps:
       - uses: actions/checkout@v7
         with:
@@ -134,16 +139,16 @@ jobs:
             ./vcpkg/bootstrap-vcpkg.sh
           fi
 
-      # Cache vcpkg installed packages
-      - name: Cache vcpkg packages
+      # Caches vcpkg's binary cache (archives), not the install tree. See
+      # ci.yml for the evidence that the old vcpkg/installed + vcpkg/packages
+      # paths restored cleanly and still rebuilt every dependency from source.
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-          key: vcpkg-${{ matrix.platform.id }}-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-${{ matrix.platform.id }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ matrix.platform.id }}-
+            vcpkg-bincache-${{ matrix.platform.id }}-
 
       - name: Build Release
         run: |
@@ -193,6 +198,11 @@ jobs:
     runs-on: windows-latest
     needs: lint
 
+    env:
+      # Defining this is the supported opt-out from run-vcpkg forcing the
+      # removed x-gha provider (it uses setVariableIfUndefined). See ci.yml.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
+
     steps:
       - uses: actions/checkout@v7
         with:
@@ -234,15 +244,13 @@ jobs:
         with:
           vcpkgGitCommitId: '65604f5075c64b18a84c30de400def13aad2e0ec'
 
-      - name: Cache vcpkg packages
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-          key: vcpkg-windows-msvc-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-windows-msvc-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-windows-msvc-x64-windows-static-release-
+            vcpkg-bincache-windows-msvc-x64-windows-static-release-
 
       - name: Setup Visual Studio Environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -320,6 +328,8 @@ jobs:
     env:
       CC: gcc
       CXX: g++
+      # Opt out of run-vcpkg's dead x-gha default. See ci.yml.
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg_bincache,readwrite'
 
     steps:
       - uses: actions/checkout@v7
@@ -377,15 +387,13 @@ jobs:
         with:
           vcpkgGitCommitId: '65604f5075c64b18a84c30de400def13aad2e0ec'
 
-      - name: Cache vcpkg packages
+      - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
-          path: |
-            vcpkg/installed
-            vcpkg/packages
-          key: vcpkg-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}
+          path: vcpkg_bincache
+          key: vcpkg-bincache-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-windows-mingw-x64-mingw-static-
+            vcpkg-bincache-windows-mingw-x64-mingw-static-
 
       - name: Setup ccache
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,23 +44,31 @@ jobs:
       fail-fast: false
       matrix:
         platform:
+          # vcpkg_triplet is what the binary cache is namespaced on, so it must
+          # match ci.yml's build matrix exactly -- that job runs on the weekly
+          # main-branch cron and is what can seed this workflow. Keying on
+          # platform.id instead would put releases in a namespace nothing on the
+          # default branch ever writes.
           - id: linux_amd64
             os: linux
             arch: amd64
             runner: ubuntu-22.04
             docker_available: true
+            vcpkg_triplet: x64-linux
 
           - id: linux_arm64
             os: linux
             arch: arm64
             runner: ubuntu-22.04-arm
             docker_available: true
+            vcpkg_triplet: arm64-linux
 
           - id: osx_arm64
             os: osx
             arch: arm64
             runner: macos-14
             docker_available: false
+            vcpkg_triplet: arm64-osx
 
     env:
       # Point vcpkg's binary cache at a directory actions/cache persists.
@@ -146,9 +154,11 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-${{ matrix.platform.id }}-${{ hashFiles('vcpkg.json') }}
+          # Triplet-namespaced (shared with ci.yml) + run_id-unique primary key.
+          # See ci.yml's build job for the full reasoning on both.
+          key: vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-${{ matrix.platform.id }}-
+            vcpkg-bincache-${{ matrix.platform.vcpkg_triplet }}-
 
       - name: Build Release
         run: |
@@ -248,9 +258,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-windows-msvc-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-bincache-x64-windows-static-release-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-windows-msvc-x64-windows-static-release-
+            vcpkg-bincache-x64-windows-static-release-
 
       - name: Setup Visual Studio Environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -391,9 +401,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-windows-mingw-x64-mingw-static-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-bincache-x64-mingw-static-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-bincache-windows-mingw-x64-mingw-static-
+            vcpkg-bincache-x64-mingw-static-
 
       - name: Setup ccache
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ obj/
 # vcpkg
 vcpkg/
 vcpkg_installed/
+# vcpkg's binary cache (files provider). CI-only, but anyone reproducing a CI
+# failure locally by exporting the same VCPKG_BINARY_SOURCES gets one too.
+vcpkg_bincache/
 
 # IDE files
 .vscode/*

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,17 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 .PHONY: vcpkg-setup docker-up docker-down docker-status integration-test test-all test-debug test-simple-query test-multi-instance-pool-isolation test-issue-96-attach-loop test-spec047-us1 test-result-stream-registry-isolation test-spec047-us3 test-token-cache-isolation test-spec047-us-sec test-concurrent-reads help
 
 # Bootstrap vcpkg if not present.
-# Spec 052 PR #127 CI fix: check for the toolchain file specifically, not
-# just the directory. GitHub Actions cache restore creates an empty `vcpkg/`
-# parent when restoring `vcpkg/installed/` — the bare directory existed
-# without the bootstrap-shipped scripts, so `make debug` then ran without
-# -DCMAKE_TOOLCHAIN_FILE and find_package(simdutf) failed.
+# Spec 052 PR #127 CI fix: check for the toolchain file specifically, not just
+# the directory — a partially-populated `vcpkg/` (the bare directory without
+# the bootstrap-shipped scripts) would otherwise pass the guard, and `make
+# debug` would then run without -DCMAKE_TOOLCHAIN_FILE and fail in
+# find_package(simdutf).
+#
+# The original trigger was a GitHub Actions cache restore creating an empty
+# `vcpkg/` parent while restoring `vcpkg/installed/`. No workflow caches that
+# path any more (the vcpkg binary cache lives in `vcpkg_bincache/`), so that
+# specific route is gone — but the file check is strictly more robust than a
+# directory check, so it stays.
 vcpkg-setup:
 	@if [ ! -f "$(VCPKG_TOOLCHAIN)" ]; then \
 		echo "Bootstrapping vcpkg..."; \


### PR DESCRIPTION
## TL;DR

**vcpkg binary caching has been doing nothing on every platform.** Two independent bugs, both silent — CI stayed green the whole time and rebuilt every dependency from source on every run.

## Bug 1: `x-gha` was removed from vcpkg 15 months ago

`codeql.yml` set it explicitly; the Windows jobs in `ci.yml`/`release.yml` get it implicitly from `run-vcpkg`.

vcpkg **removed** the provider in [vcpkg-tool#1662](https://github.com/microsoft/vcpkg-tool/pull/1662) (2025-04-29), after GitHub shut down the internal Actions Cache API it was consuming. From that PR:

> Recent changes in GitHub Actions Cache's API have rendered the `x-gha` binary caching provider useless. […] Their internal APIs were not intended to be consumed the way our program does.

The failure mode is nasty: `clear` drops the default `files` provider, and `x-gha` then resolves to nothing — so the net configuration is **zero binary sources**. vcpkg emits a warning and carries on:

```
%VCPKG_BINARY_SOURCES%: warning: The 'x-gha' binary caching backend has been removed.
  on expression: clear;x-gha,readwrite
```

## Bug 2: the `actions/cache` steps cached the wrong directories

They cached `vcpkg/installed`, `vcpkg/packages`, `vcpkg/buildtrees`. But in **manifest mode** vcpkg installs to `build/release/vcpkg_installed` (as `ci.yml` itself already knows — it references that path when locating simdutf) and looks for prebuilt archives in its *binary cache*. None of those three paths is ever consulted.

**This isn't a theory.** Runs [29339658347](https://github.com/hugr-lab/mssql-extension/actions/runs/29339658347) and [29345077972](https://github.com/hugr-lab/mssql-extension/actions/runs/29345077972) — consecutive, same branch, `vcpkg.json` unchanged, so a guaranteed cache hit — both logged:

```
Cache restored from key: vcpkg-x64-linux-7603ea2f...    <- HIT
Building openssl:x64-linux@3.4.1...                      <- rebuilt anyway
Elapsed time to handle openssl:x64-linux: 1.9 min
```

A green cache hit that rebuilt everything regardless. Same story on Windows, worse: MinGW spends **6.9 min** compiling OpenSSL every run.

## The fix

Use vcpkg's `files` provider pointed at `$GITHUB_WORKSPACE/vcpkg_bincache`, and let `actions/cache` persist *that* directory.

This is **migration option 2** from vcpkg-tool#1662. Option 1 (GitHub Packages via NuGet) is the vcpkg team's recommendation but needs a PAT and `packages:write` for no benefit at this scale. Option 2 is what the GitHub Actions team endorses, and pointing it at the *binary cache* rather than the install tree keeps per-port granularity — the downside vcpkg warns about ("the whole installed tree gets cached as a single artifact") doesn't apply.

For the Windows jobs, defining `VCPKG_BINARY_SOURCES` in the workflow is the **supported opt-out** from run-vcpkg's default. Straight from its bundle:

```js
// Allow users to define the vcpkg's binary source explicitly in the workflow,
// in that case do not override it.
this.baseUtils.setVariableIfUndefined(globals.VCPKG_BINARY_SOURCES, VcpkgRunner.VCPKG_BINARY_SOURCES_GHA);
```

### Why the prefix `restore-keys` are safe

vcpkg names archives by **ABI hash**. A stale or partial restore can never produce a wrong binary — vcpkg simply doesn't find a matching hash and rebuilds. So a loose restore-key is a pure win: it seeds a run whose `vcpkg.json` changed with whatever still matches.

## Scope

All **8** vcpkg-using jobs, across four workflows:

| Workflow | Jobs |
|---|---|
| `ci.yml` | build (linux+osx), build-windows-msvc, build-windows-mingw |
| `release.yml` | build (linux amd64/arm64 + osx), build-windows-msvc, build-windows-mingw |
| `codeql.yml` | analyze |
| `concurrency-tests.yml` | concurrency-tests |

`concurrency-tests.yml` had the same broken paths and would have been missed if I'd only grepped for `x-gha` — it's fixed too. `named-instance.yml` and `lint-extra.yml` don't use vcpkg.

Also removes `codeql.yml`'s `github-script` step that re-exported `ACTIONS_CACHE_URL` / `ACTIONS_RUNTIME_TOKEN`. It existed solely to feed x-gha and now feeds nothing.

## Interaction with #195

Worth flagging: with binary caching working, CodeQL's tracer won't see OpenSSL's translation units on a warm cache, so vendored OpenSSL alerts may vanish on their own — but **non-deterministically** (a cold cache compiles OpenSSL and they'd reappear). #195's SARIF filter is what makes that deterministic. The two are complementary, not redundant.

The `ccache` reasoning in `codeql.yml` ("ccache short-circuits compiler invocations and CodeQL's tracer would miss those translation units") does **not** transfer: vcpkg binary caching only elides *dependency* compilation, never the extension's own TUs, which are what the analysis is about.

## Verification

In progress — and this needs real verification precisely because the bug being fixed is one that looked green for 15 months. A cold run is populating the cache now ([29543742860](https://github.com/hugr-lab/mssql-extension/actions/runs/29543742860)); I'll then re-run and confirm the warm run **restores OpenSSL instead of rebuilding it**. Results to follow. Not merging on "the YAML parses".