### PR TITLE
ci: seed the test database from inside the service container (#199)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,11 +496,20 @@ jobs:
       # applies this script; the .test files expect the schema and seed rows it creates (TestDB
       # plus master.dbo.test), and fail without them.
       - name: Seed test database
+        env:
+          SQLSERVER_ID: ${{ job.services.sqlserver.id }}
         run: |
-          curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc > /dev/null
-          curl -fsSL https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list > /dev/null
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18
+          # Seed from inside the service container rather than installing mssql-tools18 on
+          # the runner. The image already ships /opt/mssql-tools18/bin/sqlcmd — the health
+          # check above is that exact binary, so a healthy service proves it is present.
+          #
+          # The host-side install was worse than redundant: it added packages.microsoft.com
+          # to apt, but the ubuntu-22.04 image already configures that same repo pinned to
+          # /usr/share/keyrings/microsoft-prod.gpg. Two Signed-By values for one source makes
+          # apt refuse to read *any* sources, so `apt-get update` exited 100 before installing
+          # anything and the seed never ran (CI run #566). See #199.
+          docker cp docker/init/init.sql "$SQLSERVER_ID:/tmp/init.sql"
+          docker cp docker/init/init-transaction-tests.sql "$SQLSERVER_ID:/tmp/init-transaction-tests.sql"
           # No -b (exit-on-error): init.sql does not run cleanly even against a fresh server —
           # one AllDataTypes INSERT does DATEADD(day, id, col_datetime2) over a far-future seed
           # row and trips "Msg 517 ... datetime2 ... overflow", terminating that statement. This
@@ -508,8 +517,10 @@ jobs:
           # the suite passes without those rows. -b here would fail every run for a benign,
           # long-standing reason. integration_test.sh verifies the seed landed instead, so a
           # genuinely broken seed is still caught rather than silently skipped. See #199.
-          /opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P TestPassword1 -C -i docker/init/init.sql
-          /opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P TestPassword1 -C -i docker/init/init-transaction-tests.sql
+          docker exec "$SQLSERVER_ID" /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P TestPassword1 -C -i /tmp/init.sql
+          docker exec "$SQLSERVER_ID" /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P TestPassword1 -C -i /tmp/init-transaction-tests.sql
           echo "Seed applied."
 
       - name: Run integration tests


### PR DESCRIPTION
## Problem

The `Seed test database` step in `integration-test` has **never succeeded**. It was added by 8e99151 (#200) and first executed on 2026-07-20 in scheduled run [#566](https://github.com/hugr-lab/mssql-extension/actions/runs/29720692517), where it failed on its opening line:

```
E: Conflicting values set for option Signed-By regarding source
   https://packages.microsoft.com/ubuntu/22.04/prod/ jammy:
   /usr/share/keyrings/microsoft-prod.gpg !=
E: The list of sources could not be read.
##[error]Process completed with exit code 100.
```

The step installed `mssql-tools18` on the runner, which meant adding `packages.microsoft.com` to apt. But the `ubuntu-22.04` image **already** configures that same repo, pinned to `/usr/share/keyrings/microsoft-prod.gpg`. This step put its key in `trusted.gpg.d/` instead, so its source entry carried no `Signed-By`. apt refuses two `Signed-By` values for one source and aborts the entire sources read — exit 100, before `mssql-tools18` installs and long before any SQL runs.

Note the failure surfaces under the name **"Seed test database"**, which points at `docker/init/init.sql`. The seed is not involved and the SQL is fine.

## Fix

Drop the host-side install entirely. The service container already ships `/opt/mssql-tools18/bin/sqlcmd` — the job's own health check (`ci.yml`) invokes that exact binary, so a healthy service is proof it's present. So `docker cp` the two init scripts in and `docker exec` sqlcmd against them.

No apt, no second copy of the tools, and no coupling to whatever the runner image happens to pin this month.

The `-b`-less invocation and its rationale are preserved verbatim; only the transport changed.

## Why this reached main

`integration-test` is gated on `workflow_dispatch`/`schedule`, so #200's own CI run **skipped the very job it was adding**, and the push run for the merge skipped it too. A green PR was not evidence.

## Verification

- `yamllint` with the repo's exact relaxed ruleset from `lint-extra.yml`: clean.
- Not verified locally: the Docker daemon isn't running on my machine and `mcr.microsoft.com/mssql/server` publishes no arm64 image, so a faithful reproduction wasn't available.
- **Verified by dispatching CI on this branch with `run_integration_tests=true`** — linked below — rather than trusting a green PR checks list. That's the check #200 needed.

## Follow-up worth considering

Given this class of bug, consider running `integration-test` on PRs that touch `.github/workflows/**` or `docker/init/**`. Otherwise CI-infrastructure changes keep getting discovered by the nightly, days after merge.