### PR TITLE
ci: prune the vcpkg binary cache and correct its seeding comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,23 @@ jobs:
             ../../duckdb
           cmake --build . --config Release
 
+      # actions/cache restores the previous generation's archives and vcpkg
+      # only ever adds to them, so without pruning this dir grows monotonically:
+      # ABI-named archives from superseded compilers / vcpkg baselines are never
+      # evicted, and each run's save carries the whole pile forward. Left alone
+      # it eats GitHub's 10 GB per-repo cache budget, at which point LRU starts
+      # silently dropping *other* caches (ccache, DuckDB). Runs before the
+      # post-job save; always() so a failed build still saves a pruned dir.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
+
       - name: Show ccache stats
         run: ccache -s
 
@@ -572,9 +589,18 @@ jobs:
       # the install tree -- see the linux/macos build job for why the old
       # vcpkg/installed + vcpkg/packages paths never elided a rebuild.
       # Namespace is the vcpkg triplet, deliberately NOT job- or workflow-scoped:
-      # release.yml's MSVC job uses the same triplet and shares this namespace,
-      # so a Windows build dispatched on main can seed the release build. See
-      # the linux/macos job for why the primary key carries github.run_id.
+      # release.yml's MSVC job uses the same triplet and shares this namespace.
+      #
+      # Caveat -- unlike the Linux/macOS namespaces, this one is NOT seeded
+      # automatically. Both Windows jobs are gated on
+      #   if: github.event_name == 'workflow_dispatch' && inputs.run_windows_build
+      # so the weekly cron (which does seed x64-linux / arm64-osx from main)
+      # never runs them. Only a manual main-branch dispatch with "Run Windows
+      # build jobs" ticked writes a cache on refs/heads/main; until someone
+      # does that, release.yml's MSVC job rebuilds OpenSSL from scratch on
+      # every tag. Adding `|| github.event_name == 'schedule'` here would fix
+      # that at the cost of two Windows builds per week on main.
+      # See the linux/macos job for why the primary key carries github.run_id.
       - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
@@ -603,6 +629,17 @@ jobs:
             ../../duckdb
           cmake --build . --config Release
           Pop-Location
+
+      # See the linux/macos build job for why the binary cache needs pruning.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
 
       - name: Upload Extension Artifact
         uses: actions/upload-artifact@v7
@@ -679,6 +716,8 @@ jobs:
       # Caches the binary-cache dir named by VCPKG_BINARY_SOURCES above. This
       # is the job that pays most for the old broken setup: run 29540869000
       # spent 6.9 min compiling OpenSSL for x64-mingw-static from scratch.
+      # Same seeding caveat as the MSVC job above: this namespace only gets a
+      # main-branch entry from a manual Windows dispatch, never from the cron.
       - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
@@ -703,6 +742,17 @@ jobs:
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
             ../../duckdb
           cmake --build . --config Release
+
+      # See the linux/macos build job for why the binary cache needs pruning.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
 
       - name: Upload Extension Artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -134,6 +134,20 @@ jobs:
             ../../duckdb
           cmake --build . --config Release --target mssql_loadable_extension
 
+      # See ci.yml's build job for why the binary cache needs pruning. This is
+      # the job that matters most for it: push-to-main runs here are what seed
+      # the shared x64-linux namespace, so unpruned growth here propagates to
+      # every PR and tag build that restores from it.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -120,25 +120,35 @@ jobs:
       # Caches vcpkg's binary cache (archives), not the install tree -- see
       # ci.yml for why the old vcpkg/installed + vcpkg/packages +
       # vcpkg/buildtrees paths restored cleanly and rebuilt anyway.
-      # Namespaced by triplet (x64-linux) and shared with ci.yml/codeql.yml
-      # rather than scoped to this workflow. This workflow only ever runs on
+      # Reads the triplet namespace (x64-linux) shared with ci.yml/codeql.yml
+      # rather than one scoped to this workflow. This workflow only ever runs on
       # pull_request + workflow_dispatch, so it never writes a cache on the
       # default branch -- and a cache written from refs/pull/N/merge can only
-      # be restored by re-runs of that same PR. A workflow-private namespace
-      # would therefore be cold on the first run of every PR, forever. Sharing
-      # the triplet namespace lets codeql.yml's push-to-main run seed it.
+      # be restored by re-runs of that same PR. A fully workflow-private
+      # namespace would therefore be cold on the first run of every PR, forever.
+      # Reading the triplet namespace lets codeql.yml's push-to-main run seed it.
       #
-      # Caveat: this job runs on ubuntu-latest while ci.yml/codeql.yml pin
-      # ubuntu-22.04, so a different compiler may make the seeded archives miss
-      # on ABI hash and rebuild. That is no worse than today and still correct
-      # (archives are ABI-named); aligning the runner images would make the
-      # seeding actually land, but that is a behaviour change for another PR.
+      # This job runs on ubuntu-latest while ci.yml/codeql.yml pin ubuntu-22.04,
+      # so its compiler differs and the archives it builds carry a different
+      # vcpkg ABI hash. Reading the shared namespace is still worth it (a hit
+      # elides the build; a miss just rebuilds -- archives are ABI-named, so a
+      # stale restore can never produce a wrong binary), but WRITING into it
+      # would push ubuntu-latest archives that no 22.04 job can use, and every
+      # restore on both sides would drag the other's dead weight along.
+      #
+      # So: write to a runner-image-specific namespace that ci.yml's
+      # `vcpkg-bincache-x64-linux-` prefix does NOT match, and keep the shared
+      # namespace as a read-only second restore-key. Pinning this job to
+      # ubuntu-22.04 would let the sharing pay off properly, but the ASan/UBSan
+      # swapfile handling here is tuned to the ubuntu-latest image -- that is a
+      # behaviour change for another PR.
       - name: Cache vcpkg binary packages
         uses: actions/cache@v6
         with:
           path: vcpkg_bincache
-          key: vcpkg-bincache-x64-linux-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
+          key: vcpkg-bincache-ubuntulatest-x64-linux-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}
           restore-keys: |
+            vcpkg-bincache-ubuntulatest-x64-linux-
             vcpkg-bincache-x64-linux-
 
       - name: Bootstrap vcpkg
@@ -149,6 +159,17 @@ jobs:
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
         run: make debug
+
+      # See ci.yml's build job for why the binary cache needs pruning.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
 
       - name: Show ccache stats
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,22 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # vcpkg_triplet is what the binary cache is namespaced on, so it must
-          # match ci.yml's build matrix exactly -- that job runs on the weekly
-          # main-branch cron and is what can seed this workflow. Keying on
+          # vcpkg_triplet is what the binary cache is namespaced on. Keying on
           # platform.id instead would put releases in a namespace nothing on the
-          # default branch ever writes.
+          # default branch ever writes; using the triplet lets ci.yml's weekly
+          # main-branch cron seed this workflow.
+          #
+          # The agreement with ci.yml's matrix is convention only -- nothing
+          # here passes the value to vcpkg (the POSIX build below infers its
+          # triplet from the runner), so a mismatch costs cache hits silently
+          # rather than failing. Two consequences to keep in mind when editing
+          # either matrix:
+          #   - x64-linux and arm64-osx do have ci.yml counterparts, so those
+          #     two namespaces are genuinely seeded by the cron.
+          #   - arm64-linux does NOT: ci.yml has no ubuntu-22.04-arm build job,
+          #     so nothing on main ever writes that namespace and the linux_arm64
+          #     release build is cold on every tag. Adding an arm64 job to ci.yml
+          #     (or accepting the cold build) is the choice here, not renaming.
           - id: linux_amd64
             os: linux
             arch: amd64
@@ -173,6 +184,17 @@ jobs:
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
             ../../duckdb
           cmake --build . --config Release
+
+      # See ci.yml's build job for why the binary cache needs pruning.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
 
       - name: Show ccache stats
         shell: bash
@@ -301,6 +323,17 @@ jobs:
             ../../duckdb
           cmake --build . --config Release
           Pop-Location
+
+      # See ci.yml's build job for why the binary cache needs pruning.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
 
       - name: Show ccache stats
         shell: bash
@@ -440,6 +473,17 @@ jobs:
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
             ../../duckdb
           cmake --build . --config Release
+
+      # See ci.yml's build job for why the binary cache needs pruning.
+      - name: Prune stale vcpkg binary archives
+        if: always()
+        shell: bash
+        run: |
+          [ -d vcpkg_bincache ] || exit 0
+          echo "before: $(du -sh vcpkg_bincache | cut -f1)"
+          find vcpkg_bincache -type f -mtime +14 -delete
+          find vcpkg_bincache -mindepth 1 -type d -empty -delete
+          echo "after:  $(du -sh vcpkg_bincache | cut -f1)"
 
       - name: Show ccache stats
         shell: bash


### PR DESCRIPTION
Follow-ups to #198 / 67a44c0, all four findings from roborev review #366.

## Prune the shared binary cache (the one real bug)

With `github.run_id` in the primary key, every run saves a new entry, and `restore-keys` prefix matching returns the newest. Combined with `path: vcpkg_bincache` restoring the previous generation and vcpkg only ever *adding* to it, each save was a strict superset of the last. Archives are ABI-named, so ones from superseded compilers or vcpkg baselines are never evicted — the dir grows monotonically until it eats into GitHub's 10 GB per-repo budget, at which point LRU starts silently dropping *other* caches (ccache, DuckDB).

All 8 vcpkg jobs now prune archives untouched for 14 days, before the post-job save, `if: always()` so a failed build still saves a pruned dir. The empty-dir sweep uses `-mindepth 1` so the cache path itself always survives (an absent path breaks the save).

Tested locally across four cases — stale deleted / fresh kept / all-stale (dir survives empty) / dir absent (clean no-op). This relies on tar preserving mtimes across a cache restore, which is tar's default on extract.

## Two comments I wrote in #198 that overclaimed

**Windows seeding.** Both Windows jobs are gated on `workflow_dispatch && inputs.run_windows_build`, so the weekly cron that seeds `x64-linux` / `arm64-osx` from main never runs them. Those namespaces get a main-branch entry only from a manual dispatch with the checkbox ticked — until someone does one, release.yml's Windows jobs still rebuild OpenSSL from scratch on every tag (the 6.9-min MinGW build this whole effort targeted). My comment read as if this were solved.

I corrected the comment rather than changing the gating. Adding `|| github.event_name == 'schedule'` would fix it properly, but that starts two Windows builds a week on main, and given #165's history it may just add red-run noise — **your call, and the comment now names the exact change.**

**release.yml triplets.** "Must match ci.yml's build matrix exactly" is convention only; nothing passes the value to vcpkg (the POSIX build infers its triplet from the runner), so a mismatch costs cache hits silently rather than failing. Worse, the review's suspicion about `arm64-linux` was right: **ci.yml has no `ubuntu-22.04-arm` job at all**, so nothing on main ever writes that namespace and `linux_arm64` is cold on every tag. Both facts are now in the comment.

I did *not* make the strings load-bearing via `-DVCPKG_TARGET_TRIPLET`, as the review suggested — release.yml only runs on tags, so a wrong explicit triplet would surface at release time.

## concurrency-tests namespace collision

It runs on `ubuntu-latest` while ci.yml/codeql.yml pin `ubuntu-22.04`, so it was writing ABI-incompatible archives into the shared namespace on every PR run, and both sides dragged the other's dead weight through restore/save.

Fixed as suggested, with one correction: a `-latest` suffix on the same prefix would still be matched by ci.yml's `vcpkg-bincache-x64-linux-` restore-key, so the pollution would flow right back. It now writes `vcpkg-bincache-ubuntulatest-x64-linux-` — which that prefix cannot match — and keeps `vcpkg-bincache-x64-linux-` as a read-only fallback restore-key, so main-branch seeding still reaches it.

## Verification

Repo's own yamllint ruleset: clean. No C++ touched. This PR modifies `.github/workflows/concurrency-tests.yml`, which is in that workflow's own `paths` filter — so the concurrency-tests job runs here and exercises the new cache key and prune step for real.