### PR TITLE
ci: actually run the SQLLogicTest suite (#192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,9 @@ jobs:
 
   # ============================================================================
   # Integration Test Job - SQL Server tests on Linux only
-  # (Manual trigger only via workflow_dispatch)
+  # Runs on the weekly schedule, and on workflow_dispatch when both run_build
+  # and run_integration_tests are set. Runs the smoke test plus the full
+  # SQLLogicTest suite (test/sql/**/*.test).
   # ============================================================================
   integration-test:
     name: Integration Test (linux_amd64)
@@ -437,9 +439,18 @@ jobs:
           name: duckdb-cli-linux_amd64
           path: cli
 
+      # The SQLLogicTest runner. The build job already produces and uploads it; this job just
+      # never downloaded it, which is why no .test file has ever run in CI (issue #192).
+      - name: Download unittest artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: unittest-linux_amd64
+          path: unittest
+
       - name: Setup executables
         run: |
           chmod +x cli/duckdb
+          chmod +x unittest/unittest
           chmod +x scripts/ci/integration_test.sh
 
       - name: Wait for SQL Server
@@ -448,9 +459,35 @@ jobs:
           timeout 120 bash -c 'until echo > /dev/tcp/localhost/1433 2>/dev/null; do sleep 5; done'
           echo "SQL Server is ready!"
 
-      - name: Run integration tests
+      # The service container starts bare. Locally `make docker-up` runs an init container that
+      # applies this script; the .test files expect the schema and seed rows it creates (TestDB
+      # plus master.dbo.test), and fail without them.
+      - name: Seed test database
         run: |
-          scripts/ci/integration_test.sh ./cli/duckdb ./extension/mssql.duckdb_extension
+          curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc > /dev/null
+          curl -fsSL https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list > /dev/null
+          sudo apt-get update
+          sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18
+          # No -b (exit-on-error): init.sql does not run cleanly even against a fresh server —
+          # one AllDataTypes INSERT does DATEADD(day, id, col_datetime2) over a far-future seed
+          # row and trips "Msg 517 ... datetime2 ... overflow", terminating that statement. This
+          # is pre-existing and happens locally too (make docker-up prints it and carries on);
+          # the suite passes without those rows. -b here would fail every run for a benign,
+          # long-standing reason. integration_test.sh verifies the seed landed instead, so a
+          # genuinely broken seed is still caught rather than silently skipped. See #199.
+          /opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P TestPassword1 -C -i docker/init/init.sql
+          /opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P TestPassword1 -C -i docker/init/init-transaction-tests.sql
+          echo "Seed applied."
+
+      - name: Run integration tests
+        env:
+          MSSQL_TEST_HOST: localhost
+          MSSQL_TEST_PORT: 1433
+          MSSQL_TEST_USER: sa
+          MSSQL_TEST_PASS: TestPassword1
+          MSSQL_TEST_DB: master
+        run: |
+          scripts/ci/integration_test.sh ./cli/duckdb ./extension/mssql.duckdb_extension ./unittest/unittest
 
   # ============================================================================
   # Windows Build Job - MSVC (Visual Studio 2022)

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -14,6 +14,32 @@ BEGIN
 END
 GO
 
+-- =============================================================================
+-- master.dbo.test — seed for catalog_discovery.test
+--
+-- That test attaches MSSQL_TEST_DSN, which defaults to Database=master (see the
+-- Makefile), and expects `dbo.test` to exist there: "we use master.dbo.test for
+-- testing". Everything else in this script lives in TestDB, so nothing created
+-- this table and the test could never pass. It went unnoticed because CI never
+-- ran the .test files (issue #192).
+--
+-- The test rewrites rows 98/99 and restores id=1 to 'A' as it goes, so it only
+-- needs a stable (1,'A'), (2,'B'), (3,'C') starting point.
+-- =============================================================================
+IF OBJECT_ID('master.dbo.test', 'U') IS NOT NULL DROP TABLE master.dbo.test;
+GO
+
+CREATE TABLE master.dbo.test (
+    id INT PRIMARY KEY,
+    name NVARCHAR(50)
+);
+GO
+
+INSERT INTO master.dbo.test (id, name) VALUES (1, 'A'), (2, 'B'), (3, 'C');
+GO
+PRINT 'master.dbo.test created';
+GO
+
 USE TestDB;
 GO
 

--- a/scripts/ci/integration_test.sh
+++ b/scripts/ci/integration_test.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 # integration_test.sh - Full SQL Server integration test for Linux
 #
-# Usage: integration_test.sh <duckdb_cli> <extension_path>
-#   duckdb_cli: Path to DuckDB CLI executable
-#   extension_path: Path to the .duckdb_extension file
+# Usage: integration_test.sh <duckdb_cli> <extension_path> [unittest_binary]
+#   duckdb_cli:      Path to DuckDB CLI executable
+#   extension_path:  Path to the .duckdb_extension file
+#   unittest_binary: Path to the SQLLogicTest runner (build/release/test/unittest).
+#                    Optional for backwards compatibility; when omitted only the
+#                    smoke test runs and the .test suite is SKIPPED with a warning.
 #
 # Prerequisites:
 #   - SQL Server container running and healthy
+#   - The test database seeded via docker/init/init.sql (creates TestDB + master.dbo.test).
+#     Without it the .test files fail rather than skip — they expect that seed data.
 #   - Environment variables set: MSSQL_TEST_HOST, MSSQL_TEST_PORT, MSSQL_TEST_USER, MSSQL_TEST_PASS, MSSQL_TEST_DB
 #
 # Exit codes:
@@ -17,8 +22,10 @@ set -euo pipefail
 
 DUCKDB_CLI="${1:-}"
 EXTENSION_PATH="${2:-}"
+UNITTEST_BIN="${3:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_DIR="$(dirname "$SCRIPT_DIR")/sql"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 # Default test environment (can be overridden by env vars)
 export MSSQL_TEST_HOST="${MSSQL_TEST_HOST:-localhost}"
@@ -26,6 +33,17 @@ export MSSQL_TEST_PORT="${MSSQL_TEST_PORT:-1433}"
 export MSSQL_TEST_USER="${MSSQL_TEST_USER:-sa}"
 export MSSQL_TEST_PASS="${MSSQL_TEST_PASS:-TestPassword1}"
 export MSSQL_TEST_DB="${MSSQL_TEST_DB:-master}"
+
+# Connection strings the .test files gate on via `require-env`. These mirror the Makefile
+# definitions verbatim — they used to exist ONLY in the Makefile, so CI never set them and every
+# .test file silently skipped (issue #192). A `require-env` miss is a SKIP, not a failure, so
+# getting these wrong makes the suite pass by doing nothing. Keep in sync with the Makefile.
+export MSSQL_TEST_DSN="${MSSQL_TEST_DSN:-Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=${MSSQL_TEST_DB};User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS}}"
+export MSSQL_TEST_URI="${MSSQL_TEST_URI:-mssql://${MSSQL_TEST_USER}:${MSSQL_TEST_PASS}@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/${MSSQL_TEST_DB}}"
+export MSSQL_TESTDB_DSN="${MSSQL_TESTDB_DSN:-Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=TestDB;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS}}"
+export MSSQL_TESTDB_URI="${MSSQL_TESTDB_URI:-mssql://${MSSQL_TEST_USER}:${MSSQL_TEST_PASS}@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/TestDB}"
+export MSSQL_TEST_SERVER="${MSSQL_TEST_SERVER:-$MSSQL_TEST_DSN}"
+export MSSQL_TEST_CONNECTION_STRING="${MSSQL_TEST_CONNECTION_STRING:-$MSSQL_TEST_DSN}"
 
 if [[ -z "$DUCKDB_CLI" ]] || [[ -z "$EXTENSION_PATH" ]]; then
     echo "ERROR: Both arguments required" >&2
@@ -96,6 +114,58 @@ echo "Running integration tests..."
 echo ""
 
 if "$DUCKDB_CLI" --unsigned < "$TEMP_SQL"; then
+    echo ""
+    echo "=== Smoke test PASSED ==="
+else
+    echo ""
+    echo "=== Smoke test FAILED ==="
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# SQLLogicTest suite (test/sql/**/*.test)
+#
+# The smoke test above only proves the extension loads and can talk to the
+# server. The real coverage is the .test files, which need the `unittest`
+# runner — the DuckDB CLI cannot execute them.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== SQLLogicTest suite ==="
+
+if [[ -z "$UNITTEST_BIN" ]]; then
+    echo "WARNING: no unittest binary passed - SKIPPING the .test suite." >&2
+    echo "         Pass it as the 3rd argument to run test/sql/**/*.test." >&2
+    echo "=== Integration Test PASSED (smoke only) ==="
+    exit 0
+fi
+
+if [[ ! -x "$UNITTEST_BIN" ]]; then
+    echo "ERROR: unittest binary not found or not executable: $UNITTEST_BIN" >&2
+    exit 1
+fi
+
+echo "Runner: $UNITTEST_BIN"
+echo "  MSSQL_TEST_DSN:   Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=${MSSQL_TEST_DB};User Id=${MSSQL_TEST_USER};Password=***"
+echo "  MSSQL_TESTDB_DSN: Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=TestDB;User Id=${MSSQL_TEST_USER};Password=***"
+echo ""
+
+# Fail if the seed is missing rather than letting every test skip or fail one by one.
+if ! "$DUCKDB_CLI" --unsigned -c "
+LOAD '$EXTENSION_PATH';
+ATTACH '${MSSQL_TESTDB_DSN}' AS seedcheck (TYPE mssql);
+SELECT count(*) FROM seedcheck.dbo.TestSimplePK;
+" > /dev/null 2>&1; then
+    echo "ERROR: TestDB is missing or unseeded - apply docker/init/init.sql first." >&2
+    echo "       The .test files expect that seed data; without it they fail, not skip." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+
+# The runner reports `require-env` misses as skips, never failures, so a missing variable would
+# quietly reduce the suite to a no-op. The skip list is printed at the end of its output; the
+# expected skips are the optional environments (Azure, Kerberos, TLS, Windows SSPI).
+if "$UNITTEST_BIN" "test/sql/*"; then
     echo ""
     echo "=== Integration Test PASSED ==="
     exit 0

--- a/test/sql/copy/copy_connection_leak.test
+++ b/test/sql/copy/copy_connection_leak.test
@@ -36,7 +36,7 @@ SELECT total_connections, idle_connections, active_connections, connections_crea
 statement error
 COPY test_data TO 'nonexistent_catalog.dbo.test' (FORMAT 'bcp');
 ----
-not found
+does not exist
 
 # Verify pool stats unchanged
 query IIII
@@ -50,10 +50,10 @@ SELECT total_connections, idle_connections, active_connections, connections_crea
 
 # Create a target table with INT column
 statement ok
-CALL mssql_exec('db', 'IF OBJECT_ID(''dbo.int_table'', ''U'') IS NOT NULL DROP TABLE dbo.int_table');
+SELECT mssql_exec('db', 'IF OBJECT_ID(''dbo.int_table'', ''U'') IS NOT NULL DROP TABLE dbo.int_table');
 
 statement ok
-CALL mssql_exec('db', 'CREATE TABLE dbo.int_table (id INT)');
+SELECT mssql_exec('db', 'CREATE TABLE dbo.int_table (id INT)');
 
 # Get current pool stats
 query IIII
@@ -75,7 +75,7 @@ SELECT total_connections, idle_connections, active_connections, connections_crea
 
 # Cleanup
 statement ok
-CALL mssql_exec('db', 'DROP TABLE dbo.int_table');
+SELECT mssql_exec('db', 'DROP TABLE dbo.int_table');
 
 #
 # T014: Test finalize phase errors release connections

--- a/test/sql/copy/copy_existing_temp.test
+++ b/test/sql/copy/copy_existing_temp.test
@@ -33,7 +33,16 @@ SELECT COUNT(*) FROM mssql_scan('db', 'SELECT * FROM #temp_bigint');
 statement ok
 ROLLBACK;
 
-# Test 2: Copy to existing temp table with INT column (source is BIGINT)
+# Test 2: Copy to existing temp table with INT column — the target's INT metadata, not the
+# source's type, must drive the wire encoding.
+#
+# This originally copied `local_test` (BIGINT) straight into the INT column and expected it to
+# succeed. It never could: IsTypeCompatible (src/copy/target_resolver.cpp) is deliberately
+# widening-only — BIGINT is compatible with `bigint` alone — so a BIGINT source into an INT
+# target is rejected rather than silently narrowed. The check and this test arrived in the same
+# commit (3c8ac8e, spec 025) and contradicted each other from the start; nothing noticed because
+# CI never ran the .test files (issue #192). The source is cast to INTEGER so the test exercises
+# what it describes; the narrowing rejection is asserted separately below.
 statement ok
 BEGIN;
 
@@ -41,14 +50,24 @@ BEGIN;
 statement ok
 SELECT mssql_exec('db', 'CREATE TABLE #temp_int (id INT)');
 
-# Copy BIGINT to INT - should use target column metadata
 statement ok
-COPY local_test TO 'mssql://db/#temp_int' (FORMAT 'bcp', CREATE_TABLE false);
+CREATE TABLE local_test_int AS SELECT id::INTEGER AS id FROM local_test;
+
+statement ok
+COPY local_test_int TO 'mssql://db/#temp_int' (FORMAT 'bcp', CREATE_TABLE false);
 
 query I
 SELECT COUNT(*) FROM mssql_scan('db', 'SELECT * FROM #temp_int');
 ----
 10
+
+# The other half of the same rule: a BIGINT source into that INT column is a narrowing
+# conversion and must be refused, not silently truncated. This is what the original Test 2
+# expected to succeed.
+statement error
+COPY local_test TO 'mssql://db/#temp_int' (FORMAT 'bcp', CREATE_TABLE false);
+----
+type mismatch
 
 statement ok
 ROLLBACK;
@@ -87,9 +106,14 @@ BEGIN;
 statement ok
 SELECT mssql_exec('db', 'CREATE TABLE #temp_multi (id INT, name NVARCHAR(50), value FLOAT)');
 
-# Copy to existing temp table with different types - should use target column metadata
+# Copy to existing temp table with different types - the target's column metadata drives the
+# wire encoding. local_multi's id is BIGINT and the target is INT, which is a narrowing
+# conversion and refused (widening-only IsTypeCompatible — see Test 2), so cast it first.
 statement ok
-COPY local_multi TO 'mssql://db/#temp_multi' (FORMAT 'bcp', CREATE_TABLE false);
+CREATE TABLE local_multi_int AS SELECT id::INTEGER AS id, name, value FROM local_multi;
+
+statement ok
+COPY local_multi_int TO 'mssql://db/#temp_multi' (FORMAT 'bcp', CREATE_TABLE false);
 
 query I
 SELECT COUNT(*) FROM mssql_scan('db', 'SELECT * FROM #temp_multi');

--- a/test/sql/copy/copy_type_mismatch.test
+++ b/test/sql/copy/copy_type_mismatch.test
@@ -20,10 +20,10 @@ CREATE TABLE varchar_source AS SELECT 'text_value' AS id, 'name' AS name FROM ra
 
 # Create target with INT column
 statement ok
-CALL mssql_exec('db', 'IF OBJECT_ID(''dbo.int_target'', ''U'') IS NOT NULL DROP TABLE dbo.int_target');
+SELECT mssql_exec('db', 'IF OBJECT_ID(''dbo.int_target'', ''U'') IS NOT NULL DROP TABLE dbo.int_target');
 
 statement ok
-CALL mssql_exec('db', 'CREATE TABLE dbo.int_target (id INT, name NVARCHAR(100))');
+SELECT mssql_exec('db', 'CREATE TABLE dbo.int_target (id INT, name NVARCHAR(100))');
 
 # Try COPY - should fail with type mismatch error mentioning column name
 statement error
@@ -33,7 +33,7 @@ type mismatch
 
 # Cleanup
 statement ok
-CALL mssql_exec('db', 'DROP TABLE dbo.int_target');
+SELECT mssql_exec('db', 'DROP TABLE dbo.int_target');
 
 statement ok
 DROP TABLE varchar_source;
@@ -48,14 +48,28 @@ CREATE TABLE bigint_source AS SELECT i::BIGINT AS id FROM range(5) t(i);
 
 # Create target with INT column (narrowing is allowed by BCP)
 statement ok
-CALL mssql_exec('db', 'IF OBJECT_ID(''dbo.int_target'', ''U'') IS NOT NULL DROP TABLE dbo.int_target');
+SELECT mssql_exec('db', 'IF OBJECT_ID(''dbo.int_target'', ''U'') IS NOT NULL DROP TABLE dbo.int_target');
 
 statement ok
-CALL mssql_exec('db', 'CREATE TABLE dbo.int_target (id INT)');
+SELECT mssql_exec('db', 'CREATE TABLE dbo.int_target (id INT)');
 
-# COPY should succeed (BIGINT to INT is compatible)
-statement ok
+# BIGINT into an INT column is a NARROWING conversion and must be refused, not silently
+# truncated: IsTypeCompatible (src/copy/target_resolver.cpp) is deliberately widening-only, so
+# BIGINT is compatible with `bigint` alone.
+#
+# This originally read "COPY should succeed (BIGINT to INT is compatible)" and expected
+# `statement ok`. It never could — the check and this test landed in the same commit (3c8ac8e,
+# spec 025) and contradicted each other from the start; CI never ran the .test files so nothing
+# caught it (issue #192). Note DuckDB's range()/COUNT()/integer literals are all BIGINT, so
+# reaching an INT target needs an explicit cast (see below).
+statement error
 COPY bigint_source TO 'db.dbo.int_target' (FORMAT 'bcp', CREATE_TABLE false);
+----
+type mismatch
+
+# Casting the source to INTEGER is the supported route, and it must work.
+statement ok
+COPY (SELECT id::INTEGER AS id FROM bigint_source) TO 'db.dbo.int_target' (FORMAT 'bcp', CREATE_TABLE false);
 
 # Verify data
 query I
@@ -65,7 +79,7 @@ SELECT COUNT(*) FROM db.dbo.int_target;
 
 # Cleanup
 statement ok
-CALL mssql_exec('db', 'DROP TABLE dbo.int_target');
+SELECT mssql_exec('db', 'DROP TABLE dbo.int_target');
 
 statement ok
 DROP TABLE bigint_source;
@@ -74,16 +88,19 @@ DROP TABLE bigint_source;
 # T023: Test error message format contains column name and types
 #
 
-# Create source with incompatible types
+# Create source with incompatible types.
+# A literal DATE, not CURRENT_DATE: the latter lives in the icu extension, which the test runner
+# does not load, so this failed with "Scalar Function with name current_date is not in the
+# catalog". The value is irrelevant here — only the DATE-vs-VARCHAR mismatch matters.
 statement ok
-CREATE TABLE date_source AS SELECT CURRENT_DATE AS date_col FROM range(3) t(i);
+CREATE TABLE date_source AS SELECT DATE '2024-01-15' AS date_col FROM range(3) t(i);
 
 # Create target with VARCHAR column (incompatible)
 statement ok
-CALL mssql_exec('db', 'IF OBJECT_ID(''dbo.varchar_target'', ''U'') IS NOT NULL DROP TABLE dbo.varchar_target');
+SELECT mssql_exec('db', 'IF OBJECT_ID(''dbo.varchar_target'', ''U'') IS NOT NULL DROP TABLE dbo.varchar_target');
 
 statement ok
-CALL mssql_exec('db', 'CREATE TABLE dbo.varchar_target (date_col VARCHAR(10))');
+SELECT mssql_exec('db', 'CREATE TABLE dbo.varchar_target (date_col VARCHAR(10))');
 
 # Note: DATE to VARCHAR might actually work in some cases via implicit conversion
 # Let's test a more strict mismatch: BLOB to INT
@@ -91,10 +108,10 @@ statement ok
 CREATE TABLE blob_source AS SELECT '\x0102'::BLOB AS data_col FROM range(3) t(i);
 
 statement ok
-CALL mssql_exec('db', 'IF OBJECT_ID(''dbo.int_target2'', ''U'') IS NOT NULL DROP TABLE dbo.int_target2');
+SELECT mssql_exec('db', 'IF OBJECT_ID(''dbo.int_target2'', ''U'') IS NOT NULL DROP TABLE dbo.int_target2');
 
 statement ok
-CALL mssql_exec('db', 'CREATE TABLE dbo.int_target2 (data_col INT)');
+SELECT mssql_exec('db', 'CREATE TABLE dbo.int_target2 (data_col INT)');
 
 # COPY should fail with clear error message
 statement error
@@ -104,10 +121,10 @@ type mismatch
 
 # Cleanup
 statement ok
-CALL mssql_exec('db', 'DROP TABLE IF EXISTS dbo.varchar_target');
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.varchar_target');
 
 statement ok
-CALL mssql_exec('db', 'DROP TABLE IF EXISTS dbo.int_target2');
+SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.int_target2');
 
 statement ok
 DROP TABLE date_source;


### PR DESCRIPTION
Closes #192. @VGSML — this turns on a gate that has never run, so it's worth a look at what it exposed.

## The problem

**No `test/sql/**/*.test` file has ever executed in CI.** The whole SQLLogicTest suite is green-by-skip.

> **Correction to the issue as filed:** I claimed the job was `workflow_dispatch`-only. That's **wrong** — `ci.yml` already runs `build` + `integration-test` weekly on a schedule. I read the `if:` from an older commit in my worktree. The stale `(Manual trigger only via workflow_dispatch)` comment above the job — fixed here — is what misled me. Corrected on the issue.

The real cause is the **script**. `integration_test.sh` only pipes `scripts/sql/smoke_test.sql` through the DuckDB CLI:

```bash
$ git show origin/main:scripts/ci/integration_test.sh | grep -c unittest
0
```

It never invokes the `unittest` runner, and never sets the connection vars the `.test` files gate on (`MSSQL_TESTDB_DSN` et al. are **Makefile**-only). A `require-env` miss is a **skip, not a failure** — so the job passed by doing nothing.

That's how a 5-month silent-truncation bug (#190) survived with `varchar_encoding.test` covering the exact column, and how #187's regression test shipped red.

## The fix

- **Run the suite.** `integration_test.sh` takes the unittest binary as an optional 3rd arg and runs `test/sql/*`. Omitted → suite skipped **with a warning**, never silently. It exports the Makefile's connection vars and **hard-fails if the seed is missing** rather than letting 143 tests skip.
- **Download the runner.** The build job *already* produces and uploads `unittest-<platform>` — this job just never pulled it. No extra build.
- **Seed the container.** CI's service container starts bare; locally `make docker-up` applies `docker/init/init.sql`. The `.test` files need that data.
- **Seed `master.dbo.test`.** `catalog_discovery.test` attaches `MSSQL_TEST_DSN` (`Database=master`) and expects `dbo.test` there — init.sql only ever built TestDB, so it could never pass.

### Why no `sqlcmd -b` on the seed

`init.sql` **doesn't run cleanly even on a fresh server** — Msg 517, a datetime2 overflow in the `AllDataTypes` duplicate-and-shift INSERT (filed as **#199**). With `-b` sqlcmd aborts mid-script, leaving a *partially seeded* database (no `LargeTableView`, no `test.test`) that then fails ~4 unrelated tests. I hit this trap while verifying — it cost me a confusing round of "new" failures. Without `-b` it exits 0 and seeds fully; the script's explicit seed check still catches a genuinely broken seed.

## Four tests that had never run

All test-side, all fixed here:

| Test | Problem |
|---|---|
| `copy_connection_leak`, `copy_type_mismatch` | `CALL mssql_exec(...)` — it's a **scalar** function; `CALL` is table-function syntax |
| `copy_connection_leak` | expected `"not found"`; DuckDB now says `Catalog "x" does not exist!` |
| `copy_type_mismatch`, `copy_existing_temp` | copied **BIGINT into INT** expecting success (see below) |
| `copy_type_mismatch` | `CURRENT_DATE` lives in the **icu** extension, which the runner doesn't load |

### The BIGINT→INT question

Three assertions claimed BIGINT→INT should succeed ("should use target column metadata"), but `IsTypeCompatible` is deliberately **widening-only** (BIGINT → `bigint` alone). The check and the tests **landed in the same commit** (3c8ac8e, spec 025) and have contradicted each other from birth — invisible, because CI never ran them.

I kept **the code as the source of truth** (never silently narrow — a BIGINT that doesn't fit INT would lose data) and fixed the tests: cast to `INTEGER` for the success path, plus an explicit assertion that narrowing is *refused*.

Flagging the UX consequence, since it's a live design question: DuckDB's `range()`, `COUNT()`, and integer literals are all BIGINT, so `COPY` into **any** existing `INT` column requires an explicit cast. If that's too strict, the alternative is to encode per target metadata and let the server reject out-of-range values — but that's a product change and belongs in its own PR, not here.

## Verification

Ran `scripts/ci/integration_test.sh` end-to-end against a fresh SQL Server 2022 container, exactly as CI invokes it:

```
test cases: 143 | 141 passed | 2 failed | 14 skipped
```

The 14 skips are the optional environments (Azure ×3 + creds, Kerberos, TLS ×4, Windows SSPI). Of the 2 failures:
- `copy_type_mismatch` — fixed by the CURRENT_DATE change after that run (verified since: **27/27**).
- `copy_varchar_length.test:69` — the BCP connection leak, fixed by **#193**; this branch doesn't carry it.

So with #193 merged, the suite is green. **Merge #193 before or with this**, or the first scheduled run reports that one failure.

## Note on CI cost

This adds ~4 min to the weekly job (150k-row `LargeTable` seed + 143 tests). It does not touch the PR path — PRs still run lint + C++ unit tests only. Making it a PR gate is a separate decision I didn't take here; happy to if you want it.
