### PR TITLE
fix(connection): wire the named-instance resolver into ATTACH (spec 045, #205)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,8 @@ duckdb --unsigned -c "INSTALL mssql FROM local_build_debug; LOAD mssql;"
 | `mssql_copy_tablock` | auto | Use TABLOCK hint for COPY/BCP (15-30% faster, blocks concurrent access). Auto-enabled for new tables when not explicitly set. |
 | `mssql_ctas_use_bcp` | true | Use BCP protocol for CTAS data transfer (2-10x faster than INSERT) |
 | `mssql_convert_varchar_max` | true | Convert VARCHAR(MAX) to NVARCHAR(MAX) in catalog queries for UTF-8 compatibility |
+| `mssql_named_instance_resolution` | true | Resolve `Server=host\instance` to the instance's dynamic TCP port via the SQL Server Browser (UDP 1434) at ATTACH time (spec 045). Set `false` in environments that strip outbound UDP 1434 — a named instance then errors instead of silently using port 1433, and you connect with an explicit `Server=host,port`. |
+| `mssql_browser_timeout_seconds` | 3 | SQL Server Browser UDP query timeout in seconds for named-instance resolution. On the ATTACH critical path, so kept short; the resolver retries once. |
 | `mssql_login7_max_packet` | 0 | **Test-only** (issue #138). Max LOGIN7 TDS packet size (bytes) for integrated auth; lowers the fragmentation boundary so the multi-packet send path can be exercised without an AD-sized Kerberos PAC. 0 = production default (4096); effective values clamped to [256, 32767]. |
 
 ## ATTACH Options & Secret Parameters (Catalog Filters)

--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -42,6 +42,19 @@ enum class AuthMethod : uint8_t {
 struct MSSQLConnectionInfo {
 	string host;
 	uint16_t port = 1433;
+
+	// Named-instance resolution (spec 045). When the Server host part carries a
+	// `\instance` suffix (ADO.NET `host\instance`, URI `host%5Cinstance`), the
+	// suffix is parsed out here and `host` keeps only the bare hostname. The
+	// port stays at its default until ResolveNamedInstance() queries the SQL
+	// Server Browser (UDP 1434) and fills in the instance's dynamic TCP port.
+	// Empty instance_name = default instance (no resolution).
+	string instance_name;
+	// True when the connection string gave an explicit `,port`. Suppresses
+	// Browser resolution — an explicit port always wins over the instance's
+	// advertised one, matching every other SQL Server client.
+	bool port_specified = false;
+
 	string database;
 	string user;
 	string password;
@@ -136,6 +149,16 @@ struct MSSQLConnectionInfo {
 	//   azure_auth - if true, user/password are optional (Azure AD authentication via azure_secret)
 	static shared_ptr<MSSQLConnectionInfo> FromConnectionString(const string &connection_string,
 																bool azure_auth = false);
+
+	// Resolve a named instance to its dynamic TCP port via the SQL Server
+	// Browser (spec 045). No-op unless instance_name is set and no explicit
+	// port was given. Reads mssql_named_instance_resolution (gate) and
+	// mssql_browser_timeout_seconds (UDP timeout) from context, sends one
+	// MC-SQLR query, and updates host/port with the advertised endpoint.
+	// Throws InvalidInputException if resolution is disabled, or IOException
+	// on an unreachable Browser / unknown instance. Called at ATTACH time,
+	// where a ClientContext (and thus the settings) is available.
+	void ResolveNamedInstance(ClientContext &context);
 
 	// Validate connection string format
 	// Returns: empty string if valid, error message if invalid

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -4,6 +4,7 @@
 #include "catalog/mssql_catalog.hpp"
 #include "catalog/mssql_catalog_filter.hpp"
 #include "catalog/mssql_transaction.hpp"
+#include "connection/instance_resolver.hpp"
 #include "connection/mssql_settings.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/exception.hpp"
@@ -18,6 +19,7 @@
 
 #include <openssl/crypto.h>
 
+#include <cctype>
 #include <cstdlib>
 
 // Debug logging (same pattern as tds_socket.cpp)
@@ -138,6 +140,33 @@ string ResolveAppName(const MSSQLConnectionInfo &info) {
 // MSSQLConnectionInfo implementation
 //===----------------------------------------------------------------------===//
 
+// Split a `host\instance` server string (spec 045). On return `host` holds the
+// bare hostname and the instance name (if any) is written to `instance_out`.
+// A default instance leaves instance_out empty. Validates the instance name
+// against SQL Server's grammar ([A-Za-z0-9_$#], <=16 chars, FR-010).
+static void SplitHostInstance(string &host, string &instance_out) {
+	auto backslash_pos = host.find('\\');
+	if (backslash_pos == string::npos) {
+		return;
+	}
+	string instance = host.substr(backslash_pos + 1);
+	host = host.substr(0, backslash_pos);
+	if (instance.empty()) {
+		throw InvalidInputException("MSSQL Error: empty instance name after backslash in Server");
+	}
+	if (instance.size() > 16) {
+		throw InvalidInputException("MSSQL Error: instance name '%s' exceeds 16 characters", instance);
+	}
+	for (char c : instance) {
+		auto uc = static_cast<unsigned char>(c);
+		if (!std::isalnum(uc) && c != '_' && c != '$' && c != '#') {
+			throw InvalidInputException(
+				"MSSQL Error: invalid character in instance name '%s' (allowed: letters, digits, _ $ #)", instance);
+		}
+	}
+	instance_out = instance;
+}
+
 shared_ptr<MSSQLConnectionInfo> MSSQLConnectionInfo::FromSecret(ClientContext &context, const string &secret_name) {
 	auto &secret_manager = SecretManager::Get(context);
 
@@ -164,6 +193,11 @@ shared_ptr<MSSQLConnectionInfo> MSSQLConnectionInfo::FromSecret(ClientContext &c
 	result->host = kv_secret.TryGetValue("host").ToString();
 	auto port_val = kv_secret.TryGetValue("port");
 	result->port = port_val.IsNull() ? 1433 : static_cast<uint16_t>(port_val.GetValue<int32_t>());
+	result->port_specified = !port_val.IsNull();
+	// Named instance via secret (spec 045): a `host\instance` value in the
+	// secret's host field is split the same way as the connection-string form,
+	// then resolved to a port at ATTACH time.
+	SplitHostInstance(result->host, result->instance_name);
 	result->database = kv_secret.TryGetValue("database").ToString();
 	result->user = kv_secret.TryGetValue("user").ToString();
 	result->password = kv_secret.TryGetValue("password").ToString();
@@ -381,12 +415,15 @@ static case_insensitive_map_t<string> ParseUri(const string &uri) {
 		host_port = rest;
 	}
 
-	// Parse host:port
+	// Parse host:port. URL-decode the host so a `%5C`-encoded instance
+	// separator (`host%5Cinstance`) becomes `host\instance` and flows through
+	// the same `\`-split as the ADO.NET form (spec 045 T021). The port digits
+	// carry no reserved characters, so they are left as-is.
 	auto colon_pos = host_port.rfind(':');
 	if (colon_pos != string::npos) {
-		result["server"] = host_port.substr(0, colon_pos) + "," + host_port.substr(colon_pos + 1);
+		result["server"] = UrlDecode(host_port.substr(0, colon_pos)) + "," + host_port.substr(colon_pos + 1);
 	} else {
-		result["server"] = host_port;
+		result["server"] = UrlDecode(host_port);
 	}
 
 	// Parse query parameters
@@ -820,10 +857,17 @@ shared_ptr<MSSQLConnectionInfo> MSSQLConnectionInfo::FromConnectionString(const 
 	if (comma_pos != string::npos) {
 		result->host = server.substr(0, comma_pos);
 		result->port = static_cast<uint16_t>(std::stoi(server.substr(comma_pos + 1)));
+		result->port_specified = true;
 	} else {
 		result->host = server;
 		result->port = 1433;  // Default MSSQL port
 	}
+
+	// Named instance (spec 045): split a `host\instance` host part. The URI
+	// parser URL-decodes `%5C` to `\` before this, so both connection-string
+	// forms land here. The bare hostname stays in host; the instance name is
+	// resolved to a port later by ResolveNamedInstance() at ATTACH time.
+	SplitHostInstance(result->host, result->instance_name);
 
 	result->database = params["database"];
 	result->user = params["user"];
@@ -909,6 +953,49 @@ shared_ptr<MSSQLConnectionInfo> MSSQLConnectionInfo::FromConnectionString(const 
 
 	result->connected = false;
 	return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Named-instance resolution (spec 045)
+//===----------------------------------------------------------------------===//
+
+void MSSQLConnectionInfo::ResolveNamedInstance(ClientContext &context) {
+	// Nothing to resolve for a default instance, and an explicit port always
+	// wins over the Browser-advertised one.
+	if (instance_name.empty() || port_specified) {
+		return;
+	}
+
+	Value val;
+	bool enabled = true;
+	if (context.TryGetCurrentSetting("mssql_named_instance_resolution", val)) {
+		enabled = val.GetValue<bool>();
+	}
+	if (!enabled) {
+		throw InvalidInputException(
+			"MSSQL Error: named-instance resolution is disabled; set mssql_named_instance_resolution=true "
+			"or connect with an explicit port (Server=host,port). Instance requested: '%s\\%s'",
+			host, instance_name);
+	}
+
+	int timeout_seconds = 3;
+	if (context.TryGetCurrentSetting("mssql_browser_timeout_seconds", val)) {
+		timeout_seconds = static_cast<int>(val.GetValue<int64_t>());
+	}
+
+	auto resolved = mssql::InstanceResolver::Resolve(host, instance_name, timeout_seconds);
+	if (!resolved.ok) {
+		// Surface the resolver's typed diagnostic verbatim (it already names the
+		// host + instance and distinguishes browser-down from instance-not-found).
+		throw IOException("MSSQL Error: %s", resolved.error.message);
+	}
+
+	// The Browser may advertise the engine on a different hostname than the one
+	// running Browser (failover cluster, two-hostname layouts); honour it.
+	if (!resolved.host.empty()) {
+		host = resolved.host;
+	}
+	port = resolved.port;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1386,6 +1473,15 @@ unique_ptr<Catalog> MSSQLAttach(optional_ptr<StorageExtensionInfo> storage_info,
 		// the 128-UTF-16-code-unit clamp + control-char strip.
 		connection_info->application_name = application_name_option;
 	}
+
+	// Spec 045: resolve a named instance (host\instance) to its dynamic TCP
+	// port via the SQL Server Browser. Runs here, at ATTACH, because the
+	// ClientContext — and thus mssql_named_instance_resolution /
+	// mssql_browser_timeout_seconds — is available. No-op for default
+	// instances and for connection strings that gave an explicit port. Must
+	// precede endpoint-type caching and the eager credential check below,
+	// both of which read the (now resolved) host/port.
+	connection_info->ResolveNamedInstance(context);
 
 	// T040 (Bug 0.7): Cache endpoint type at ATTACH time for performance
 	// Fabric endpoints don't support BCP/INSERT BULK, need fallback to INSERT

--- a/test/sql/named_instance/named_instance_parse.test
+++ b/test/sql/named_instance/named_instance_parse.test
@@ -1,0 +1,44 @@
+# name: test/sql/named_instance/named_instance_parse.test
+# description: Named-instance (host\instance) parsing and gating (spec 045). These
+#              cases fail before any network I/O, so they need no SQL Server or
+#              SQL Server Browser — only the extension loaded.
+# group: [mssql]
+
+require mssql
+
+# An empty instance after the backslash is rejected at parse time.
+statement error
+ATTACH 'Server=localhost\;Database=db;User Id=u;Password=p' AS ni_empty (TYPE mssql);
+----
+empty instance name after backslash
+
+# Instance names allow only [A-Za-z0-9_$#]; a space is invalid.
+statement error
+ATTACH 'Server=localhost\bad inst;Database=db;User Id=u;Password=p' AS ni_space (TYPE mssql);
+----
+invalid character in instance name
+
+# A hyphen is likewise outside the grammar.
+statement error
+ATTACH 'Server=localhost\bad-inst;Database=db;User Id=u;Password=p' AS ni_hyphen (TYPE mssql);
+----
+invalid character in instance name
+
+# Instance names are capped at 16 characters.
+statement error
+ATTACH 'Server=localhost\ABCDEFGHIJKLMNOPQ;Database=db;User Id=u;Password=p' AS ni_long (TYPE mssql);
+----
+exceeds 16 characters
+
+# With resolution disabled, a named instance is a hard error rather than a
+# silent fall-back to port 1433. This throws before the Browser is queried.
+statement ok
+SET mssql_named_instance_resolution=false;
+
+statement error
+ATTACH 'Server=localhost\SQLEXPRESS;Database=db;User Id=u;Password=p' AS ni_disabled (TYPE mssql);
+----
+named-instance resolution is disabled
+
+statement ok
+SET mssql_named_instance_resolution=true;

--- a/test/sql/named_instance/named_instance_resolve.test
+++ b/test/sql/named_instance/named_instance_resolve.test
@@ -1,0 +1,43 @@
+# name: test/sql/named_instance/named_instance_resolve.test
+# description: End-to-end named-instance resolution against the mock SQL Server
+#              Browser stack (spec 045, test/named-instance/). Requires that
+#              stack: browser.example.com advertising TESTINST -> sql.example.com:11433,
+#              a NamedInstTest database with dbo.Probe(id, payload). Gated on
+#              MSSQL_NAMED_INSTANCE_HOST so it is skipped in the ordinary suite.
+# group: [mssql]
+
+require mssql
+
+require-env MSSQL_NAMED_INSTANCE_HOST
+
+# Basic resolution: host\TESTINST resolves via the Browser to the instance's
+# TCP port, and the attached catalog reads the probe row.
+statement ok
+ATTACH 'Server=${MSSQL_NAMED_INSTANCE_HOST}\TESTINST;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_basic (TYPE mssql);
+
+query IT
+SELECT id, payload FROM ni_basic.dbo.Probe ORDER BY id;
+----
+1	spec045 lives
+
+statement ok
+DETACH ni_basic;
+
+# Unknown instance: the Browser answers but has no such instance.
+statement error
+ATTACH 'Server=${MSSQL_NAMED_INSTANCE_HOST}\NONESUCH;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_unknown (TYPE mssql);
+----
+not found
+
+# Explicit port skips the Browser entirely: host\TESTINST,11433 connects
+# straight to 11433 without a UDP round trip.
+statement ok
+ATTACH 'Server=${MSSQL_NAMED_INSTANCE_HOST}\TESTINST,11433;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_explicit (TYPE mssql);
+
+query IT
+SELECT id, payload FROM ni_explicit.dbo.Probe ORDER BY id;
+----
+1	spec045 lives
+
+statement ok
+DETACH ni_explicit;


### PR DESCRIPTION
Closes #205. Completes spec 045 Phase 3.

## Background

Spec 045 landed the SQL Server Browser resolver (`InstanceResolver`, MC-SQLR client), its unit tests, a mock-browser stack, a CI workflow, and two settings that both default on. None of it was ever called. `Server=host\instance` went straight to `getaddrinfo`, which cannot resolve a backslash name, so named-instance attach failed and `mssql_named_instance_resolution` did nothing. #204 is a user hitting exactly this.

## Change

Tasks T020 through T022 from `specs/045-named-instance-resolution/tasks.md`:

- Parse `host\instance` in both connection-string forms. The ADO.NET path splits the Server host part on `\`. The URI parser now URL-decodes the host token first, so `host%5Cinstance` reaches the same split. Instance names are validated against SQL Server's grammar (`[A-Za-z0-9_$#]`, up to 16 characters). A `host\instance` value in a secret's host field goes through the same helper.
- Resolve the instance to its dynamic TCP port in a new `MSSQLConnectionInfo::ResolveNamedInstance()`, called at ATTACH time. That is where a `ClientContext` exists, so the two settings are readable there. The spec pseudocode put this inside `FromConnectionString`, but that function has no context (it also runs in secret-resolution paths), so resolution lives at the ATTACH site next to the other eager network I/O and the parser stays pure. An explicit `,port` skips the Browser; disabling the setting turns a named instance into a clear error rather than a silent fall-back to 1433. When the Browser advertises the engine on a different hostname than the one running Browser, the advertised host is honoured.

## Tests

- `test/sql/named_instance/named_instance_parse.test` covers the parse and gate errors (empty instance, invalid character, over 16 characters, resolution disabled). All of these throw before any network call, so the file needs no SQL Server and runs wherever the extension loads.
- `test/sql/named_instance/named_instance_resolve.test` is the end-to-end case against the mock-browser stack in `test/named-instance/` (basic resolve, unknown instance, explicit-port bypass), gated on `MSSQL_NAMED_INSTANCE_HOST`.

## Build and test status

I did not build or run this locally: the working copy had no `duckdb` submodule checked out and a full vcpkg build was not practical in the session. Verification so far is code inspection plus clang-format-14. CI builds it, and the offline parse test is the part that actively guards the new code once a runner picks up `test/sql/*`. The end-to-end file needs both the mock stack and the `test/named-instance/` runner extended to drive DuckDB (its `run-tests.sh` is resolver-only today), and the main integration job currently selects zero `.test` files — a separate problem I can file if it is not already tracked.

## Deferred

T023 (LOGIN7 `ServerName` set to `host\instance`) is left out. Once the resolved port selects the instance, the `ServerName` field is informational, so this is cosmetic, and setting it touches the FEDAUTH routing path. Worth a follow-up, not needed for connectivity.

## Docs

Both settings added to the CLAUDE.md settings table.
