### PR TITLE
spec 054: materialization baseline + phase-0 quick wins (encode 1.6–2.8×, decode 1.5–2.6×, #177 fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,27 @@ jobs:
           LD_LIBRARY_PATH=build/release/src DYLD_LIBRARY_PATH=build/release/src ./build/test/test_datetime_codec
           echo "::endgroup::"
 
+          # spec 054: run the remaining per-family codec unit tests. Only
+          # datetime ran in CI before, so the #177 HUGEINT guard and the W1
+          # dictionary/constant fixes had no CI coverage. Same link set as
+          # `make test-codec-<fam>`, plus bcp_row_encoder.cpp — integer/decimal
+          # EncodeToBcp call BCPRowEncoder::EncodeDecimal, defined there.
+          for fam in boolean integer float decimal string binary uuid money; do
+            echo "::group::test_${fam}_codec"
+            "${CXX:-c++}" -std=c++17 -pthread -Wno-deprecated-declarations \
+              -I src/include -I duckdb/src/include -I "$PREFIX/include" \
+              "test/cpp/codec/test_${fam}_codec.cpp" \
+              src/codec/*.cpp \
+              src/tds/encoding/utf16.cpp src/tds/encoding/datetime_encoding.cpp \
+              src/tds/encoding/decimal_encoding.cpp src/tds/encoding/guid_encoding.cpp \
+              src/tds/encoding/bcp_row_encoder.cpp \
+              -L "$PREFIX/lib" -lsimdutf \
+              -L build/release/src -lduckdb \
+              -o "build/test/test_${fam}_codec"
+            LD_LIBRARY_PATH=build/release/src DYLD_LIBRARY_PATH=build/release/src "./build/test/test_${fam}_codec"
+            echo "::endgroup::"
+          done
+
       # Spec 053 (#161): the shipped Linux extension must NOT hard-link the
       # Kerberos runtime, or it fails to LOAD on images without it. GSSAPI/krb5
       # are dlopen'd lazily, so they must be absent from DT_NEEDED.

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -122,6 +122,7 @@ classDiagram
         -cleanup_thread_ : thread
         -pool_mutex_ : mutex
         -available_cv_ : condition_variable
+        -cleanup_cv_ : condition_variable
     }
     class PoolConfiguration {
         +connection_limit
@@ -134,8 +135,9 @@ classDiagram
 ```
 
 - One pool **per `MSSQLCatalog`** (no process-wide singleton — that was spec 047's headline fix). Lifetime is bounded by catalog lifetime.
-- Background `cleanup_thread_` reaps idle connections past `idle_timeout`.
+- Background `cleanup_thread_` reaps idle connections past `idle_timeout`. It parks on its **own** `cleanup_cv_` (notified only by `Shutdown()`, so DETACH doesn't wait out a blind 1-second sleep); `available_cv_` is reserved for `Acquire()` waiters — the invariant is that `Release()`'s `notify_one` always reaches a thread blocked on pool exhaustion, never the cleanup thread (spec 054 review).
 - DuckDB's quiescence contract requires every connection be released before `~MSSQLCatalog` runs; the pool's `Shutdown()` emits a warning + assertion if `active_connections_` is non-empty at teardown.
+- COPY/CTAS bulk loads that die mid-BCP-stream must not return the connection as-is (the server still awaits bulk data). Both paths share one release protocol — `mssql::ReleaseBcpConnectionOnError` (`src/connection/mssql_connection_provider.cpp`): close if mid-stream, then `SetNeedsReset` + `Release` through the catalog's `weak_ptr` pool handle (a failed `lock()` = catalog torn down → drop). Worker-thread safe (issue #178); called from `~MSSQLCopyGlobalState` (issue #191) and `CTASExecutionState::ReleaseBCPConnectionOnError`.
 
 ---
 
@@ -356,17 +358,23 @@ classDiagram
     }
     class FamilyModule {
         <<per-family>>
-        EncodeToBcp(value, buffer)
-        DecodeFromTds(buffer) Value
+        EncodeToBcp(vec, fmt, row, col, buffer)
+        DecodeFromTds(buffer, col, out_vec, row)
         FormatSqlLiteral(value)
         FormatDdlTypeName(type)
     }
+    class BCPRowEncoder {
+        +EncodeChunk(buffer, chunk, columns, mapping)
+    }
     FamilyDispatcher ..> FamilyModule : delegates
     FamilyModule --> TypeFamily
+    BCPRowEncoder ..> FamilyModule : fn-pointer per column
 ```
 
 - One module per family under `src/codec/` (`boolean_codec.cpp`, `integer_codec.cpp`, etc.). Each owns its four operations (encode for BCP, decode from TDS, SQL literal formatting, DDL type-name rendering).
-- The two dispatchers are `literal_format.cpp` and `type_family.cpp`. LogicalType-side dispatch sites in the rest of the codebase collapse to a one-liner family lookup.
+- The two dispatchers are `literal_format.cpp` and `type_family.cpp`. LogicalType-side dispatch sites in the rest of the codebase collapse to a one-liner family lookup. `type_family.hpp` also owns `TYPE_FAMILY_COUNT` and `FamilyName()` — anything sized or labelled per family (the `MSSQL_DEBUG>=2` counter output) uses these, never a hand-sized `[9]` table.
+- **BCP encode contract (spec 054 W1/W2)**: production writes go through `BCPRowEncoder::EncodeChunk`, which builds one `UnifiedVectorFormat` per column per chunk, resolves each column's family encoder ONCE to a function pointer, precomputes the NULL wire kind (fixed / variable-USHORT / PLP), and emits the `0xD1` ROW token per row. Family `EncodeToBcp` overloads take the pre-built format (`vec, fmt, row, col, buffer`); shared accessors (`FormatValue` / `FormatIsNull`) and the per-row test shim (`EncodeToBcpViaFormat`) live in `codec/vector_format.hpp`. A new family or encode caller must implement/consume the fmt overload — the per-row `(Vector&, idx_t)` wrapper is a unit-test compatibility API only.
+- **TDS decode (spec 054 R1)**: `DecodeFromTds` writes straight into the output `Vector` slot (`StringVector::EmptyString` + valid-input UTF-16→UTF-8 conversion, no intermediate `std::string`); invalid UTF-16 (unpaired surrogates — legal UCS-2) falls back to the legacy decoder on the untrimmed payload with output-side CHAR/NCHAR space trim, preserving pre-054 semantics exactly.
 - TIMESTAMP_MS/NS/S/TZ round-trip through SQL Server `DATETIME2(3/7/0/7)` with the catalog and the codec reporting the same DuckDB type — closes the VIEW catalog-vs-runtime divergence (issue #89).
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -364,11 +364,14 @@ BENCH_MAT_SOURCES := $(wildcard src/codec/*.cpp) \
     src/tds/encoding/decimal_encoding.cpp \
     src/tds/encoding/guid_encoding.cpp
 
-bench-materialize: release
+# Deliberately NOT dependent on `release`: re-running the release configure
+# here would drop tpch from a `make bench-build` tree (the two targets share
+# build/release). Requires an existing release build (either flavor).
+bench-materialize:
 	@echo "Building materialization microbenchmark (spec 054)..."
 	@mkdir -p build/test
-	@if [ -z "$(BENCH_UTF16_VCPKG_TRIPLET)" ]; then \
-		echo "ERROR: $(BENCH_UTF16_VCPKG_INSTALLED) has no triplet subdir; run 'make release' first." >&2; \
+	@if [ -z "$(BENCH_UTF16_VCPKG_TRIPLET)" ] || ! ls build/release/src/libduckdb* >/dev/null 2>&1; then \
+		echo "ERROR: no release build found; run 'make release' or 'make bench-build' first." >&2; \
 		exit 1; \
 	fi
 	$(CXX) $(BENCH_MAT_FLAGS) $(BENCH_UTF16_INCLUDES) \

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,11 @@ CODEC_TEST_ENCODING_SOURCES := \
     src/tds/encoding/utf16.cpp \
     src/tds/encoding/datetime_encoding.cpp \
     src/tds/encoding/decimal_encoding.cpp \
-    src/tds/encoding/guid_encoding.cpp
+    src/tds/encoding/guid_encoding.cpp \
+    src/tds/encoding/bcp_row_encoder.cpp
+# bcp_row_encoder.cpp is required: integer/decimal EncodeToBcp call
+# BCPRowEncoder::EncodeDecimal, which is defined there (not in a codec source).
+# Without it `make test-codec-integer` / `test-codec-decimal` fail to link.
 # CODEC_TEST_FAMILY_SOURCES is appended by Phase 2 (T011) and each family
 # migration phase as $(wildcard src/codec/*.cpp) once stub files exist.
 CODEC_TEST_FAMILY_SOURCES := $(wildcard src/codec/*.cpp)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 # Custom targets (preserved from original Makefile)
 #
 
-.PHONY: vcpkg-setup docker-up docker-down docker-status integration-test test-all test-debug test-simple-query test-multi-instance-pool-isolation test-issue-96-attach-loop test-spec047-us1 test-result-stream-registry-isolation test-spec047-us3 test-token-cache-isolation test-spec047-us-sec test-concurrent-reads help
+.PHONY: vcpkg-setup docker-up docker-down docker-status integration-test test-all test-debug test-simple-query test-multi-instance-pool-isolation test-issue-96-attach-loop test-spec047-us1 test-result-stream-registry-isolation test-spec047-us3 test-token-cache-isolation test-spec047-us-sec test-concurrent-reads bench-build help
 
 # Bootstrap vcpkg if not present.
 # Spec 052 PR #127 CI fix: check for the toolchain file specifically, not just
@@ -312,6 +312,16 @@ test-token-parser-security: debug
 	@echo ""
 	@echo "Running TDS token-parser security regression..."
 	build/test/test_token_parser_security
+
+# Spec 054 D2: benchmark build — release build with TPC-H (dbgen) enabled for
+# the e2e materialization benches (test/bench/bench_tpch_e2e.sh).
+# tpch must NOT go into extension_config.cmake (that file ships to community
+# builds); test/bench/bench_extension_config.cmake carries it and is prepended
+# here via the ci-tools EXTRA_EXTENSION_CONFIGS hook.
+# NOTE: a later plain `make`/`make release` reconfigures WITHOUT tpch (cmake
+# drops it on re-run) — re-run `make bench-build` before benchmarking.
+bench-build:
+	EXTRA_EXTENSION_CONFIGS='$(PROJ_DIR)test/bench/bench_extension_config.cmake' $(MAKE) release
 
 # Spec 044: codec microbenchmark — simdutf vs legacy hand-rolled converter.
 # Manual target; NOT part of `make test` or any CI workflow.

--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,34 @@ bench-utf16: release
 	@echo "Running UTF-16 codec microbenchmark..."
 	build/test/bench_utf16
 
+# Spec 054 D1: materialization microbenchmark (string decode / fixed decode /
+# bcp encode groups). Manual target; NOT part of `make test` or CI.
+# Links the RELEASE libduckdb (Vector/DataChunk symbols) + release simdutf,
+# compiles the codec sources at -O3 so the timed body matches shipped code.
+BENCH_MAT_FLAGS := -std=c++17 -O3 -pthread -Wno-deprecated-declarations -DMSSQL_BENCH_BUILD
+BENCH_MAT_SOURCES := $(wildcard src/codec/*.cpp) \
+    src/tds/encoding/utf16.cpp \
+    src/tds/encoding/datetime_encoding.cpp \
+    src/tds/encoding/decimal_encoding.cpp \
+    src/tds/encoding/guid_encoding.cpp
+
+bench-materialize: release
+	@echo "Building materialization microbenchmark (spec 054)..."
+	@mkdir -p build/test
+	@if [ -z "$(BENCH_UTF16_VCPKG_TRIPLET)" ]; then \
+		echo "ERROR: $(BENCH_UTF16_VCPKG_INSTALLED) has no triplet subdir; run 'make release' first." >&2; \
+		exit 1; \
+	fi
+	$(CXX) $(BENCH_MAT_FLAGS) $(BENCH_UTF16_INCLUDES) \
+	    test/cpp/bench_materialize.cpp \
+	    $(BENCH_MAT_SOURCES) \
+	    $(BENCH_UTF16_LIBS) \
+	    -L build/release/src -lduckdb \
+	    -o build/test/bench_materialize
+	@echo ""
+	@echo "Running materialization microbenchmark..."
+	DYLD_LIBRARY_PATH=build/release/src LD_LIBRARY_PATH=build/release/src build/test/bench_materialize
+
 # Spec 045: per-type-family codec unit tests
 # Pattern target: `make test-codec-<family>` builds and runs
 # test/cpp/codec/test_<family>_codec.cpp linked against src/codec/*.cpp.

--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,7 @@ bench-utf16: release
 # compiles the codec sources at -O3 so the timed body matches shipped code.
 BENCH_MAT_FLAGS := -std=c++17 -O3 -pthread -Wno-deprecated-declarations -DMSSQL_BENCH_BUILD
 BENCH_MAT_SOURCES := $(wildcard src/codec/*.cpp) \
+    src/tds/encoding/bcp_row_encoder.cpp \
     src/tds/encoding/utf16.cpp \
     src/tds/encoding/datetime_encoding.cpp \
     src/tds/encoding/decimal_encoding.cpp \

--- a/docs/proposals/simd-chunk-materialization-design.md
+++ b/docs/proposals/simd-chunk-materialization-design.md
@@ -1,0 +1,518 @@
+# Design: Batch / SIMD chunk materialization between TDS and DuckDB vectors
+
+**Status:** Design (pre-spec). Investigation complete; benchmarks pending.
+**Scope:** TDS → DuckDB DataChunk materialization (scan) and DuckDB DataChunk → BCP/TDS encoding (COPY/CTAS).
+**Goals:** throughput and maintainability. **Verified against:** DuckDB v1.5.5 submodule (`d8cdaa3`), simdutf 6.1.1, extension @ v0.2.2.
+
+This document grounds the original research draft (columnar staging + SIMD batch conversion +
+CONSTANT/DICTIONARY vector reuse) in the actual code: what exists today with file:line evidence,
+which DuckDB/simdutf APIs are confirmed available, which draft ideas survive contact with the
+code, what changes shape, and how we benchmark before committing to an implementation.
+
+---
+
+## 1. Current implementation inventory (verified)
+
+### 1.1 Read path: TDS bytes → DataChunk
+
+```text
+socket → TdsTokenParser::Feed (buffer_ append, sliding window)
+       → ParseRow / ParseNBCRow                     tds_token_parser.cpp:259/301
+       → RowReader::ReadRow / ReadNBCRow            tds_row_reader.cpp:11/51
+         → per column: ReadValue → row.values[col]  (std::vector<uint8_t> per column)
+       → MSSQLResultStream::FillChunk loop          mssql_result_stream.cpp:198-351
+         → ProcessRow → per column:
+           TypeConverter::ConvertValue              type_converter.cpp:263-341 (switch per VALUE)
+           → codec DecodeFromTds → Vector write
+```
+
+Key measured facts:
+
+| Fact | Evidence |
+|---|---|
+| Chunk loop fills up to `STANDARD_VECTOR_SIZE` (2048) rows, then `SetCardinality` | mssql_result_stream.cpp:218,341 |
+| **Raw bytes are already copied once** into `RowData::values` (`vector<vector<uint8_t>>`, one per column, capacity reused across rows, 32 B pre-reserve) | tds_token_parser.hpp:81-107 |
+| Codec dispatch is a 20-way `switch` on `type_id` executed **per value** (per cell) | type_converter.cpp:280-340 |
+| Fixed-width types already write directly into `FlatVector::GetData<T>()[row]` — no `duckdb::Value`, no generic casts | integer_codec.cpp:89-117, float_codec.cpp:107-118 |
+| Strings: `Utf16LEDecode(bytes)` → temporary `std::string` → `StringVector::AddString` → **second copy** into the vector heap; one simdutf call per value | string_codec.cpp:154-179 |
+| NULLs: ROW tokens set `null_mask` per value during read; NBCROW parses a bitmap up-front; either way materialization does per-row `FlatVector::SetNull` | tds_row_reader.cpp:63-68, type_converter.cpp:266 |
+| PLP (MAX types): chunked, accumulated into one `vector<uint8_t>` per value; may span packets | tds_row_reader.cpp:506-592 |
+| Scan output vectors are always FLAT today; `SetTargetVectors()` exists for the composite-PK rowid STRUCT case | mssql_result_stream.hpp:129-131 |
+| rowid is populated post-`FillChunk` by copying PK columns | table_scan.cpp:548-624 |
+
+Interpretation: **a columnar staging layer replaces an existing per-row copy, it does not add a
+new one.** The row→column pivot point already exists inside `RowReader`; today it pivots into a
+row-oriented structure (`RowData`), the design pivots it into per-column staging instead.
+The per-cell costs to eliminate on this path are (a) the per-value dispatch switch,
+(b) the string double-copy through `std::string`, (c) per-value `FlatVector::SetNull` calls
+where NBC bitmaps could bulk-write validity words.
+
+### 1.2 Write path: DataChunk → BCP
+
+```text
+BCPCopySink(DataChunk)                              copy_function.cpp:542-620
+  → BCPWriter::WriteRows (per-row loop, one mutex acquire per chunk)   bcp_writer.cpp:96-133
+    → BCPRowEncoder::EncodeRow (per-column loop)    bcp_row_encoder.cpp:65-140
+      → per value: ToUnifiedFormat + family switch + EncodeToBcp
+  → accumulator_buffer_ (~1 MB reserve, reused across batches)
+  → flush at mssql_copy_flush_rows → BuildBulkLoadMultiPacket (4 KB packets) → socket
+```
+
+| Fact | Evidence |
+|---|---|
+| `vec.ToUnifiedFormat(1, format)` is reconstructed **per value** (inside `GetVectorValue` / `IsVectorNull`) — per cell, per row | integer_codec.cpp:48-55, bcp_row_encoder.cpp:34-59 |
+| Family dispatch: 9-way switch per row per column | bcp_row_encoder.cpp:111-138 |
+| DICTIONARY/CONSTANT inputs are handled *transparently* (via `format.sel`) but **never exploited** — a constant string column is re-converted to UTF-16 for every row | design gap |
+| NVARCHAR encode does up to 3 passes per value: `ValidateNVarcharLength` (validate + `utf16_length_from_utf8`), then `Utf16LEEncodeDirect` (validate **again** + convert) | string_codec.cpp:106-122, 48-55; utf16.cpp:344-355 |
+| COLMETADATA precomputed once per batch; packet fragmentation post-batch; DONE per flush | bcp_writer.cpp:347-445, 461-479 |
+| Fixed types (int/decimal/datetime/GUID) append to the accumulator with no per-value allocation | bcp_row_encoder.cpp:260-286, 339-377, 442-447 |
+| INSERT literal path is per-value string formatting via `FormatSqlLiteral` — orders of magnitude more expensive than BCP by construction; out of scope for batch optimization | mssql_value_serializer.cpp:86-103 |
+
+### 1.3 UTF-16 layer (simdutf 6.1.1)
+
+Wrapper (`src/tds/encoding/utf16.cpp`) uses the two-pass scheme: `validate_*` gate →
+`convert_valid_*` fast path → hand-rolled legacy fallback on invalid input (bit-identical to
+pre-spec-043 semantics). All hot call sites are **per string value**:
+decode `string_codec.cpp:159`, encode `string_codec.cpp:51,85`, length check `string_codec.cpp:115`.
+
+Available-but-unused simdutf APIs relevant here: `convert_utf16le_to_utf8_with_errors`,
+`convert_utf8_to_utf16le_with_errors` (single-pass with error position — candidate to replace
+the double-validate on the BCP path). simdutf has **no multi-string batch API**: batching is
+achieved only by concatenation or by amortizing call overhead into fewer, longer calls.
+
+---
+
+## 2. Verified platform facts (what the design may rely on)
+
+All checked directly in the pinned v1.5.5 submodule — not from memory.
+
+1. **Table functions may legally emit DICTIONARY and CONSTANT vectors.** The Parquet reader
+   does exactly this: `result.Dictionary(dictionary, dictionary_selection_vector)` —
+   `duckdb/extension/parquet/decoder/dictionary_decoder.cpp:117`. Two constraints observed there:
+   - dictionary emission only when the chunk is filled **from offset 0** (`result_offset == 0`;
+     otherwise it flattens via `VectorOperations::Copy`). Our `FillChunk` always fills from 0. ✅
+   - NULL rows are represented by an **extra child slot appended after the dictionary values**
+     (`sel.Verify(count, dictionary_size + can_have_nulls)`) — precisely the mixed-null model
+     from the draft (§5.2). We adopt the same convention.
+2. **APIs** (duckdb/src/include/duckdb/common/types/vector.hpp):
+   - `Vector::Dictionary(Vector &dict, idx_t dictionary_size, const SelectionVector &sel, idx_t count)` (:199)
+   - `Vector::Dictionary(buffer_ptr<VectorChildBuffer> reusable_dict, const SelectionVector &sel)` (:201) +
+     `DictionaryVector::CreateReusableDictionary(type, size)` (:440) — lets us allocate the
+     ≤100-entry child **once per column per stream** and reuse it across chunks.
+   - `ConstantVector::SetNull/GetData/Validity` (:333-389).
+   - `StringVector::AddBuffer(Vector&, buffer_ptr<VectorBuffer>)` (:571) — attach a caller-owned
+     backing buffer so `string_t` may point into it; `StringVector::EmptyString(vector, len)`
+     (:565) — allocate a writable, vector-owned string slot to convert **directly into**.
+   - `SelectionVector` owns its data via `buffer_ptr<SelectionData>` (shared) — safe to build
+     once and hand to the vector (selection_vector.hpp:31-136).
+3. **`string_t` inline threshold is 12 bytes** (string_type.hpp:29). Strings ≤12 B are stored
+   inline in the `string_t` itself — a shared backing buffer only pays off for longer strings;
+   short strings must be written into the `string_t` regardless. This matters for the
+   short-string benchmark fixtures.
+4. **`UnifiedVectorFormat` erases the original `VectorType`.** A representation-aware BCP writer
+   must check `vec.GetVectorType()` **before** calling `ToUnifiedFormat` (vector.hpp:31-76).
+5. **ValidityMask is 64-bit-word addressable** (`GetData()`, `SetAllValid/SetAllInvalid`,
+   validity_mask.hpp:60-381) — NBC bitmaps can be translated bitmap→validity words rather than
+   per-row `SetNull`.
+6. **Downstream operators do not force-flatten dictionary vectors**; expression execution works
+   on unified format. (Flatten happens only where an operator's contract requires it.) So
+   emitted dictionaries survive at least through common projections/filters — enough for the
+   LIMIT/aggregate/filter workloads a remote scan feeds.
+7. **C++ standard: mixed-mode is confirmed dead; whole-tree C++17 is achievable.**
+   Empirically verified (2026-07-28, GCC 11.4 on Linux, pattern lifted from v1.5.5
+   `types.hpp:392` / `types.cpp:179`):
+   - Compiling extension TUs as C++17 against C++11-built DuckDB reproduces the historical
+     `multiple definition of 'LogicalType::BIGINT'` link error. Root cause: GCC emits C++17
+     inline variables as **GNU-unique (`u`) symbols**, which conflict with the strong
+     out-of-line definitions still present in `types.cpp:179+`. So
+     `target_compile_features(... cxx_std_17)` per-target remains forbidden — CLAUDE.md's
+     warning is current, not stale. (duckdb-spatial is *not* a precedent: its root
+     CMakeLists sets standard **11**; no `cxx_std_17` in spatial/azure/delta/iceberg.)
+   - The viable lever: DuckDB loads `DUCKDB_EXTENSION_CONFIGS` at **top level, before
+     `add_subdirectory(src)`** (duckdb/CMakeLists.txt:834 include → extension_build_tools.cmake:557
+     foreach-include vs `add_subdirectory(src)` at :854). A plain
+     `set(CMAKE_CXX_STANDARD 17)` in our `extension_config.cmake` therefore flips the
+     **entire tree** — DuckDB, third_party, and the extension — to C++17 consistently, in
+     local builds, our CI, and community-extensions builds alike (the config ships with the
+     extension; no pipeline knob needed).
+   - Gate before adoption: full-matrix build + tests (Linux GCC, macOS Clang, **MSVC and
+     MinGW** — bundled fmt is a known MSVC sore spot, cf. issue #165; watch for C++17
+     removals like `std::random_shuffle` in third_party).
+   - **Adoption stance (maintainer decision):** C++17 is *not scheduled*. It is taken up only
+     when a concrete kernel or refactor is demonstrably better in C++17 (readability or
+     performance) — not for its own sake. Until then all code stays C++11-compatible; this
+     subsection documents the verified mechanism for when that justification appears.
+   No intrinsics in v1 either way — rely on simdutf + auto-vectorizable loops
+   (GCC/Clang/MSVC all handle contiguous fixed-width loops; MinGW is the one to watch in CI).
+
+---
+
+## 3. Target architecture — read (TDS → DataChunk)
+
+### 3.1 Pipeline
+
+```text
+TDS packets → token/row framing (unchanged)
+  → per-column staging writes (pivot INSIDE RowReader, replacing RowData)
+  → at chunk boundary (2048 rows or DONE):
+      chunk analyzer per column:
+        all-equal / all-null           → CONSTANT
+        unique ≤ cap (default 100)     → DICTIONARY (reusable child + selection)
+        otherwise                      → FLAT batch materialization
+  → DataChunk handed to DuckDB
+```
+
+Latency note: the 2048-row accumulation boundary is identical to today's `FillChunk` loop —
+staging adds no extra buffering stage, it changes the layout of the existing one.
+
+### 3.2 Column staging classes
+
+Replace `RowData` with a `ColumnStagingSet` owned by `MSSQLResultStream` (arena-style, reused
+across chunks, capacity high-water-mark retained):
+
+```cpp
+// fixed-width families (integer/float/money/datetime raw/uuid/decimal buckets)
+template <class RAW>
+struct FixedStaging {                     // capacity = STANDARD_VECTOR_SIZE, alignas(64)
+    RAW values[STANDARD_VECTOR_SIZE];
+    uint64_t validity_words[STANDARD_VECTOR_SIZE / 64];
+};
+
+// var-width families (UTF-16 strings, binary)
+struct VarStaging {
+    std::vector<uint8_t> payload;         // contiguous UTF-16LE / raw bytes
+    uint32_t offsets[STANDARD_VECTOR_SIZE];
+    uint32_t lengths[STANDARD_VECTOR_SIZE];   // unit: BYTES (fixed contract)
+    uint64_t validity_words[...];
+    bool saw_embedded_nul;                // updated on append (for strategy C gating)
+    bool boundary_risky;                  // last code unit is a high surrogate anywhere
+};
+```
+
+**Direct-write bypass (important refinement of the draft §4.2):** for 1:1 families where the
+TDS payload already equals DuckDB physical layout (INT1/2/4/8, FLOAT4/8 — both little-endian),
+staging is *skipped entirely*: the row reader writes straight into
+`FlatVector::GetData<T>()` at `row_idx`. Today these values take a detour through
+`RowData::values` byte vectors; the redesign removes a copy for the cheapest types rather than
+adding staging overhead to them. These columns are simultaneously fed to a tiny
+constant-detector (compare against row 0) so the CONSTANT case is still caught with one
+branch per value, but they are **excluded from dictionary building** (draft §5.4 policy).
+
+Staged families and their batch finalizers:
+
+| Family | Staged form | Finalize (FLAT case) |
+|---|---|---|
+| DATETIME2/DATETIMEOFFSET/DATE/TIME | packed raw (days/ticks or per-scale ints) | scale/epoch arithmetic loop → `timestamp_t[]` (auto-vectorizable multiply/add) |
+| DECIMAL/NUMERIC | sign byte + fixed magnitude bucket (8/16 B) | per-precision-width specialized loop → int64/hugeint |
+| MONEY/SMALLMONEY | raw int64/int32 | scale loop |
+| UNIQUEIDENTIFIER | 16-byte records | byte-shuffle loop → DuckDB UUID layout |
+| N(VAR)CHAR/XML | `VarStaging` UTF-16LE | §3.4 |
+| (VAR)BINARY | `VarStaging` raw | memcpy into vector heap / backing buffer |
+| BIT/BITN | byte per row | widen loop |
+
+PLP/MAX values: staged into the same `VarStaging.payload` (chunk accumulation loop appends
+there instead of a per-value vector). A per-column `max_payload` policy (checked arithmetic,
+oversized-single-value support, watermark-based capacity release) replaces the current
+unbounded per-value vectors. Columns containing any PLP value in the chunk are excluded from
+dictionary consideration (draft §5.4: long payload dedup only when clearly profitable —
+deferred to the adaptive phase).
+
+### 3.3 NULL handling
+
+- NBCROW: translate the wire bitmap directly into staging `validity_words` (word-wise, inverted;
+  bitmap is column-major per row so this is a per-row scatter — but into words, not into
+  per-row `SetNull` calls), then one `FlatVector::SetValidity`/mask copy per column per chunk.
+- ROW tokens: per-value flag into validity words at append time (same cost as today's bool).
+- Fixed staging writes a neutral placeholder into invalid slots so finalize loops stay
+  branch-free (draft §6.2 confirmed viable — DuckDB does not require deterministic bytes under
+  invalid slots).
+
+### 3.4 String materialization strategies (to benchmark, not to hardcode)
+
+Baseline **A** (per-value, zero-temporary): compute `utf8_length_from_utf16le` per value,
+prefix-sum into output offsets, allocate ONE backing buffer for the whole column
+(`make_buffer<VectorStringBuffer>`-owned, attached via `StringVector::AddBuffer`), then
+`convert_valid_utf16le_to_utf8` per value directly into its slot; build `string_t` manually
+(inline for ≤12 B, pointer into backing otherwise). Eliminates both the `std::string`
+temporary and the `AddString` copy while keeping per-value simdutf calls.
+
+**B** (bulk convert of concatenated payload): one `convert_valid_utf16le_to_utf8` over the whole
+concatenated staged payload + per-value `utf8_length` prefix sum for slot boundaries.
+Correctness hazard confirmed in the draft: a value ending in an unpaired high surrogate merging
+with the next value's leading low surrogate changes semantics at the boundary. Gate: bulk path
+requires whole-payload validation **plus** `boundary_risky == false` (no value ends in
+0xD800–0xDBFF); otherwise fall back to A. The flag is computed during staging append (one
+compare of the last code unit per value).
+
+**C** (NUL-delimited single conversion + `memchr` splitting): only legal when
+`saw_embedded_nul == false` (U+0000 is a valid NVARCHAR character; detection happens at append
+via a 16-bit scan of the value). Benchmark hypothesis: wins only on long-string columns; the
+delimiter overhead dominates for short strings.
+
+Decision procedure: implement A as the default in the first phase (it already removes the two
+copies and all temporaries); implement B and C behind the benchmark harness; promote per the
+§7 acceptance criteria, keyed on average staged length (e.g. B/C for avg ≥ N bytes). Dictionary
+and constant columns bypass all three: ≤100 unique values are converted individually into the
+reusable child vector — at most 100 conversions instead of 2048 (draft §6.5 stands as-is).
+
+### 3.5 Chunk analyzer & representation choice
+
+Per column, at chunk finalize, in this order (draft §5.1 confirmed):
+
+1. all-NULL → `CONSTANT` + `ConstantVector::SetNull`.
+2. all-valid-and-equal (raw-representation compare) → `CONSTANT` (one decode).
+3. dictionary attempt — only for families whose policy allows it (strings/decimal/datetime/UUID;
+   never 1:1 ints/floats/bools): chunk-local hash over **raw staged bytes** (hash confirmed by
+   full equality; keys are offsets into staging payload, which never reallocates mid-chunk —
+   reserve enforced), cap `MAX = mssql_scan_dictionary_max` (default 100, `0` disables). On
+   overflow → FLAT, dedup state discarded.
+4. FLAT batch materialization otherwise.
+
+Dictionary emission: reusable child per column (`CreateReusableDictionary`, size cap+1 slot for
+NULL, parquet-style), unique values decoded into child, `SelectionVector` (owned, reused)
+mapping 2048 rows → child indexes, NULL rows → the trailing invalid slot, then
+`Vector::Dictionary(reusable_dict, sel)`.
+
+Interaction checks (verified):
+- `FillChunk` fills from offset 0 → dictionary emission legal (parquet precedent constraint).
+- rowid post-processing (`PopulateRowIdVector`, table_scan.cpp:548) copies PK columns via
+  vector ops that accept any representation; must be re-verified in tests when PK columns
+  become dictionaries (worst case: `Flatten()` those specific columns — cheap, they are ints
+  almost always, hence FLAT by policy anyway).
+- Debug builds run `Vector::Verify`; the parquet conventions we mirror already satisfy it.
+
+Cost policy: start with the draft §5.5 shape (thresholds + overflow fallback) but treat the
+weights as benchmark outputs, not design inputs. The §8 counters exist precisely to calibrate
+this.
+
+### 3.6 Codec architecture changes
+
+- Dispatch: resolved **once per column** after COLMETADATA into a small ops struct
+  (`append_raw` / `finalize_flat` / `build_dictionary_child` function pointers or a
+  per-family virtual resolved outside the hot loop) — removes the per-value 20-way switch
+  (type_converter.cpp:280). Batch finalizers are statically specialized loops (templates on
+  RAW/DST), which is what makes auto-vectorization possible.
+- The chunk analyzer is family-agnostic; hashing/equality/cost callbacks come from the codec
+  (draft §8.3 as written).
+- File layout: staging + analyzer live in `src/codec/staging/` (new), family batch kernels join
+  the existing `src/codec/<family>_codec.cpp` files so per-type logic stays consolidated
+  (spec 045 structure preserved — maintainability goal).
+- Error reporting contract (draft §10.2): slow-path decode errors carry column index, in-chunk
+  row index, source TDS type, target type, reason. The staging layer must keep enough info to
+  reconstruct the row index after batch failure (re-run the failing column per-value on error —
+  rare path, correctness only).
+
+---
+
+## 4. Target architecture — write (DataChunk → BCP)
+
+### 4.1 Stage 0 quick wins (no representation change, measurable immediately)
+
+1. **Hoist `ToUnifiedFormat` to once per column per chunk.** Today it runs per *cell*
+   (integer_codec.cpp:50). Mechanical change inside `BCPRowEncoder::EncodeRow` callers: build
+   `UnifiedVectorFormat formats[ncols]` before the row loop, pass down. No behavior change.
+2. **Hoist family dispatch out of the row loop**: per-column encoder function resolved once
+   per chunk (mirror of read-side §3.6).
+3. **Single-pass NVARCHAR encode**: replace validate+length / validate+convert
+   (3 scans per value today, string_codec.cpp:115+51) with one
+   `convert_utf8_to_utf16le_with_errors` into a sized scratch, or validate-once + length+convert.
+4. Reserve the accumulator per chunk from column-width estimates instead of growth-by-resize
+   inside string appends (string_codec.cpp:50 resize per value).
+
+These are low-risk, pure-win changes and double as the control group for benchmarking the
+bigger redesign.
+
+### 4.2 Representation-aware encoding
+
+Check `vec.GetVectorType()` **before** `ToUnifiedFormat` (fact §2.4):
+
+- **CONSTANT**: encode payload once (`null` → per-row null markers only); row serializer
+  memcpy's the same encoded span per row. TDS/BCP wire format still carries every row —
+  the savings are conversion + allocation, not bytes (draft §1.2/§3.2 non-goals stand).
+- **DICTIONARY**: chunk-local cache `encoded[child_index]`; encode each **used** child value
+  once (selection scan → used set), then per-row memcpy of cached spans. This is where a
+  DuckDB-side dictionary (e.g. reading from Parquet and writing to SQL Server) turns 2048
+  UTF-16 conversions into ≤ dictionary-size conversions with zero analyzer cost — the
+  representation arrives for free.
+- **FLAT fixed-width**: columnar batch encode into per-column staged spans (datetime
+  decomposition, decimal bucket write, GUID shuffle as loops), then the row-oriented serializer
+  stitches spans. BCP framing itself stays row-oriented (protocol requirement).
+- **FLAT strings**: baseline = per-value single-pass encode into the accumulator (after §4.1
+  this is already 3× fewer scans). Adaptive local dedup (≤100, stop-on-overflow) is
+  benchmark-gated and off by default (draft §7.4).
+
+NULL serialization stays in the existing per-wire-type helpers
+(`EncodeNullFixed/Variable/PLP/GUID/DateTime`, bcp_row_encoder.cpp:478-500) — unchanged
+contract, validity checked before selection deref (draft §7.6).
+
+---
+
+## 5. Memory ownership rules
+
+- Staging arenas: owned by `MSSQLResultStream` (read) / `BCPWriter` (write); fixed arrays
+  are POD members; var payload keeps high-water capacity with a watermark release policy
+  (release when capacity > K× recent peak; K and cadence TBD by bench).
+- All `string_t` handed to DuckDB point into (a) the vector's own `VectorStringBuffer`
+  (strategy A slots / `EmptyString`), (b) an `AddBuffer`-attached caller buffer, or
+  (c) inline storage. Never into staging (staging is reused next chunk).
+- Reusable dictionary children and `SelectionVector` data are `buffer_ptr`-owned and attached
+  to the outgoing vector per the parquet pattern — lifetime extends with the chunk.
+- Checked arithmetic on every capacity/offset computation (`uint32_t` offsets cap a column's
+  chunk payload at 4 GiB; enforce `max_payload` well below).
+
+---
+
+## 6. Correctness & differential testing
+
+Invariants (draft §10.1 adopted verbatim): row order, NULL vs empty distinction, embedded NUL
+preservation, no cross-value UTF merging, decimal/temporal semantics identical to current
+codecs, dictionary hash always confirmed by equality.
+
+Test strategy:
+1. **Differential harness**: run identical queries through a baseline build and the staged
+   build against the same SQL Server; compare full result sets (ORDER BY PK + hash). Datasets:
+   the §7 fixture matrix + existing `test/sql/**` suites (which already cover type edges:
+   datetimeoffset NBC, wide varchar, XML, PLP).
+2. Unit tests per batch kernel (`test/cpp/`): fixture arrays → expected vectors, including
+   invalid-UTF fallback rows, boundary-surrogate cases, embedded NUL, all-NULL, dictionary
+   overflow at exactly cap and cap+1.
+3. Existing sqllogictests must pass unchanged — representation is invisible at the SQL level.
+4. Fuzzing: the TDS-parser fuzz target (#162) keeps covering framing; add a staging-level
+   fuzz entry (random column mixes → analyzer → materialize) if the parser refactor moves
+   parsing boundaries.
+
+---
+
+## 7. Benchmark plan (before and during implementation)
+
+### 7.1 Harness
+
+- Extend the existing pattern: `make bench-utf16` (median-of-N, byte-identical assertion,
+  `-DMSSQL_BENCH_BUILD`, test/cpp/bench_utf16.cpp) with new micro benches:
+  - `bench_string_materialize`: current path vs A vs B vs C vs dictionary vs constant.
+    Fixture matrix from the draft §12.1: lengths {0,4,8,16,32,64,256,4096} code units ×
+    scripts {ASCII, Cyrillic, CJK, surrogate pairs} × NULL {0,10,50,100}% ×
+    cardinality {1,2,10,100,101,512,2048} × embedded-NUL × malformed-boundary.
+    The 12-byte `string_t` inline threshold makes {4,8,16} the critical short-string cells.
+  - `bench_fixed_materialize`: per family — row-by-row (current) vs staged scalar loop vs
+    staged vectorized loop (compiler reports: `-Rpass=loop-vectorize` / `-fopt-info-vec`
+    asserted in CI for the kernels) vs direct-write bypass; dictionary at {1,10,100} uniques.
+  - `bench_bcp_encode`: FLAT unique / FLAT repetitive / DICTIONARY {1,10,100} / CONSTANT ×
+    null ratios; measures conversion throughput separately from packet serialization.
+- Metrics per bench: ns/value, bytes copied/output byte, allocations/chunk (hook the arena).
+
+### 7.2 End-to-end
+
+- `test/bench/bench_codec_e2e.sh` stays the template (TSV protocol, host metadata,
+  bench_results.md recording). Extended with representation-sensitive steps: low-cardinality
+  scan (dictionary win case), constant-column scan, LIMIT-heavy scan, and the reverse COPY
+  cases.
+- **TPC-H**: add `duckdb_extension_load(tpch)` to `extension_config.cmake` (bench/local builds;
+  it is not shipped — the loadable mssql extension is unaffected). Then:
+  `CALL dbgen(sf=…)` → COPY lineitem/orders/customer/part → SQL Server → scan back.
+  - small: SF 0.01 and SF 0.1 (latency-dominated; catches per-chunk overhead regressions),
+  - large: SF 1 and SF 10 (throughput; lineitem = numeric/date-heavy, part/customer =
+    string-heavy, l_shipmode/l_returnflag = natural low-cardinality dictionary columns).
+  - measure both directions + `select_full`-style drain; record small AND large per the
+    requirement that neither regresses.
+- Environment reality check (from spec 044 experience, bench_results.md): at 100M rows the
+  codec is invisible behind SQL Server I/O in Docker — e2e validates *no regression* and
+  measures the drain step; **microbenches are the optimization signal**. Set expectations
+  accordingly.
+
+### 7.3 Acceptance criteria (draft §12.4 adopted)
+
+An optimization ships enabled-by-default only if it: (1) shows a reproducible micro win and
+non-regressing e2e on the target workloads; (2) does not degrade the common case beyond an
+agreed threshold (proposal: 3% on the FLAT/unique path); (3) has a bounded-memory fallback;
+(4) passes differential tests.
+
+### 7.4 Observability
+
+Per-stream counters (dumped at `MSSQL_DEBUG>=2` on stream close; zero-cost when disabled —
+plain increments behind the existing debug-level check): draft §13 list verbatim
+(`chunks_flat/dictionary/constant`, `dictionary_overflow`, `string_bulk_runs`,
+`string_row_fallbacks`, `embedded_nul_fallbacks`, `invalid_utf_fallbacks`, raw/materialized
+bytes, conversion ns). These are the calibration inputs for the §3.5 cost policy.
+
+---
+
+## 8. Settings
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `mssql_scan_dictionary_max` | 100 | per-chunk unique cap; 0 disables dictionary/constant analysis (FLAT-only escape hatch) |
+| `mssql_scan_batch_strings` | auto | `auto`/`per_value`/`bulk` — pins the §3.4 strategy for debugging/benchmarks |
+
+(Existing settings table style; both read at stream init, atomics not needed.)
+
+---
+
+## 9. Related open issues to fix alongside
+
+| Issue | Relation | Where it lands |
+|---|---|---|
+| [#177](https://github.com/hugr-lab/mssql-extension/issues/177) — `COPY TO (bcp)` throws NotImplemented on HUGEINT (e.g. `SUM()` output) | Left-behind TODO from spec 045 in `integer_codec.cpp` `EncodeToBcp` (~L151/189); DDL already maps HUGEINT→`DECIMAL(38,0)` and the literal path already serializes it — only the BCP arm throws | **Phase M/0** (small standalone fix): forward HUGEINT/UHUGEINT to `BCPRowEncoder::EncodeDecimal(v, 38, 0)` mirroring the UBIGINT arm, **plus a client-side range guard**: int128 extremes (2^127≈1.7e38, 39 digits) exceed `DECIMAL(38,0)` — out-of-range must raise a clean conversion error, not a server-side surprise. Regression test in `test/cpp/codec/test_integer_codec.cpp`; also unblocks the TPC-H benchmark itself (aggregate-then-COPY is exactly the failing pattern) |
+| [#197](https://github.com/hugr-lab/mssql-extension/issues/197) — NTEXT/IMAGE unreadable (no decoder for wire types 0x63/0x22) | Decode-path gap in the same row-reader/codec layer the staging refactor rewrites | **Phase 1** ride-along: add legacy LONGLEN readers while the value-read dispatch is being restructured (cheaper to do during the pivot than before/after) |
+| [#153](https://github.com/hugr-lab/mssql-extension/issues/153) — should BCP COPY allow compatible numeric coercion (BIGINT→INT) into existing tables? | Write-path type-mapping policy, adjacent to the representation-aware encoder | Open question for **Phase 3**: batch encoders make per-column coercion kernels cheap; policy decision (error vs range-checked coercion) stays a spec-level question |
+
+Not related (tracked separately): #199 (test infra), #204/#122 (connectivity), #140 (DML), #85/#86 (catalog), #189, #129, #165 (MSVC fmt — relevant only as a C++17-gate canary, §2.7), #119.
+
+## 10. Phasing → specs
+
+**Measurement comes first.** No conversion code changes until the baseline is captured; every
+phase re-runs the same suite; the final deliverable is a before/after report.
+
+| Phase | Content | Risk | Candidate spec |
+|---|---|---|---|
+| **M (baseline)** | Bench harness + fixtures (§7.1) + TPC-H enablement (§7.2) + counters (§7.4) + differential harness (§6); **capture the full baseline on current main** into `test/bench/bench_results_simd_baseline.md` (micro: ns/value per family/strategy; e2e: TPC-H SF 0.01 / 0.1 / 1 / 10 both directions + drain; environment metadata per the spec-044 protocol). Includes the #177 HUGEINT fix (needed for aggregate-then-COPY benches). C++17 is **not** part of this phase (§2.7 adoption stance) | low | 054 |
+| **0** | Write-side quick wins (§4.1: hoist UnifiedFormat + dispatch, single-pass NVARCHAR encode); read-side string copy elimination (A-lite: `EmptyString`/direct convert, kill the `std::string` temp). Re-run suite → first delta vs baseline | low | 054 |
+| **1** | Read staging: `ColumnStagingSet`, RowReader pivot, direct-write bypass for 1:1 types, batch finalizers for datetime/decimal/GUID, NBC bulk validity, PLP payload policy; FLAT-only output. + #197 NTEXT/IMAGE decoders | medium | 055 |
+| **2** | Chunk analyzer: CONSTANT + DICTIONARY emission, reusable children, cost policy v1, settings | medium | 056 |
+| **3** | Write-side representation awareness: CONSTANT/DICTIONARY encode-once, FLAT columnar batch encode; #153 policy decision | medium | 057 |
+| **4** | Bulk string strategies B/C promotion, adaptive dedup on write, cost calibration from counters, optional reader/materializer pipelining | opt-in by data | 058 |
+| **R (report)** | Final before/after report: baseline vs post-implementation across the whole matrix (small AND large volumes), per-phase attribution of the wins, counter dumps for representative workloads, regressions (if any) with disposition. Lives next to the bench results; summarized in the release notes | — | closes the series |
+
+Each phase is independently shippable and benchmark-gated; the baseline phase alone produces
+the measurement infrastructure everything else is judged against.
+
+---
+
+## 11. Risks & open questions
+
+1. **Dictionary payoff depends on downstream consumers.** Verified they don't force-flatten,
+   but the actual win vs `selection_bytes` overhead is workload-dependent → cost policy is
+   deliberately conservative + counter-calibrated. Worst case: `mssql_scan_dictionary_max=0`.
+2. **VARCHAR under non-UTF-8 collations** is handled by scan-SQL rewrite (spec 026
+   `BuildColumnExpression` / `mssql_convert_varchar_max`), so the decode hot path is
+   overwhelmingly NVARCHAR/UTF-16 — the design targets the right bottleneck. Single-byte
+   VARCHAR pass-through stays byte-for-byte unchanged.
+3. **MSVC/MinGW auto-vectorization variance**: kernels must stay trivially vectorizable
+   (contiguous, branch-free, no aliasing — `__restrict` where portable); vectorization-report
+   assertions run on GCC/Clang only, MinGW gets perf smoke only (Rtools 4.2 constraint).
+4. **rowid STRUCT target-vector path** (`SetTargetVectors`) must keep working with staging;
+   composite-PK scan writes into STRUCT children — those columns get the FLAT path forcibly.
+5. **FSST_VECTOR** exists in v1.5.5 but is out of scope (we never emit it; write-side treats
+   it via Flatten fallback if ever encountered).
+6. **Multi-statement `mssql_scan`** shares `FillChunk`; staging must reset cleanly across
+   result sets within one stream (same reuse rules as chunks).
+7. Parallelism (draft §11): explicitly deferred; the staged design is pipelining-ready
+   (raw chunk = natural work unit), decision only after §7.4 counters show where time goes.
+
+---
+
+## Appendix A — draft deltas
+
+Differences from the original research draft, post-verification:
+
+- **Direct-write bypass for 1:1 fixed types replaces their staging** (draft §4.2 allowed this;
+  code inspection shows it removes an existing copy — promoted from option to default).
+- **Strategy B refined**: per-string convert into prefix-summed slots is the safe default
+  formulation; the single-call concatenated variant needs the `boundary_risky` gate
+  (unpaired-high-surrogate at value end), computed during staging.
+- **Mixed-null dictionary model confirmed** against parquet: trailing NULL child slot, not a
+  `[NULL, value]` child pair (draft §5.2 sketch adjusted to match engine convention).
+- **`ToUnifiedFormat` per-cell on the write path** was worse than the draft assumed (per value,
+  not per row) — hence Stage 0 exists.
+- **TPC-H requires a one-line build config change** (not shipped in the default build).
+- Dictionary cap is a setting (`mssql_scan_dictionary_max`), not a compile constant, from day 1.

--- a/specs/054-simd-baseline-and-quick-wins/spec.md
+++ b/specs/054-simd-baseline-and-quick-wins/spec.md
@@ -87,6 +87,17 @@ Steps per SF:
 | `scan_lowcard` | TDS→DuckDB | `l_shipmode`/`l_returnflag` projection (dictionary win case, phases 2+) |
 | `scan_limit` | TDS→DuckDB | `LIMIT 10` cold bind (per-chunk overhead / abandonment) |
 | `q1_local` | mixed | TPC-H Q1 over the attached table (scan + aggregate) |
+| `q6_local` | mixed | TPC-H Q6 over the attached table (selective filter → pushdown) |
+
+**Pre-merge release comparison (maintainer requirement, 2026-07-28):** before the
+phase-0 changes merge, deploy TPC-H on SQL Server at a scale where `lineitem`
+holds ≥ 10M rows (SF 2 ≈ 12M) and run the query steps of this script from
+DuckDB twice on the same server: once with the **current release**
+(stock DuckDB CLI + `INSTALL mssql FROM community`, v0.2.2) and once with the
+**new build** — medians of ≥ 3 runs, recorded side-by-side in the D6 file.
+The script supports this via `MSSQL_BENCH_LOAD_SQL` / `MSSQL_BENCH_UNSIGNED`
+(load the released or a local unsigned extension into a stock CLI; dbgen
+autoloads core tpch there).
 
 ### D4. Counters (debug-only, zero-risk instrumentation of the current paths)
 
@@ -189,6 +200,9 @@ After D8: re-run D1 + D3, append the delta column to the baseline file.
 4. No changes to shipped defaults, settings, or wire behavior; counters invisible unless
    `MSSQL_DEBUG>=2`.
 5. Design doc updated if any finding here contradicts it (append to §Appendix A).
+6. Pre-merge: the D3 release comparison (current release vs new build, TPC-H on
+   SQL Server with `lineitem` ≥ 10M rows, query steps from DuckDB, median of ≥ 3)
+   is recorded in the D6 file and shows no step regressing > 3%.
 
 ## 5. Task order
 

--- a/specs/054-simd-baseline-and-quick-wins/spec.md
+++ b/specs/054-simd-baseline-and-quick-wins/spec.md
@@ -133,6 +133,22 @@ Tests: `test/cpp/codec/test_integer_codec.cpp` — round-trip encode for 0, ±1,
 10^38−1, −(10^38−1); error for 10^38 and above; UHUGEINT edges. SQL-level regression in
 `test/sql/copy/` (SUM over BIGINT → COPY bcp; also CTAS default path). Closes #177.
 
+**As-landed divergence (commit `e12f418`):** the integer-codec arms alone were not enough.
+(a) `COPY … CREATE_TABLE true` reads the created table's metadata back, so a HUGEINT source
+column arrives as `DECIMAL(38,0)` and dispatches through the **Decimal** family — the same
+mantissa-fits-precision guard was added to `codec::decimal::EncodeToBcp` (both overloads),
+which also protects any decimal-target BCP from mid-batch server rejections.
+(b) `TargetResolver::GenerateColumnMetadata` emitted precision/scale **0/0** for HUGEINT in
+COLMETADATA; now 38/0 with max_length 17.
+(c) The CTAS BCP sink leaked its connection mid-bulk-load on a row-encode error, hanging the
+next DDL on the pool ("Query timeout") — fixed with the issue-#191 COPY pattern
+(`AddChunkBCP` catch + `FlushBCP` close-before-release + `~CTASExecutionState` last resort
+via a `weak_ptr` pool handle).
+(d) `SUM(UBIGINT)` returns HUGEINT (not UHUGEINT) in DuckDB v1.5.5, so UHUGEINT stays
+unwired in `FamilyFromLogicalType`; its codec arms are defensive and unit-tested only.
+(e) The guard forwards `col.precision/col.scale` (as the UBIGINT arm does) rather than
+literal 38/0, keeping the wire byte size in lockstep with COLMETADATA.
+
 ### D8. Phase-0 quick wins (after D6 is committed)
 
 Write path:

--- a/specs/054-simd-baseline-and-quick-wins/spec.md
+++ b/specs/054-simd-baseline-and-quick-wins/spec.md
@@ -1,0 +1,207 @@
+# Spec 054 — Materialization baseline & quick wins (phases M + 0)
+
+**Status:** Draft
+**Date:** 2026-07-28
+**Design:** `docs/proposals/simd-chunk-materialization-design.md` (§7 benchmark plan, §9 related
+issues, §10 phasing). This spec covers phases **M (baseline)** and **0 (quick wins)**.
+**Process note:** this spec is documentation, not a spec-kit pipeline. Implementation proceeds
+natively; this file (plus the design doc) is the single source of truth for scope and
+acceptance. Update it in the same PR when reality diverges.
+
+---
+
+## 1. Goal
+
+Build the measurement infrastructure for the batch/SIMD materialization series, capture a
+reproducible performance baseline of the **current** implementation before any conversion code
+changes, fix issue #177 (which blocks the aggregate-then-COPY benchmarks), then land the
+low-risk quick wins and record the first before/after delta.
+
+**Hard ordering rule:** the baseline (D6) must be captured and committed before any change to
+conversion code (D8) lands. The #177 fix (D7) is the one exception — it converts a hard error
+into a working path, so no baseline exists for it to invalidate; it must land *before* the
+TPC-H e2e capture because the benchmark itself hits that error.
+
+## 2. Non-goals
+
+- No representation changes (staging, CONSTANT/DICTIONARY emission, batch kernels) — phases 1+.
+- No C++17 migration. Per maintainer decision: C++17 is adopted only if a concrete change is
+  justified by readability or performance, not for its own sake. The verified mechanism and
+  constraints live in design doc §2.7 for when that day comes. All code in this spec stays
+  C++11-compatible.
+- No new user-facing settings (counters are debug-only output).
+- e2e numbers are *no-regression evidence*, not the optimization signal (spec-044 lesson:
+  SQL-Server-in-Docker I/O dominates at scale; microbenchmarks carry the signal).
+
+## 3. Deliverables
+
+### D1. Micro-benchmark harness (`test/cpp/bench_materialize.cpp`, `make bench-materialize`)
+
+Follows the `bench_utf16.cpp` pattern: `-DMSSQL_BENCH_BUILD -O3`, median-of-N timing
+(`std::chrono::steady_clock`), correctness assertion per fixture (output must be byte/value
+identical to the reference path), manual-run only (not part of `make test` / CI).
+
+Benchmark groups:
+
+1. **String decode** (`utf16 payload → string vector`): current path
+   (`Utf16LEDecode`→`std::string`→`AddString`) vs strategy A-lite (`EmptyString` direct
+   convert) vs strategy A (shared backing buffer + prefix sum) — B/C variants are added in
+   later phases but the fixture matrix must already cover their gating cases.
+   Fixture matrix (design §7.1): lengths {0,4,8,16,32,64,256,4096} code units ×
+   scripts {ASCII, Cyrillic, CJK, surrogate pairs} × NULL {0,10,50,100}% ×
+   cardinality {1,2,10,100,101,512,2048} × {embedded U+0000} × {value ending in a lone high
+   surrogate}. The 12-byte `string_t` inline threshold makes {4,8,16} mandatory cells.
+2. **Fixed decode** per family (int widths, float, DATETIME2 components, DECIMAL buckets,
+   GUID shuffle): current per-value path vs staged scalar loop (reference implementation for
+   phase 1 kernels — measured here to size the expected win, thrown away if phase 1 reshapes it).
+3. **BCP encode**: current per-cell path vs hoisted-format path (D8/W1-W2) on
+   FLAT-unique / FLAT-repetitive / DICTIONARY {1,10,100} / CONSTANT inputs × NULL ratios.
+   Dictionary/constant inputs are built with `Vector::Dictionary` / constant vectors directly
+   in the bench — this also pins down the representation-detection API use for phase 3.
+
+Metrics per cell: ns/value (median, plus p10/p90 spread), bytes copied per output byte,
+allocations per chunk (arena hook or malloc-count interposition where portable).
+
+### D2. TPC-H enablement for bench builds only
+
+`duckdb_extension_load(tpch)` must NOT go into `extension_config.cmake` (it ships to
+community builds). Instead: `test/bench/bench_extension_config.cmake` containing the tpch
+load, appended to `DUCKDB_EXTENSION_CONFIGS` by a dedicated make target
+(e.g. `make bench-build` → configures with
+`DUCKDB_EXTENSION_CONFIGS='<repo>/extension_config.cmake;<repo>/test/bench/bench_extension_config.cmake'`).
+Verify `CALL dbgen(sf=0.01)` works in the resulting CLI.
+
+### D3. End-to-end TPC-H benchmark (`test/bench/bench_tpch_e2e.sh`)
+
+Same TSV protocol + host-metadata footer as `bench_codec_e2e.sh` (spec 044). Parameters:
+`SF ∈ {0.01, 0.1, 1, 10}` (small AND large — both are required outputs), DSN via env.
+Steps per SF:
+
+| step | direction | what it exercises |
+| --- | --- | --- |
+| `dbgen` | — | data generation (excluded from comparison) |
+| `copy_lineitem` / `copy_orders` / `copy_part` / `copy_customer` | DuckDB→BCP | numeric/date-heavy, string-heavy, low-cardinality columns (`l_shipmode`, `l_returnflag`) |
+| `copy_sum_agg` | DuckDB→BCP | aggregate-then-COPY (HUGEINT → DECIMAL(38,0), regression for #177) |
+| `scan_full_lineitem` | TDS→DuckDB | drain scan via `COPY (SELECT * FROM mss...) TO '/dev/null'` |
+| `scan_strings` | TDS→DuckDB | part/customer string columns |
+| `scan_lowcard` | TDS→DuckDB | `l_shipmode`/`l_returnflag` projection (dictionary win case, phases 2+) |
+| `scan_limit` | TDS→DuckDB | `LIMIT 10` cold bind (per-chunk overhead / abandonment) |
+| `q1_local` | mixed | TPC-H Q1 over the attached table (scan + aggregate) |
+
+### D4. Counters (debug-only, zero-risk instrumentation of the current paths)
+
+Per-stream / per-writer counters printed at `MSSQL_DEBUG>=2` on close: rows, chunks, values
+converted per family, string bytes in/out, PLP values, fallback counts (invalid UTF), and
+wall time inside `FillChunk` / `WriteRows` (steady_clock, accumulated). Plain integer
+increments guarded by the existing debug-level check; no atomics (streams are
+single-threaded), no output when disabled. The full counter list from design §7.4 lands with
+the code it instruments in later phases; this spec only wires what current code can count.
+
+### D5. Differential harness (`test/bench/diff_check.sh`)
+
+Runs an identical query list through two extension builds (env: two `duckdb` binaries or two
+`--unsigned` load paths) against the same SQL Server; compares full ordered result sets
+(ORDER BY PK, `COPY TO` csv + `cmp`, or checksum aggregate). Query list covers: every type
+family (reuse `docker/init/init.sql` AllDataTypes), NULL-heavy, empty-string vs NULL, embedded
+NUL, PLP/MAX values, 0-row and 1-row results, >2048-row results. Used from phase 0 onward as
+a merge gate for every conversion-touching PR in the series.
+
+### D6. Baseline capture → `test/bench/bench_results_simd_baseline.md`
+
+- Micro: full D1 matrix on the reference machine (macOS ARM64 dev box) + one Linux x86_64 run
+  (CI runner or the lab container) — record both; medians with run count and spread.
+- e2e: D3 at SF 0.01/0.1/1 locally (SF 10 optional if the Docker volume allows; record what
+  ran). Environment metadata per the spec-044 footer (host, CPU, RAM, Docker, server image).
+- Committed to the repo before any D8 change merges. This file is append-only for the series:
+  each later phase adds its column next to baseline.
+
+### D7. Issue #177 fix — HUGEINT/UHUGEINT BCP encode
+
+In `src/codec/integer_codec.cpp` `EncodeToBcp` (both `Vector` and `Value` overloads): replace
+the `NotImplementedException` arms with forwarding to
+`BCPRowEncoder::EncodeDecimal(value, /*precision*/38, /*scale*/0)`, mirroring the adjacent
+UBIGINT arm and matching the existing DDL (`FormatDdlTypeName` → `DECIMAL(38,0)`) and literal
+(`SerializeDecimal(…, 38, 0)`) paths.
+
+**Range guard:** `DECIMAL(38,0)` holds |v| ≤ 10^38−1; int128 reaches ≈1.70·10^38 and uint128
+≈3.40·10^38. Values with 39 digits must raise a clean client-side conversion error naming the
+column and value (InvalidInputException style), not a server-side error mid-BCP-batch.
+Constant for the bound: `10^38 − 1` as hugeint (compare via `Hugeint::GreaterThan` on the
+absolute value; UHUGEINT compared against the same bound).
+
+Tests: `test/cpp/codec/test_integer_codec.cpp` — round-trip encode for 0, ±1, int64 edges,
+10^38−1, −(10^38−1); error for 10^38 and above; UHUGEINT edges. SQL-level regression in
+`test/sql/copy/` (SUM over BIGINT → COPY bcp; also CTAS default path). Closes #177.
+
+### D8. Phase-0 quick wins (after D6 is committed)
+
+Write path:
+
+- **W1** — hoist `ToUnifiedFormat` from per-cell to once per column per chunk: build
+  `UnifiedVectorFormat` array in `BCPRowEncoder::EncodeRow`'s caller (`BCPWriter::WriteRows`)
+  and thread it through; delete the per-call `GetVectorValue`/`IsVectorNull` reconstruction
+  (`integer_codec.cpp:48-55` pattern, all 9 families + `bcp_row_encoder.cpp:34-59`).
+- **W2** — resolve the family encoder once per column per chunk (function-pointer or
+  pre-switched loop) instead of the 9-way switch per row (`bcp_row_encoder.cpp:111-138`).
+- **W3** — single-pass NVARCHAR encode: today `ValidateNVarcharLength` (validate + utf16
+  length) precedes `Utf16LEEncodeDirect` (validate again + convert) — collapse to one
+  validate + one length + one convert per value, or `convert_utf8_to_utf16le_with_errors`
+  where the sized output is already reserved. Length-overflow error text must not change
+  (FR-023 wording is tested).
+- **W4** — reserve the accumulator per chunk from column estimates; kill the per-string-value
+  `resize` in `AppendNVarcharNonPlp` (`string_codec.cpp:50`).
+
+Read path:
+
+- **R1** — string decode without temporaries: replace
+  `Utf16LEDecode → std::string → StringVector::AddString` with `utf8_length_from_utf16le` →
+  `StringVector::EmptyString(vector, len)` → `convert_valid_utf16le_to_utf8` directly into the
+  slot (invalid input falls back to the legacy per-value path unchanged). Applies to
+  `string_codec.cpp:154-179`; binary codec (`AddStringOrBlob`) is already single-copy — leave.
+
+After D8: re-run D1 + D3, append the delta column to the baseline file.
+
+## 4. Acceptance criteria
+
+1. `make bench-materialize` and `bench_tpch_e2e.sh` run reproducibly (documented invocation,
+   median-of-N, spread reported); D6 baseline file merged **before** the first D8 commit.
+2. #177: repro from the issue passes; range-guard errors are clean; codec unit tests + SQL
+   regression green; issue closed.
+3. Quick wins: differential harness (D5) reports zero result differences on the full query
+   list; all existing `make test` / integration suites green; micro delta appended showing
+   the win; **no e2e step regresses >3%** (median over ≥3 runs).
+4. No changes to shipped defaults, settings, or wire behavior; counters invisible unless
+   `MSSQL_DEBUG>=2`.
+5. Design doc updated if any finding here contradicts it (append to §Appendix A).
+
+## 5. Task order
+
+```text
+T1  D1 harness skeleton + string-decode group (current path only)     [no product code]
+T2  D2 bench build config + tpch smoke                                 [no product code]
+T3  D3 e2e script (runs with #177 workaround ::DECIMAL(38,0) cast)     [no product code]
+T4  D7 #177 fix + tests                                                [small product change]
+T5  D4 counters on current paths                                       [debug-only]
+T6  D1 remaining groups (fixed decode, bcp encode)                     [no product code]
+T7  D6 baseline capture (micro macOS+Linux; e2e SF 0.01/0.1/1[/10])    → commit baseline
+T8  D5 differential harness                                            [no product code]
+T9  D8 W1+W2 (hoisting)          → diff-check + re-run affected benches
+T10 D8 W3+W4 (NVARCHAR single-pass + reserve)                → same
+T11 D8 R1 (decode zero-temp)                                  → same
+T12 Append phase-0 delta to baseline file; update design doc if needed
+```
+
+T1–T3, T5, T6, T8 are pure additive (benches/scripts) and can proceed in parallel; T4 lands
+independently; T9–T11 are sequential and each gated by the diff harness.
+
+## 6. Risks
+
+- **Bench noise** (Docker SQL Server, laptop thermals): mitigate with medians over ≥3 runs,
+  reported spread, and pinning the comparison to the same machine per file section.
+- **W1/W2 touch every family codec** — mechanical but wide; the diff harness plus existing
+  codec unit tests are the guard. Do W1 as one mechanical PR, not interleaved with W3/R1.
+- **R1 changes string memory ownership** (vector-owned slot instead of copied std::string):
+  the invalid-UTF fallback must still produce identical bytes — covered by the D1 correctness
+  assertion and D5.
+- SF 10 dataset (~10 GB in SQL Server) may not fit the dev Docker volume — the spec accepts
+  SF 1 as the largest mandatory point, SF 10 recorded when available.

--- a/src/codec/binary_codec.cpp
+++ b/src/codec/binary_codec.cpp
@@ -29,6 +29,7 @@
 
 #include "codec/binary_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "duckdb/common/exception.hpp"
 #include "mssql_compat.hpp"
@@ -71,14 +72,23 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		StringVector::AddStringOrBlob(out, reinterpret_cast<const char *>(bytes.data()), bytes.size());
 }
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	auto data = FlatVector::GetData<string_t>(in);
-	const string_t &blob = data[row];
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+				 duckdb::vector<uint8_t> &buf) {
+	// Format-based access (was FlatVector::GetData — wrong for dictionary/
+	// constant inputs; fixed as part of the W1 hoisting, spec 054).
+	(void)in;
+	const string_t blob = FormatValue<string_t>(fmt, row);
 	if (col.IsPLPType()) {
 		tds::encoding::BCPRowEncoder::EncodeBinaryPLP(buf, blob);
 	} else {
 		tds::encoding::BCPRowEncoder::EncodeBinary(buf, blob);
 	}
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/binary_codec.cpp
+++ b/src/codec/binary_codec.cpp
@@ -86,9 +86,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/boolean_codec.cpp
+++ b/src/codec/boolean_codec.cpp
@@ -19,6 +19,7 @@
 
 #include "codec/boolean_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "duckdb/common/exception.hpp"
 #include "mssql_compat.hpp"
 
@@ -29,27 +30,23 @@ namespace mssql {
 namespace codec {
 namespace boolean {
 
-namespace {
-
-bool GetVectorBool(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto data = UnifiedVectorFormat::GetData<bool>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
-
-}  // namespace
-
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata & /*col*/, Vector &out, idx_t row) {
 	bool b = !bytes.empty() && bytes[0] != 0;
 	FlatVector::GetData<bool>(out)[row] = b;
 }
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {
-	bool v = GetVectorBool(in, row);
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata & /*col*/,
+				 duckdb::vector<uint8_t> &buf) {
+	(void)in;
+	bool v = FormatValue<bool>(fmt, row);
 	buf.push_back(1);
 	buf.push_back(v ? 0x01 : 0x00);
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/boolean_codec.cpp
+++ b/src/codec/boolean_codec.cpp
@@ -44,9 +44,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/datetime_codec.cpp
+++ b/src/codec/datetime_codec.cpp
@@ -381,9 +381,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/codec/datetime_codec.cpp
+++ b/src/codec/datetime_codec.cpp
@@ -52,6 +52,7 @@
 
 #include "codec/datetime_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -83,15 +84,6 @@ using duckdb::tds::TDS_TYPE_DATETIMEN;
 using duckdb::tds::TDS_TYPE_DATETIMEOFFSET;
 using duckdb::tds::TDS_TYPE_SMALLDATETIME;
 using duckdb::tds::TDS_TYPE_TIME;
-
-template <typename T>
-T GetVectorValue(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto data = UnifiedVectorFormat::GetData<T>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
 
 //===----------------------------------------------------------------------===//
 // Canonical text renderers — shared between FormatSqlLiteral and
@@ -352,13 +344,15 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // EncodeToBcp — Vector overload
 //===----------------------------------------------------------------------===//
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+				 duckdb::vector<uint8_t> &buf) {
+	(void)in;
 	switch (col.duckdb_type.id()) {
 	case LogicalTypeId::DATE:
-		tds::encoding::BCPRowEncoder::EncodeDate(buf, GetVectorValue<date_t>(in, row));
+		tds::encoding::BCPRowEncoder::EncodeDate(buf, FormatValue<date_t>(fmt, row));
 		return;
 	case LogicalTypeId::TIME:
-		tds::encoding::BCPRowEncoder::EncodeTime(buf, GetVectorValue<dtime_t>(in, row), col.scale);
+		tds::encoding::BCPRowEncoder::EncodeTime(buf, FormatValue<dtime_t>(fmt, row), col.scale);
 		return;
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_MS:
@@ -366,7 +360,7 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 	case LogicalTypeId::TIMESTAMP_SEC: {
 		uint64_t time_value;
 		uint32_t date_value;
-		ComputeDatetime2Components(GetVectorValue<timestamp_t>(in, row).value, col.duckdb_type.id(), col.scale,
+		ComputeDatetime2Components(FormatValue<timestamp_t>(fmt, row).value, col.duckdb_type.id(), col.scale,
 								   time_value, date_value);
 		tds::encoding::BCPRowEncoder::EncodeDatetime2Raw(buf, time_value, date_value, col.scale);
 		return;
@@ -375,7 +369,7 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 		// DuckDB stores TIMESTAMP_TZ as UTC µs; offset 0 on the wire.
 		uint64_t time_value;
 		uint32_t date_value;
-		ComputeDatetime2Components(GetVectorValue<timestamp_t>(in, row).value, LogicalTypeId::TIMESTAMP_TZ, col.scale,
+		ComputeDatetime2Components(FormatValue<timestamp_t>(fmt, row).value, LogicalTypeId::TIMESTAMP_TZ, col.scale,
 								   time_value, date_value);
 		tds::encoding::BCPRowEncoder::EncodeDatetimeOffsetRaw(buf, time_value, date_value, 0, col.scale);
 		return;
@@ -384,6 +378,12 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 		throw NotImplementedException("codec::datetime::EncodeToBcp: unexpected DuckDB type '%s'",
 									  col.duckdb_type.ToString());
 	}
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -81,8 +81,13 @@ void CheckMantissaFitsPrecision(const hugeint_t &value, const mssql::BCPColumnMe
 	if (col.precision == 0 || col.precision > 38) {
 		return;	 // malformed metadata — let the server decide
 	}
-	hugeint_t abs_value = value.upper < 0 ? Hugeint::Negate(value) : value;
-	if (Hugeint::GreaterThan(abs_value, Hugeint::POWERS_OF_TEN[col.precision] - 1)) {
+	// Bound both ends directly rather than negating `value` first: Hugeint::Negate
+	// on HUGEINT min (-2^127) overflows int128, so an abs-then-compare guard let
+	// that value slip (or threw a raw overflow). +/-(10^precision - 1) are both
+	// representable for precision <= 38, so the check is exact for every input.
+	const hugeint_t max = Hugeint::POWERS_OF_TEN[col.precision] - 1;
+	const hugeint_t min = Hugeint::Negate(max);
+	if (Hugeint::GreaterThan(value, max) || Hugeint::GreaterThan(min, value)) {
 		throw InvalidInputException(
 			"MSSQL: DECIMAL value (mantissa %s, scale %d) in column \"%s\" is out of range for DECIMAL(%d,%d)",
 			Hugeint::ToString(value), static_cast<int>(col.scale), col.name, static_cast<int>(col.precision),

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -31,9 +31,9 @@
 
 #include "codec/decimal_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "dml/insert/mssql_value_serializer.hpp"
-#include "codec/vector_format.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/decimal.hpp"

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -79,6 +79,25 @@ hugeint_t WidenVectorToHugeint(Vector &vec, idx_t row_idx) {
 	}
 }
 
+// #177: SQL Server rejects a row whose mantissa exceeds the declared precision
+// with a mid-batch "Invalid data for type numeric" that aborts the whole BCP
+// stream. Guard client-side instead: |mantissa| must fit in `precision` digits.
+// Reached e.g. when a HUGEINT source feeds a DECIMAL(38,0) target column
+// (COPY CREATE_TABLE reads the created table's metadata back, so the column
+// dispatches through the Decimal family, not Integer).
+void CheckMantissaFitsPrecision(const hugeint_t &value, const mssql::BCPColumnMetadata &col) {
+	if (col.precision == 0 || col.precision > 38) {
+		return;	 // malformed metadata — let the server decide
+	}
+	hugeint_t abs_value = value.upper < 0 ? Hugeint::Negate(value) : value;
+	if (Hugeint::GreaterThan(abs_value, Hugeint::POWERS_OF_TEN[col.precision] - 1)) {
+		throw InvalidInputException(
+			"MSSQL: DECIMAL value (mantissa %s, scale %d) in column \"%s\" is out of range for DECIMAL(%d,%d)",
+			Hugeint::ToString(value), static_cast<int>(col.scale), col.name, static_cast<int>(col.precision),
+			static_cast<int>(col.scale));
+	}
+}
+
 }  // namespace
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row) {
@@ -99,6 +118,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
 	hugeint_t value = WidenVectorToHugeint(in, row);
+	CheckMantissaFitsPrecision(value, col);
 	tds::encoding::BCPRowEncoder::EncodeDecimal(buf, value, col.precision, col.scale);
 }
 
@@ -108,7 +128,9 @@ void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb
 	// BCPRowEncoder::EncodeValue DECIMAL arm did the same. Keep that behavior
 	// here for parity — the dispatcher always reaches the Vector overload in
 	// practice (BCPRowEncoder::EncodeRow path).
-	tds::encoding::BCPRowEncoder::EncodeDecimal(buf, value.GetValue<hugeint_t>(), col.precision, col.scale);
+	hugeint_t mantissa = value.GetValue<hugeint_t>();
+	CheckMantissaFitsPrecision(mantissa, col);
+	tds::encoding::BCPRowEncoder::EncodeDecimal(buf, mantissa, col.precision, col.scale);
 }
 
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext /*ctx*/) {

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -116,9 +116,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/decimal_codec.cpp
+++ b/src/codec/decimal_codec.cpp
@@ -33,6 +33,7 @@
 
 #include "copy/target_resolver.hpp"
 #include "dml/insert/mssql_value_serializer.hpp"
+#include "codec/vector_format.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/decimal.hpp"
@@ -53,27 +54,18 @@ namespace decimal {
 
 namespace {
 
-template <typename T>
-T GetVectorValue(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto data = UnifiedVectorFormat::GetData<T>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
-
 // Widen the value to hugeint based on DuckDB's PhysicalType. Mirrors
 // the dispatch in BCPRowEncoder::EncodeRow DECIMAL arm.
-hugeint_t WidenVectorToHugeint(Vector &vec, idx_t row_idx) {
+hugeint_t WidenVectorToHugeint(Vector &vec, const UnifiedVectorFormat &fmt, idx_t row_idx) {
 	switch (vec.GetType().InternalType()) {
 	case PhysicalType::INT16:
-		return hugeint_t(GetVectorValue<int16_t>(vec, row_idx));
+		return hugeint_t(FormatValue<int16_t>(fmt, row_idx));
 	case PhysicalType::INT32:
-		return hugeint_t(GetVectorValue<int32_t>(vec, row_idx));
+		return hugeint_t(FormatValue<int32_t>(fmt, row_idx));
 	case PhysicalType::INT64:
-		return hugeint_t(GetVectorValue<int64_t>(vec, row_idx));
+		return hugeint_t(FormatValue<int64_t>(fmt, row_idx));
 	case PhysicalType::INT128:
-		return GetVectorValue<hugeint_t>(vec, row_idx);
+		return FormatValue<hugeint_t>(fmt, row_idx);
 	default:
 		throw InternalException("codec::decimal::EncodeToBcp: unexpected PhysicalType for DECIMAL");
 	}
@@ -116,10 +108,17 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	}
 }
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	hugeint_t value = WidenVectorToHugeint(in, row);
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+				 duckdb::vector<uint8_t> &buf) {
+	hugeint_t value = WidenVectorToHugeint(in, fmt, row);
 	CheckMantissaFitsPrecision(value, col);
 	tds::encoding::BCPRowEncoder::EncodeDecimal(buf, value, col.precision, col.scale);
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/float_codec.cpp
+++ b/src/codec/float_codec.cpp
@@ -23,6 +23,7 @@
 
 #include "codec/float_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "duckdb/common/exception.hpp"
 #include "mssql_compat.hpp"
 
@@ -39,15 +40,6 @@ namespace codec {
 namespace float_family {
 
 namespace {
-
-template <typename T>
-T GetVectorValue(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto data = UnifiedVectorFormat::GetData<T>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
 
 void AppendFloatBcp(duckdb::vector<uint8_t> &buf, float value) {
 	buf.push_back(4);
@@ -117,18 +109,25 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	// Other sizes silently skip (mirror legacy ConvertFloat — defensive only).
 }
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata & /*col*/,
+				 duckdb::vector<uint8_t> &buf) {
 	switch (in.GetType().id()) {
 	case LogicalTypeId::FLOAT:
-		AppendFloatBcp(buf, GetVectorValue<float>(in, row));
+		AppendFloatBcp(buf, FormatValue<float>(fmt, row));
 		break;
 	case LogicalTypeId::DOUBLE:
-		AppendDoubleBcp(buf, GetVectorValue<double>(in, row));
+		AppendDoubleBcp(buf, FormatValue<double>(fmt, row));
 		break;
 	default:
 		throw InternalException("codec::float_family::EncodeToBcp: unexpected LogicalType '%s'",
 								in.GetType().ToString());
 	}
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/float_codec.cpp
+++ b/src/codec/float_codec.cpp
@@ -125,9 +125,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -193,9 +193,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -10,9 +10,9 @@
 //     on bytes.size(): 1->u8, 2->i16, 4->i32, 8->i64).
 //   - EncodeToBcp mirrors BCPRowEncoder Integer arms for TINYINT..UBIGINT
 //     (UBIGINT delegates to BCPRowEncoder::EncodeDecimal). HUGEINT and
-//     UHUGEINT BCP encoding lands with the Decimal family migration; for
-//     now they throw NotImplementedException to preserve the pre-spec-045
-//     default-arm behavior.
+//     UHUGEINT also delegate to EncodeDecimal as DECIMAL(38,0) (issue #177),
+//     guarded client-side: 39-digit values overflow DECIMAL(38,0) and raise
+//     InvalidInputException before the row enters the BCP batch.
 //   - FormatSqlLiteral produces identical output in Filter and InsertValues
 //     contexts (FR-020 (b) — HUGEINT correctness fix; previously Filter
 //     fell through filter_encoder's VARCHAR default arm and rendered
@@ -29,6 +29,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/types/uhugeint.hpp"
 #include "mssql_compat.hpp"
 #include "tds/encoding/bcp_row_encoder.hpp"
 #include "tds/encoding/type_converter.hpp"
@@ -81,6 +82,34 @@ void AppendInt64Bcp(duckdb::vector<uint8_t> &buf, int64_t value) {
 	buf.push_back(8);
 	for (int i = 0; i < 8; ++i) {
 		buf.push_back(static_cast<uint8_t>((value >> (i * 8)) & 0xFF));
+	}
+}
+
+// #177: HUGEINT/UHUGEINT travel as DECIMAL(38,0) on the BCP wire (matching
+// FormatDdlTypeName / FormatSqlLiteral). DECIMAL(38,0) holds at most 38 digits
+// while int128 reaches ~1.70e38 and uint128 ~3.40e38 (39 digits), so
+// out-of-range values must fail client-side before the row enters the batch —
+// a server-side overflow would abort the whole BCP transfer mid-stream.
+const hugeint_t &MaxDecimal38() {
+	static const hugeint_t max = Hugeint::POWERS_OF_TEN[38] - 1;
+	return max;
+}
+
+void CheckHugeintFitsDecimal38(const hugeint_t &value, const std::string &col_name) {
+	hugeint_t abs_value = value.upper < 0 ? Hugeint::Negate(value) : value;
+	if (Hugeint::GreaterThan(abs_value, MaxDecimal38())) {
+		throw InvalidInputException(
+			"MSSQL: HUGEINT value %s in column \"%s\" is out of range for DECIMAL(38,0) (max 38 digits)",
+			Hugeint::ToString(value), col_name);
+	}
+}
+
+void CheckUhugeintFitsDecimal38(const uhugeint_t &value, const std::string &col_name) {
+	const uhugeint_t max(static_cast<uint64_t>(MaxDecimal38().upper), MaxDecimal38().lower);
+	if (value > max) {
+		throw InvalidInputException(
+			"MSSQL: UHUGEINT value %s in column \"%s\" is out of range for DECIMAL(38,0) (max 38 digits)",
+			Uhugeint::ToString(value), col_name);
 	}
 }
 
@@ -148,11 +177,22 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, hugeint_t(0, val), col.precision, col.scale);
 		return;
 	}
-	case LogicalTypeId::HUGEINT:
-	case LogicalTypeId::UHUGEINT:
-		// Deferred to spec-045 Decimal family migration (Phase 6 / T069).
-		throw NotImplementedException("MSSQL: BCP encoding for %s is not yet implemented (spec 045 Phase 6)",
-									  col.duckdb_type.ToString());
+	case LogicalTypeId::HUGEINT: {
+		// #177: HUGEINT (e.g. SUM() over integers) encodes as DECIMAL(38,0),
+		// consistent with the DDL and literal paths.
+		hugeint_t val = GetVectorValue<hugeint_t>(in, row);
+		CheckHugeintFitsDecimal38(val, col.name);
+		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, val, col.precision, col.scale);
+		return;
+	}
+	case LogicalTypeId::UHUGEINT: {
+		uhugeint_t val = GetVectorValue<uhugeint_t>(in, row);
+		CheckUhugeintFitsDecimal38(val, col.name);
+		// Guarded value is < 2^127, so the signed reinterpretation is lossless.
+		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, hugeint_t(static_cast<int64_t>(val.upper), val.lower),
+													col.precision, col.scale);
+		return;
+	}
 	default:
 		throw NotImplementedException("codec::integer::EncodeToBcp: unsupported type %s", col.duckdb_type.ToString());
 	}
@@ -186,10 +226,19 @@ void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb
 		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, hugeint_t(0, val), col.precision, col.scale);
 		return;
 	}
-	case LogicalTypeId::HUGEINT:
-	case LogicalTypeId::UHUGEINT:
-		throw NotImplementedException("MSSQL: BCP encoding for %s is not yet implemented (spec 045 Phase 6)",
-									  col.duckdb_type.ToString());
+	case LogicalTypeId::HUGEINT: {
+		hugeint_t val = value.GetValue<hugeint_t>();
+		CheckHugeintFitsDecimal38(val, col.name);
+		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, val, col.precision, col.scale);
+		return;
+	}
+	case LogicalTypeId::UHUGEINT: {
+		uhugeint_t val = value.GetValue<uhugeint_t>();
+		CheckUhugeintFitsDecimal38(val, col.name);
+		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, hugeint_t(static_cast<int64_t>(val.upper), val.lower),
+													col.precision, col.scale);
+		return;
+	}
 	default:
 		throw NotImplementedException("codec::integer::EncodeToBcp(Value): unsupported type %s",
 									  col.duckdb_type.ToString());

--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -24,6 +24,7 @@
 
 #include "codec/integer_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "dml/insert/mssql_value_serializer.hpp"
 #include "duckdb/common/exception.hpp"
@@ -45,15 +46,6 @@ namespace codec {
 namespace integer {
 
 namespace {
-
-template <typename T>
-T GetVectorValue(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto data = UnifiedVectorFormat::GetData<T>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
 
 void AppendInt8Bcp(duckdb::vector<uint8_t> &buf, int8_t value) {
 	buf.push_back(1);
@@ -145,48 +137,50 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	}
 }
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+				 duckdb::vector<uint8_t> &buf) {
+	(void)in;
 	switch (col.duckdb_type.id()) {
 	case LogicalTypeId::TINYINT:
-		AppendInt8Bcp(buf, GetVectorValue<int8_t>(in, row));
+		AppendInt8Bcp(buf, FormatValue<int8_t>(fmt, row));
 		return;
 	case LogicalTypeId::UTINYINT:
-		AppendUInt8Bcp(buf, GetVectorValue<uint8_t>(in, row));
+		AppendUInt8Bcp(buf, FormatValue<uint8_t>(fmt, row));
 		return;
 	case LogicalTypeId::SMALLINT:
-		AppendInt16Bcp(buf, GetVectorValue<int16_t>(in, row));
+		AppendInt16Bcp(buf, FormatValue<int16_t>(fmt, row));
 		return;
 	case LogicalTypeId::USMALLINT:
 		// USMALLINT (0-65535) widens to int32 to fit without overflow.
-		AppendInt32Bcp(buf, static_cast<int32_t>(GetVectorValue<uint16_t>(in, row)));
+		AppendInt32Bcp(buf, static_cast<int32_t>(FormatValue<uint16_t>(fmt, row)));
 		return;
 	case LogicalTypeId::INTEGER:
-		AppendInt32Bcp(buf, GetVectorValue<int32_t>(in, row));
+		AppendInt32Bcp(buf, FormatValue<int32_t>(fmt, row));
 		return;
 	case LogicalTypeId::UINTEGER:
 		// UINTEGER (0-4B) widens to int64 to fit without overflow.
-		AppendInt64Bcp(buf, static_cast<int64_t>(GetVectorValue<uint32_t>(in, row)));
+		AppendInt64Bcp(buf, static_cast<int64_t>(FormatValue<uint32_t>(fmt, row)));
 		return;
 	case LogicalTypeId::BIGINT:
-		AppendInt64Bcp(buf, GetVectorValue<int64_t>(in, row));
+		AppendInt64Bcp(buf, FormatValue<int64_t>(fmt, row));
 		return;
 	case LogicalTypeId::UBIGINT: {
 		// UBIGINT (0-18e18) uses DECIMAL(20,0) on the wire — SQL Server BIGINT is signed.
 		// Two-argument hugeint_t(upper=0, lower=val) avoids sign issues when val > INT64_MAX.
-		uint64_t val = GetVectorValue<uint64_t>(in, row);
+		uint64_t val = FormatValue<uint64_t>(fmt, row);
 		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, hugeint_t(0, val), col.precision, col.scale);
 		return;
 	}
 	case LogicalTypeId::HUGEINT: {
 		// #177: HUGEINT (e.g. SUM() over integers) encodes as DECIMAL(38,0),
 		// consistent with the DDL and literal paths.
-		hugeint_t val = GetVectorValue<hugeint_t>(in, row);
+		hugeint_t val = FormatValue<hugeint_t>(fmt, row);
 		CheckHugeintFitsDecimal38(val, col.name);
 		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, val, col.precision, col.scale);
 		return;
 	}
 	case LogicalTypeId::UHUGEINT: {
-		uhugeint_t val = GetVectorValue<uhugeint_t>(in, row);
+		uhugeint_t val = FormatValue<uhugeint_t>(fmt, row);
 		CheckUhugeintFitsDecimal38(val, col.name);
 		// Guarded value is < 2^127, so the signed reinterpretation is lossless.
 		tds::encoding::BCPRowEncoder::EncodeDecimal(buf, hugeint_t(static_cast<int64_t>(val.upper), val.lower),
@@ -196,6 +190,12 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 	default:
 		throw NotImplementedException("codec::integer::EncodeToBcp: unsupported type %s", col.duckdb_type.ToString());
 	}
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -88,8 +88,14 @@ const hugeint_t &MaxDecimal38() {
 }
 
 void CheckHugeintFitsDecimal38(const hugeint_t &value, const std::string &col_name) {
-	hugeint_t abs_value = value.upper < 0 ? Hugeint::Negate(value) : value;
-	if (Hugeint::GreaterThan(abs_value, MaxDecimal38())) {
+	// Bound both ends directly instead of negating `value`: Hugeint::Negate on
+	// HUGEINT min (-2^127) is itself out of int128 range, so the old
+	// abs-then-compare let that one value slip the guard (or threw a raw
+	// overflow). +/-(10^38-1) are both representable (< 2^127), so the range
+	// check is exact and keeps the column-named message for every input.
+	const hugeint_t &max = MaxDecimal38();
+	const hugeint_t min = Hugeint::Negate(max);
+	if (Hugeint::GreaterThan(value, max) || Hugeint::GreaterThan(min, value)) {
 		throw InvalidInputException(
 			"MSSQL: HUGEINT value %s in column \"%s\" is out of range for DECIMAL(38,0) (max 38 digits)",
 			Hugeint::ToString(value), col_name);

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -46,19 +46,32 @@ void AppendNVarcharNonPlp(duckdb::vector<uint8_t> &buf, const char *input, size_
 	buf.resize(start_pos + 2 + utf16_len);
 }
 
+// Single-chunk PLP frame primitives — the wire layout (8-byte UNKNOWN-length
+// header, 4-byte LE chunk length, data, 4-byte zero terminator) is written in
+// exactly one place so the legacy and W3 append paths cannot drift apart.
+void WriteLe32(uint8_t *out, uint32_t v) {
+	out[0] = static_cast<uint8_t>(v & 0xFF);
+	out[1] = static_cast<uint8_t>((v >> 8) & 0xFF);
+	out[2] = static_cast<uint8_t>((v >> 16) & 0xFF);
+	out[3] = static_cast<uint8_t>((v >> 24) & 0xFF);
+}
+
+void WritePlpHeader(uint8_t *out) {
+	constexpr uint64_t UNKNOWN_PLP_LEN = 0xFFFFFFFFFFFFFFFEULL;
+	for (int i = 0; i < 8; i++) {
+		out[i] = static_cast<uint8_t>((UNKNOWN_PLP_LEN >> (i * 8)) & 0xFF);
+	}
+}
+
 // Append a PLP-framed nvarchar(max) payload to `buf`. Mirrors
 // BCPRowEncoder::EncodeNVarcharPLP bit-for-bit.
 void AppendNVarcharPlp(duckdb::vector<uint8_t> &buf, const char *input, size_t input_len) {
-	constexpr uint64_t UNKNOWN_PLP_LEN = 0xFFFFFFFFFFFFFFFEULL;
-
 	if (input_len == 0) {
-		for (int i = 0; i < 8; i++) {
-			buf.push_back(static_cast<uint8_t>((UNKNOWN_PLP_LEN >> (i * 8)) & 0xFF));
-		}
-		buf.push_back(0x00);
-		buf.push_back(0x00);
-		buf.push_back(0x00);
-		buf.push_back(0x00);
+		// Empty value: header + zero terminator, no data chunk.
+		const size_t start_pos = buf.size();
+		buf.resize(start_pos + 8 + 4);
+		WritePlpHeader(buf.data() + start_pos);
+		WriteLe32(buf.data() + start_pos + 8, 0);
 		return;
 	}
 
@@ -67,26 +80,11 @@ void AppendNVarcharPlp(duckdb::vector<uint8_t> &buf, const char *input, size_t i
 	buf.resize(start_pos + 8 + 4 + max_utf16_len + 4);
 
 	uint8_t *out = buf.data() + start_pos;
-	for (int i = 0; i < 8; i++) {
-		out[i] = static_cast<uint8_t>((UNKNOWN_PLP_LEN >> (i * 8)) & 0xFF);
-	}
-	out += 8;
-
-	uint8_t *chunk_len_ptr = out;
-	out += 4;
-	size_t utf16_len = tds::encoding::Utf16LEEncodeDirect(input, input_len, out);
-	out += utf16_len;
-
-	uint32_t chunk_len = static_cast<uint32_t>(utf16_len);
-	chunk_len_ptr[0] = static_cast<uint8_t>(chunk_len & 0xFF);
-	chunk_len_ptr[1] = static_cast<uint8_t>((chunk_len >> 8) & 0xFF);
-	chunk_len_ptr[2] = static_cast<uint8_t>((chunk_len >> 16) & 0xFF);
-	chunk_len_ptr[3] = static_cast<uint8_t>((chunk_len >> 24) & 0xFF);
-
-	out[0] = 0x00;
-	out[1] = 0x00;
-	out[2] = 0x00;
-	out[3] = 0x00;
+	WritePlpHeader(out);
+	uint8_t *chunk_len_ptr = out + 8;
+	size_t utf16_len = tds::encoding::Utf16LEEncodeDirect(input, input_len, chunk_len_ptr + 4);
+	WriteLe32(chunk_len_ptr, static_cast<uint32_t>(utf16_len));
+	WriteLe32(chunk_len_ptr + 4 + utf16_len, 0);
 
 	buf.resize(start_pos + 8 + 4 + utf16_len + 4);
 }
@@ -127,7 +125,6 @@ void EncodeNVarcharFromUtf8(const char *utf8_data, size_t utf8_len, const mssql:
 	}
 
 	if (col.IsPLPType()) {
-		constexpr uint64_t UNKNOWN_PLP_LEN = 0xFFFFFFFFFFFFFFFEULL;
 		if (utf16_byte_len == 0) {
 			// Empty PLP value: header + zero terminator, no data chunk.
 			AppendNVarcharPlp(buf, utf8_data, utf8_len);
@@ -136,20 +133,10 @@ void EncodeNVarcharFromUtf8(const char *utf8_data, size_t utf8_len, const mssql:
 		const size_t start = buf.size();
 		buf.resize(start + 8 + 4 + utf16_byte_len + 4);
 		uint8_t *out = buf.data() + start;
-		for (int i = 0; i < 8; i++) {
-			out[i] = static_cast<uint8_t>((UNKNOWN_PLP_LEN >> (i * 8)) & 0xFF);
-		}
-		const uint32_t chunk_len = static_cast<uint32_t>(utf16_byte_len);
-		out[8] = static_cast<uint8_t>(chunk_len & 0xFF);
-		out[9] = static_cast<uint8_t>((chunk_len >> 8) & 0xFF);
-		out[10] = static_cast<uint8_t>((chunk_len >> 16) & 0xFF);
-		out[11] = static_cast<uint8_t>((chunk_len >> 24) & 0xFF);
+		WritePlpHeader(out);
+		WriteLe32(out + 8, static_cast<uint32_t>(utf16_byte_len));
 		tds::encoding::Utf16LEEncodeValidDirect(utf8_data, utf8_len, out + 12);
-		uint8_t *terminator = out + 12 + utf16_byte_len;
-		terminator[0] = 0x00;
-		terminator[1] = 0x00;
-		terminator[2] = 0x00;
-		terminator[3] = 0x00;
+		WriteLe32(out + 12 + utf16_byte_len, 0);
 		return;
 	}
 
@@ -180,10 +167,14 @@ std::string EscapeSqlSingleQuotes(const std::string &str) {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row) {
 	// R1 (spec 054): decode straight into the vector's string slot — no
-	// intermediate std::string. Trailing-space trim for fixed-length
-	// CHAR/NCHAR happens on the INPUT (a trailing U+0020 is a trailing
-	// 0x0020 code unit / 0x20 byte — no other sequence produces one), which
-	// matches the old trim-the-UTF-8-output behaviour bit-for-bit.
+	// intermediate std::string. For VALID UTF-16 the trailing-space trim for
+	// fixed-length CHAR/NCHAR happens on the INPUT (a trailing U+0020 is a
+	// trailing 0x0020 code unit / 0x20 byte, and a space can never be part of
+	// a surrogate pair — so the trim neither changes validity nor differs
+	// from the old trim-the-UTF-8-output behaviour). Invalid UTF-16 (e.g.
+	// unpaired surrogates, legal in UCS-2 collations) must go through the
+	// legacy decoder with the UNTRIMMED payload + output-side trim, exactly
+	// as every pre-054 release did.
 	const bool trim_trailing_spaces = col.type_id == tds::TDS_TYPE_BIGCHAR || col.type_id == tds::TDS_TYPE_NCHAR;
 
 	if (col.type_id == tds::TDS_TYPE_NCHAR || col.type_id == tds::TDS_TYPE_NVARCHAR ||
@@ -196,8 +187,14 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 		}
 		const size_t utf8_len = tds::encoding::Utf8LengthFromUtf16LEView(bytes.data(), byte_len);
 		if (utf8_len == SIZE_MAX) {
-			// Invalid UTF-16 — legacy per-value fallback, semantics unchanged.
-			std::string str = tds::encoding::Utf16LEDecode(bytes.data(), byte_len);
+			// Invalid UTF-16 — legacy per-value fallback on the FULL payload,
+			// then trim the decoded output (pre-054 semantics bit-for-bit).
+			std::string str = tds::encoding::Utf16LEDecode(bytes.data(), bytes.size());
+			if (trim_trailing_spaces) {
+				while (!str.empty() && str.back() == ' ') {
+					str.pop_back();
+				}
+			}
 			FlatVector::GetData<string_t>(out)[row] = StringVector::AddString(out, str);
 			return;
 		}
@@ -245,9 +242,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -9,6 +9,7 @@
 
 #include "codec/string_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "dml/ctas/mssql_ctas_config.hpp"
 #include "duckdb/common/exception.hpp"
@@ -29,15 +30,6 @@ namespace codec {
 namespace string {
 
 namespace {
-
-template <typename T>
-T GetVectorValue(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto data = UnifiedVectorFormat::GetData<T>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
 
 // Defer to the public EscapeSqlSingleQuotes API for in-module callers so
 // both this file and external callers (FilterEncoder LIKE emitter) share
@@ -178,10 +170,12 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	FlatVector::GetData<string_t>(out)[row] = StringVector::AddString(out, str);
 }
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+				 duckdb::vector<uint8_t> &buf) {
+	(void)in;
 	switch (col.duckdb_type.id()) {
 	case LogicalTypeId::VARCHAR: {
-		auto str_val = GetVectorValue<string_t>(in, row);
+		auto str_val = FormatValue<string_t>(fmt, row);
 		EncodeNVarcharFromUtf8(str_val.GetData(), str_val.GetSize(), col, buf);
 		return;
 	}
@@ -189,7 +183,7 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 		// Render interval as canonical T-SQL-safe string before encoding.
 		// New behaviour for INTERVAL columns (FR-026 — DDL routes to
 		// NVARCHAR(50), encode routes to the canonical string form).
-		auto iv = GetVectorValue<interval_t>(in, row);
+		auto iv = FormatValue<interval_t>(fmt, row);
 		auto str = Interval::ToString(iv);
 		EncodeNVarcharFromUtf8(str.c_str(), str.size(), col, buf);
 		return;
@@ -197,6 +191,12 @@ void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duc
 	default:
 		throw NotImplementedException("codec::string::EncodeToBcp: unsupported type %s", col.duckdb_type.ToString());
 	}
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -179,30 +179,46 @@ std::string EscapeSqlSingleQuotes(const std::string &str) {
 }
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row) {
-	std::string str;
+	// R1 (spec 054): decode straight into the vector's string slot — no
+	// intermediate std::string. Trailing-space trim for fixed-length
+	// CHAR/NCHAR happens on the INPUT (a trailing U+0020 is a trailing
+	// 0x0020 code unit / 0x20 byte — no other sequence produces one), which
+	// matches the old trim-the-UTF-8-output behaviour bit-for-bit.
+	const bool trim_trailing_spaces = col.type_id == tds::TDS_TYPE_BIGCHAR || col.type_id == tds::TDS_TYPE_NCHAR;
 
 	if (col.type_id == tds::TDS_TYPE_NCHAR || col.type_id == tds::TDS_TYPE_NVARCHAR ||
 		col.type_id == tds::TDS_TYPE_XML) {
-		str = tds::encoding::Utf16LEDecode(bytes.data(), bytes.size());
-	} else {
-		// CHAR/VARCHAR are single-byte (collation-dependent in theory; in
-		// practice the test fixtures and the pre-spec-045 path treated the
-		// bytes as UTF-8 / CP1252 indistinguishably for ASCII).
-		str = std::string(reinterpret_cast<const char *>(bytes.data()), bytes.size());
+		size_t byte_len = bytes.size();
+		if (trim_trailing_spaces) {
+			while (byte_len >= 2 && bytes[byte_len - 2] == 0x20 && bytes[byte_len - 1] == 0x00) {
+				byte_len -= 2;
+			}
+		}
+		const size_t utf8_len = tds::encoding::Utf8LengthFromUtf16LEView(bytes.data(), byte_len);
+		if (utf8_len == SIZE_MAX) {
+			// Invalid UTF-16 — legacy per-value fallback, semantics unchanged.
+			std::string str = tds::encoding::Utf16LEDecode(bytes.data(), byte_len);
+			FlatVector::GetData<string_t>(out)[row] = StringVector::AddString(out, str);
+			return;
+		}
+		string_t slot = StringVector::EmptyString(out, utf8_len);
+		tds::encoding::Utf16LEDecodeValidInto(bytes.data(), byte_len, slot.GetDataWriteable());
+		slot.Finalize();
+		FlatVector::GetData<string_t>(out)[row] = slot;
+		return;
 	}
 
-	// Trim trailing spaces for fixed-length CHAR/NCHAR (matches
-	// TypeConverter::ConvertString bit-for-bit).
-	if (col.type_id == tds::TDS_TYPE_BIGCHAR || col.type_id == tds::TDS_TYPE_NCHAR) {
-		size_t end = str.find_last_not_of(' ');
-		if (end != std::string::npos) {
-			str.erase(end + 1);
-		} else {
-			str.clear();
+	// CHAR/VARCHAR are single-byte (collation-dependent in theory; in
+	// practice the test fixtures and the pre-spec-045 path treated the
+	// bytes as UTF-8 / CP1252 indistinguishably for ASCII).
+	size_t len = bytes.size();
+	if (trim_trailing_spaces) {
+		while (len > 0 && bytes[len - 1] == 0x20) {
+			len--;
 		}
 	}
-
-	FlatVector::GetData<string_t>(out)[row] = StringVector::AddString(out, str);
+	FlatVector::GetData<string_t>(out)[row] =
+		StringVector::AddString(out, reinterpret_cast<const char *>(bytes.data()), len);
 }
 
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -91,38 +91,73 @@ void AppendNVarcharPlp(duckdb::vector<uint8_t> &buf, const char *input, size_t i
 	buf.resize(start_pos + 8 + 4 + utf16_len + 4);
 }
 
-// FR-023 (issue #91) — pre-encode length check for non-PLP nvarchar(N).
-// `utf16_byte_len = Utf16LEByteLength(utf8)`; throws a clear, column-named
-// error when the value would not fit. PLP columns are skipped (the
-// max_length sentinel 0xFFFF means nvarchar(max), no client-side cap).
-void ValidateNVarcharLength(const char *utf8_data, size_t utf8_len, const mssql::BCPColumnMetadata &col) {
-	if (col.IsPLPType()) {
-		return;
-	}
-	// Compute the byte count without allocating an output buffer. simdutf-
-	// backed via tds::encoding::Utf16LEByteLength (handles invalid input by
-	// falling back to the legacy hand-rolled counter — same contract as
-	// Utf16LEEncodeDirect).
-	std::string tmp(utf8_data, utf8_len);
-	size_t utf16_byte_len = tds::encoding::Utf16LEByteLength(tmp);
-	if (utf16_byte_len > col.max_length) {
+// Shared encode body taking already-resolved UTF-8 string view. Picks the
+// PLP / non-PLP path based on col, after running FR-023 validation.
+//
+// W3+W4 (spec 054): validate + length are computed ONCE per value
+// (Utf16LEByteLengthView), the FR-023 check reuses that length, and the
+// valid-input path appends at the exact final size (length prefix written
+// up front, conversion via Utf16LEEncodeValidDirect with no re-validation
+// and no oversize-resize-then-shrink). The pre-W3 flow validated twice and
+// allocated a temporary std::string per value. Invalid UTF-8 (cold path)
+// keeps the legacy append flow bit-for-bit.
+void EncodeNVarcharFromUtf8(const char *utf8_data, size_t utf8_len, const mssql::BCPColumnMetadata &col,
+							duckdb::vector<uint8_t> &buf) {
+	bool valid_utf8 = false;
+	const size_t utf16_byte_len = tds::encoding::Utf16LEByteLengthView(utf8_data, utf8_len, valid_utf8);
+
+	// FR-023 (issue #91) — pre-encode length check for non-PLP nvarchar(N).
+	// PLP columns are skipped (max_length sentinel 0xFFFF = nvarchar(max),
+	// no client-side cap). Error wording is tested — do not change.
+	if (!col.IsPLPType() && utf16_byte_len > col.max_length) {
 		throw InvalidInputException(
 			"MSSQL: NVARCHAR column '%s' overflow: value is %zu UCS-2 code units (%zu UTF-16LE bytes) "
 			"but column max is %u code units (%u bytes)",
 			col.name, utf16_byte_len / 2, utf16_byte_len, col.max_length / 2, col.max_length);
 	}
-}
 
-// Shared encode body taking already-resolved UTF-8 string view. Picks the
-// PLP / non-PLP path based on col, after running FR-023 validation.
-void EncodeNVarcharFromUtf8(const char *utf8_data, size_t utf8_len, const mssql::BCPColumnMetadata &col,
-							duckdb::vector<uint8_t> &buf) {
-	ValidateNVarcharLength(utf8_data, utf8_len, col);
-	if (col.IsPLPType()) {
-		AppendNVarcharPlp(buf, utf8_data, utf8_len);
-	} else {
-		AppendNVarcharNonPlp(buf, utf8_data, utf8_len);
+	if (!valid_utf8) {
+		// Cold path: legacy oversize-append flow, bit-identical to pre-W3.
+		if (col.IsPLPType()) {
+			AppendNVarcharPlp(buf, utf8_data, utf8_len);
+		} else {
+			AppendNVarcharNonPlp(buf, utf8_data, utf8_len);
+		}
+		return;
 	}
+
+	if (col.IsPLPType()) {
+		constexpr uint64_t UNKNOWN_PLP_LEN = 0xFFFFFFFFFFFFFFFEULL;
+		if (utf16_byte_len == 0) {
+			// Empty PLP value: header + zero terminator, no data chunk.
+			AppendNVarcharPlp(buf, utf8_data, utf8_len);
+			return;
+		}
+		const size_t start = buf.size();
+		buf.resize(start + 8 + 4 + utf16_byte_len + 4);
+		uint8_t *out = buf.data() + start;
+		for (int i = 0; i < 8; i++) {
+			out[i] = static_cast<uint8_t>((UNKNOWN_PLP_LEN >> (i * 8)) & 0xFF);
+		}
+		const uint32_t chunk_len = static_cast<uint32_t>(utf16_byte_len);
+		out[8] = static_cast<uint8_t>(chunk_len & 0xFF);
+		out[9] = static_cast<uint8_t>((chunk_len >> 8) & 0xFF);
+		out[10] = static_cast<uint8_t>((chunk_len >> 16) & 0xFF);
+		out[11] = static_cast<uint8_t>((chunk_len >> 24) & 0xFF);
+		tds::encoding::Utf16LEEncodeValidDirect(utf8_data, utf8_len, out + 12);
+		uint8_t *terminator = out + 12 + utf16_byte_len;
+		terminator[0] = 0x00;
+		terminator[1] = 0x00;
+		terminator[2] = 0x00;
+		terminator[3] = 0x00;
+		return;
+	}
+
+	const size_t start = buf.size();
+	buf.resize(start + 2 + utf16_byte_len);
+	buf[start] = static_cast<uint8_t>(utf16_byte_len & 0xFF);
+	buf[start + 1] = static_cast<uint8_t>((utf16_byte_len >> 8) & 0xFF);
+	tds::encoding::Utf16LEEncodeValidDirect(utf8_data, utf8_len, buf.data() + start + 2);
 }
 
 }  // namespace

--- a/src/codec/uuid_codec.cpp
+++ b/src/codec/uuid_codec.cpp
@@ -111,9 +111,7 @@ void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const ms
 }
 
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
-	UnifiedVectorFormat fmt;
-	in.ToUnifiedFormat(row + 1, fmt);
-	EncodeToBcp(in, fmt, row, col, buf);
+	EncodeToBcpViaFormat(EncodeToBcp, in, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/codec/uuid_codec.cpp
+++ b/src/codec/uuid_codec.cpp
@@ -24,6 +24,7 @@
 
 #include "codec/uuid_codec.hpp"
 
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "dml/ctas/mssql_ctas_config.hpp"
 #include "duckdb/common/exception.hpp"
@@ -97,12 +98,22 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // Encode (DuckDB → TDS BCP)
 //===----------------------------------------------------------------------===//
 
-void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {
-	auto uuid = FlatVector::GetData<hugeint_t>(in)[row];
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata & /*col*/,
+				 duckdb::vector<uint8_t> &buf) {
+	// Format-based access (was FlatVector::GetData — wrong for dictionary/
+	// constant inputs; fixed as part of the W1 hoisting, spec 054).
+	(void)in;
+	auto uuid = FormatValue<hugeint_t>(fmt, row);
 	buf.push_back(GUID_LENGTH_PREFIX);
 	const size_t start = buf.size();
 	buf.resize(start + GUID_WIRE_SIZE);
 	EncodeHugeIntToWire(uuid, buf.data() + start);
+}
+
+void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	EncodeToBcp(in, fmt, row, col, buf);
 }
 
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata & /*col*/, duckdb::vector<uint8_t> &buf) {

--- a/src/connection/mssql_connection_provider.cpp
+++ b/src/connection/mssql_connection_provider.cpp
@@ -242,4 +242,46 @@ void ConnectionProvider::ReleaseConnection(ClientContext &context, MSSQLCatalog 
 	// Do nothing - connection stays pinned
 }
 
+namespace mssql {
+
+void ReleaseBcpConnectionOnError(std::shared_ptr<tds::TdsConnection> &connection,
+								 const duckdb::weak_ptr<tds::ConnectionPool> &pool_handle,
+								 bool transaction_pinned) noexcept {
+	if (!connection) {
+		return;
+	}
+
+	// Closing ends the session, rolls back the INSERT BULK transaction and
+	// drops the locks held on the target table (see the header contract).
+	auto conn_state = connection->GetState();
+	if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
+		try {
+			connection->Close();
+		} catch (...) {
+			// Ignore — the shared_ptr destructor closes the socket regardless.
+		}
+	}
+
+	if (transaction_pinned) {
+		// The MSSQLTransaction owns the pin; just drop our reference.
+		connection.reset();
+		return;
+	}
+
+	if (auto pool = pool_handle.lock()) {
+		try {
+			connection->SetNeedsReset(true);
+			pool->Release(std::move(connection));
+		} catch (...) {
+			// Release failed — drop it; the shared_ptr destructor closes the socket.
+			connection.reset();
+		}
+	} else {
+		// Catalog torn down — dropping is the safe failure mode.
+		connection.reset();
+	}
+}
+
+}  // namespace mssql
+
 }  // namespace duckdb

--- a/src/copy/bcp_writer.cpp
+++ b/src/copy/bcp_writer.cpp
@@ -70,7 +70,10 @@ static double ElapsedMs(TimePoint start) {
 
 BCPWriter::BCPWriter(tds::TdsConnection &conn, const BCPCopyTarget &target, vector<BCPColumnMetadata> columns,
 					 vector<int32_t> column_mapping)
-	: conn_(conn), target_(target), columns_(std::move(columns)), column_mapping_(std::move(column_mapping)),
+	: conn_(conn),
+	  target_(target),
+	  columns_(std::move(columns)),
+	  column_mapping_(std::move(column_mapping)),
 	  counters_enabled_(GetBCPDebugLevel() >= 2) {
 	// Pre-allocate buffer to reduce reallocation overhead
 	// Estimate: 100 bytes per column per row, reserve for 10K rows
@@ -100,7 +103,7 @@ BCPWriter::~BCPWriter() {
 		return;
 	}
 	static const char *kFamilyNames[9] = {"boolean", "integer", "float",	"decimal", "money",
-										  "string",  "binary",	"datetime", "uuid"};
+										  "string",	 "binary",	"datetime", "uuid"};
 	fprintf(stderr,
 			"[MSSQL COUNTERS] bcp writer close: rows=%llu chunks=%llu bytes_sent=%llu plp_values=%llu "
 			"utf16_fallback=%llu write_rows=%lluus\n",

--- a/src/copy/bcp_writer.cpp
+++ b/src/copy/bcp_writer.cpp
@@ -157,12 +157,12 @@ idx_t BCPWriter::WriteRows(DataChunk &chunk) {
 	const uint64_t utf16_fallbacks_at_entry = counters_enabled_ ? tds::encoding::Utf16FallbackCount() : 0;
 
 	auto start_encode = Clock::now();
-	// Accumulate rows into the accumulator buffer
-	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		// Build ROW token for this row
-		BuildRowToken(accumulator_buffer_, chunk, row_idx);
-		rows_written++;
-	}
+	// Accumulate all rows into the accumulator buffer. EncodeChunk writes the
+	// 0xD1 ROW token per row and hoists per-column state (UnifiedVectorFormat,
+	// family encoder, NULL wire kind) once per chunk (spec 054 W1+W2).
+	const vector<int32_t> *mapping_ptr = column_mapping_.empty() ? nullptr : &column_mapping_;
+	tds::encoding::BCPRowEncoder::EncodeChunk(accumulator_buffer_, chunk, columns_, mapping_ptr);
+	rows_written = row_count;
 	double encode_ms = ElapsedMs(start_encode);
 
 	size_t bytes_added = accumulator_buffer_.size() - buffer_start;
@@ -503,20 +503,6 @@ void BCPWriter::BuildColmetadataToken(vector<uint8_t> &buffer) {
 		// Column name (B_VARCHAR format: length byte + UTF-16LE)
 		WriteUTF16LEString(buffer, col.name);
 	}
-}
-
-void BCPWriter::BuildRowToken(vector<uint8_t> &buffer, DataChunk &chunk, idx_t row_idx) {
-	// ROW token format:
-	// Token (1 byte): 0xD1
-	// Column values (variable): Type-specific encoding for each column
-
-	// Token
-	WriteUInt8(buffer, TOKEN_ROW);
-
-	// Encode all column values using BCPRowEncoder
-	// Pass column mapping if we have one (for name-based source-to-target mapping)
-	const vector<int32_t> *mapping_ptr = column_mapping_.empty() ? nullptr : &column_mapping_;
-	tds::encoding::BCPRowEncoder::EncodeRow(buffer, chunk, row_idx, columns_, mapping_ptr);
 }
 
 void BCPWriter::BuildDoneToken(vector<uint8_t> &buffer, idx_t row_count) {

--- a/src/copy/bcp_writer.cpp
+++ b/src/copy/bcp_writer.cpp
@@ -4,7 +4,9 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <string>
 
+#include "codec/type_family.hpp"
 #include "duckdb/common/exception.hpp"
 #include "tds/encoding/bcp_row_encoder.hpp"
 #include "tds/encoding/utf16.hpp"
@@ -68,12 +70,57 @@ static double ElapsedMs(TimePoint start) {
 
 BCPWriter::BCPWriter(tds::TdsConnection &conn, const BCPCopyTarget &target, vector<BCPColumnMetadata> columns,
 					 vector<int32_t> column_mapping)
-	: conn_(conn), target_(target), columns_(std::move(columns)), column_mapping_(std::move(column_mapping)) {
+	: conn_(conn), target_(target), columns_(std::move(columns)), column_mapping_(std::move(column_mapping)),
+	  counters_enabled_(GetBCPDebugLevel() >= 2) {
 	// Pre-allocate buffer to reduce reallocation overhead
 	// Estimate: 100 bytes per column per row, reserve for 10K rows
 	// This will grow as needed but reduces initial reallocations
 	size_t estimated_row_size = columns_.size() * 100;
 	accumulator_buffer_.reserve(estimated_row_size * 10000);  // ~1MB initial
+
+	// D4 (spec 054): every row encodes every target column, so per-family
+	// value counts are rows × per-family column counts — precompute the
+	// latter once (same FamilyFromLogicalType dispatch EncodeRow uses).
+	if (counters_enabled_) {
+		for (const auto &col : columns_) {
+			try {
+				family_col_count_[static_cast<uint8_t>(codec::FamilyFromLogicalType(col.duckdb_type))]++;
+			} catch (...) {
+				unknown_family_col_count_++;
+			}
+			if (col.IsPLPType()) {
+				plp_col_count_++;
+			}
+		}
+	}
+}
+
+BCPWriter::~BCPWriter() {
+	if (!counters_enabled_) {
+		return;
+	}
+	static const char *kFamilyNames[9] = {"boolean", "integer", "float",	"decimal", "money",
+										  "string",  "binary",	"datetime", "uuid"};
+	fprintf(stderr,
+			"[MSSQL COUNTERS] bcp writer close: rows=%llu chunks=%llu bytes_sent=%llu plp_values=%llu "
+			"utf16_fallback=%llu write_rows=%lluus\n",
+			(unsigned long long)rows_sent_.load(), (unsigned long long)counter_chunks_,
+			(unsigned long long)bytes_sent_.load(), (unsigned long long)counter_plp_values_,
+			(unsigned long long)counter_utf16_fallbacks_, (unsigned long long)counter_write_rows_us_);
+	std::string families;
+	for (int f = 0; f < 9; f++) {
+		if (counter_values_per_family_[f] > 0) {
+			families += " ";
+			families += kFamilyNames[f];
+			families += "=" + std::to_string(counter_values_per_family_[f]);
+		}
+	}
+	if (counter_unknown_family_values_ > 0) {
+		families += " unknown=" + std::to_string(counter_unknown_family_values_);
+	}
+	if (!families.empty()) {
+		fprintf(stderr, "[MSSQL COUNTERS]   values/family (incl. NULLs):%s\n", families.c_str());
+	}
 }
 
 //===----------------------------------------------------------------------===//
@@ -105,6 +152,9 @@ idx_t BCPWriter::WriteRows(DataChunk &chunk) {
 	idx_t rows_written = 0;
 	idx_t row_count = chunk.size();
 	size_t buffer_start = accumulator_buffer_.size();
+	// D4: thread-local snapshot — the delta after the encode loop is this
+	// call's fallbacks (the loop runs on the calling thread, under the mutex).
+	const uint64_t utf16_fallbacks_at_entry = counters_enabled_ ? tds::encoding::Utf16FallbackCount() : 0;
 
 	auto start_encode = Clock::now();
 	// Accumulate rows into the accumulator buffer
@@ -118,6 +168,17 @@ idx_t BCPWriter::WriteRows(DataChunk &chunk) {
 	size_t bytes_added = accumulator_buffer_.size() - buffer_start;
 	rows_sent_.fetch_add(rows_written);
 	rows_in_batch_.fetch_add(rows_written);
+
+	if (counters_enabled_ && rows_written > 0) {
+		counter_chunks_++;
+		for (int f = 0; f < 9; f++) {
+			counter_values_per_family_[f] += rows_written * family_col_count_[f];
+		}
+		counter_unknown_family_values_ += rows_written * unknown_family_col_count_;
+		counter_plp_values_ += rows_written * plp_col_count_;
+		counter_utf16_fallbacks_ += tds::encoding::Utf16FallbackCount() - utf16_fallbacks_at_entry;
+		counter_write_rows_us_ += static_cast<uint64_t>(ElapsedMs(start_lock) * 1000.0);
+	}
 
 	// Log timing if debug enabled
 	if (GetBCPDebugLevel() >= 1) {

--- a/src/copy/bcp_writer.cpp
+++ b/src/copy/bcp_writer.cpp
@@ -102,8 +102,6 @@ BCPWriter::~BCPWriter() {
 	if (!counters_enabled_) {
 		return;
 	}
-	static const char *kFamilyNames[9] = {"boolean", "integer", "float",	"decimal", "money",
-										  "string",	 "binary",	"datetime", "uuid"};
 	fprintf(stderr,
 			"[MSSQL COUNTERS] bcp writer close: rows=%llu chunks=%llu bytes_sent=%llu plp_values=%llu "
 			"utf16_fallback=%llu write_rows=%lluus\n",
@@ -111,10 +109,10 @@ BCPWriter::~BCPWriter() {
 			(unsigned long long)bytes_sent_.load(), (unsigned long long)counter_plp_values_,
 			(unsigned long long)counter_utf16_fallbacks_, (unsigned long long)counter_write_rows_us_);
 	std::string families;
-	for (int f = 0; f < 9; f++) {
+	for (uint8_t f = 0; f < codec::TYPE_FAMILY_COUNT; f++) {
 		if (counter_values_per_family_[f] > 0) {
 			families += " ";
-			families += kFamilyNames[f];
+			families += codec::FamilyName(static_cast<codec::TypeFamily>(f));
 			families += "=" + std::to_string(counter_values_per_family_[f]);
 		}
 	}

--- a/src/copy/copy_function.cpp
+++ b/src/copy/copy_function.cpp
@@ -106,43 +106,9 @@ MSSQLCopyGlobalState::~MSSQLCopyGlobalState() {
 	// BCPCopyFinalize (both success and error) reset() `connection`. This only fires when the sink
 	// threw and copy_to_finalize was never called — see the contract note on the declaration.
 	//
-	// Touch no ClientContext here (issue #178 / PR #179): this can run on a worker thread while
-	// the client thread commits the query's transaction.
-	if (!connection) {
-		return;
-	}
-
-	// A COPY that died mid-stream leaves the server awaiting bulk data on this session, so the
-	// connection is not reusable: closing it is what ends the session, rolls back the INSERT BULK
-	// transaction, and drops the locks it held on the target table. Returning it to the pool in
-	// that state would hand the next caller a connection stuck mid-bulk-load.
-	auto conn_state = connection->GetState();
-	if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
-		try {
-			connection->Close();
-		} catch (...) {
-			// Ignore - the shared_ptr destructor closes the socket regardless.
-		}
-	}
-
-	if (transaction_pinned) {
-		// The MSSQLTransaction owns the pin; just drop our reference.
-		connection.reset();
-		return;
-	}
-
-	if (auto pool = pool_handle.lock()) {
-		try {
-			connection->SetNeedsReset(true);
-			pool->Release(std::move(connection));
-		} catch (...) {
-			// Release failed - drop it; the shared_ptr destructor closes the socket.
-			connection.reset();
-		}
-	} else {
-		// Catalog torn down - dropping is the safe failure mode.
-		connection.reset();
-	}
+	// Shared mid-BCP release protocol (see ReleaseBcpConnectionOnError contract) — worker-thread
+	// safe per issue #178 / PR #179.
+	mssql::ReleaseBcpConnectionOnError(connection, pool_handle, transaction_pinned);
 }
 
 namespace mssql {

--- a/src/copy/target_resolver.cpp
+++ b/src/copy/target_resolver.cpp
@@ -953,6 +953,14 @@ vector<BCPColumnMetadata> TargetResolver::GenerateColumnMetadata(const vector<Lo
 			col.max_length = 9;	 // DECIMAL(20,0) needs 9 bytes
 		}
 
+		// Handle HUGEINT as DECIMAL(38,0) — #177 (SUM() aggregates return HUGEINT).
+		// COLMETADATA precision must match the codec's EncodeDecimal byte size.
+		if (source_types[i].id() == LogicalTypeId::HUGEINT) {
+			col.precision = 38;
+			col.scale = 0;
+			col.max_length = 17;  // DECIMAL(38,0) needs 17 bytes
+		}
+
 		// Handle scale for time types. Scale MUST match the source's native
 		// precision so the BCP wire COLMETADATA agrees with how the codec
 		// encodes the value (see codec::datetime::ComputeDatetime2Components +

--- a/src/dml/ctas/mssql_ctas_executor.cpp
+++ b/src/dml/ctas/mssql_ctas_executor.cpp
@@ -49,9 +49,48 @@ static void DebugLog(int level, const char *format, ...) {
 // CTASExecutionState::Initialize
 //===----------------------------------------------------------------------===//
 
+CTASExecutionState::~CTASExecutionState() {
+	// No-op on paths that already released (FlushBCP success/error, AddChunkBCP
+	// error). Fires only when the sink died without reaching those. Touch no
+	// ClientContext here (issue #178): can run on a worker thread.
+	ReleaseBCPConnectionOnError();
+}
+
+void CTASExecutionState::ReleaseBCPConnectionOnError() noexcept {
+	if (!connection) {
+		return;
+	}
+	// A CTAS that died mid-stream leaves the server awaiting bulk data on this
+	// session, so the connection is not reusable: closing it ends the session,
+	// rolls back the INSERT BULK transaction and drops the locks held on the
+	// target table. Returning it to the pool as-is would hand the next caller a
+	// connection stuck mid-bulk-load (observed as "Query timeout" on the next
+	// DDL statement).
+	auto conn_state = connection->GetState();
+	if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
+		try {
+			connection->Close();
+		} catch (...) {
+			// Ignore — the shared_ptr destructor closes the socket regardless.
+		}
+	}
+	if (auto pool = pool_handle.lock()) {
+		try {
+			connection->SetNeedsReset(true);
+			pool->Release(std::move(connection));
+		} catch (...) {
+			connection.reset();
+		}
+	} else {
+		// Catalog torn down — dropping is the safe failure mode.
+		connection.reset();
+	}
+}
+
 void CTASExecutionState::Initialize(MSSQLCatalog &catalog_ref, CTASTarget target_p, vector<CTASColumnDef> columns_p,
 									CTASConfig config_p) {
 	catalog = &catalog_ref;
+	pool_handle = catalog_ref.GetConnectionPoolHandle();
 	target = std::move(target_p);
 	columns = std::move(columns_p);
 	config = std::move(config_p);
@@ -475,44 +514,53 @@ void CTASExecutionState::AddChunkBCP(ClientContext &context, DataChunk &chunk) {
 	DebugLog(2, "AddChunkBCP: %llu rows (batch has %llu rows)", (unsigned long long)chunk_rows,
 			 (unsigned long long)bcp_rows_in_batch);
 
-	// Write rows to BCP writer
-	idx_t written = bcp_writer->WriteRows(chunk);
-	bcp_rows_in_batch += written;
-	rows_produced += written;
+	try {
+		// Write rows to BCP writer
+		idx_t written = bcp_writer->WriteRows(chunk);
+		bcp_rows_in_batch += written;
+		rows_produced += written;
 
-	// Check if we need to flush the batch
-	if (config.bcp_flush_rows > 0 && bcp_rows_in_batch >= config.bcp_flush_rows) {
-		DebugLog(1, "BCP batch threshold reached (%llu >= %llu), flushing", (unsigned long long)bcp_rows_in_batch,
-				 (unsigned long long)config.bcp_flush_rows);
+		// Check if we need to flush the batch
+		if (config.bcp_flush_rows > 0 && bcp_rows_in_batch >= config.bcp_flush_rows) {
+			DebugLog(1, "BCP batch threshold reached (%llu >= %llu), flushing", (unsigned long long)bcp_rows_in_batch,
+					 (unsigned long long)config.bcp_flush_rows);
 
-		// Flush current batch
-		idx_t confirmed = bcp_writer->FlushBatch(bcp_rows_in_batch);
-		rows_inserted += confirmed;
+			// Flush current batch
+			idx_t confirmed = bcp_writer->FlushBatch(bcp_rows_in_batch);
+			rows_inserted += confirmed;
 
-		// Reset for next batch
-		bcp_writer->ResetForNextBatch();
-		bcp_rows_in_batch = 0;
+			// Reset for next batch
+			bcp_writer->ResetForNextBatch();
+			bcp_rows_in_batch = 0;
 
-		// Re-execute INSERT BULK for next batch
-		auto &pool = catalog->GetConnectionPool();
-		string insert_bulk = "INSERT BULK " + bcp_target.GetFullyQualifiedName() + " (";
-		for (idx_t i = 0; i < bcp_columns.size(); i++) {
-			if (i > 0) {
-				insert_bulk += ", ";
+			// Re-execute INSERT BULK for next batch
+			string insert_bulk = "INSERT BULK " + bcp_target.GetFullyQualifiedName() + " (";
+			for (idx_t i = 0; i < bcp_columns.size(); i++) {
+				if (i > 0) {
+					insert_bulk += ", ";
+				}
+				insert_bulk += "[" + bcp_columns[i].name + "] ";
+				insert_bulk += bcp_columns[i].GetSQLServerTypeDeclaration();
 			}
-			insert_bulk += "[" + bcp_columns[i].name + "] ";
-			insert_bulk += bcp_columns[i].GetSQLServerTypeDeclaration();
-		}
-		insert_bulk += ")";
-		if (config.bcp_tablock) {
-			insert_bulk += " WITH (TABLOCK)";
-		}
+			insert_bulk += ")";
+			if (config.bcp_tablock) {
+				insert_bulk += " WITH (TABLOCK)";
+			}
 
-		auto result = MSSQLSimpleQuery::Execute(*connection, insert_bulk);
-		connection->TransitionState(tds::ConnectionState::Idle, tds::ConnectionState::Executing);
+			auto result = MSSQLSimpleQuery::Execute(*connection, insert_bulk);
+			connection->TransitionState(tds::ConnectionState::Idle, tds::ConnectionState::Executing);
 
-		// Write COLMETADATA for next batch
-		bcp_writer->WriteColmetadata();
+			// Write COLMETADATA for next batch
+			bcp_writer->WriteColmetadata();
+		}
+	} catch (...) {
+		// Row encode or batch flush failed mid-BCP-stream (e.g. the #177
+		// DECIMAL(38,0) range guard). Close and return the connection before
+		// the error propagates so the server rolls back the bulk load and
+		// releases its locks.
+		ReleaseBCPConnectionOnError();
+		bcp_writer.reset();
+		throw;
 	}
 }
 
@@ -551,13 +599,10 @@ void CTASExecutionState::FlushBCP(ClientContext &context) {
 
 		DebugLog(1, "BCP completed: %llu total rows transferred", (unsigned long long)rows_inserted);
 
-	} catch (std::exception &e) {
-		// Release connection on failure
-		if (connection) {
-			auto &pool = catalog->GetConnectionPool();
-			pool.Release(std::move(connection));
-			connection = nullptr;
-		}
+	} catch (std::exception &) {
+		// Release connection on failure. The stream died mid-bulk-load, so the
+		// connection must be closed, not reused (see ReleaseBCPConnectionOnError).
+		ReleaseBCPConnectionOnError();
 		bcp_writer.reset();
 		throw;
 	}

--- a/src/dml/ctas/mssql_ctas_executor.cpp
+++ b/src/dml/ctas/mssql_ctas_executor.cpp
@@ -1,6 +1,7 @@
 #include "dml/ctas/mssql_ctas_executor.hpp"
 #include "catalog/mssql_catalog.hpp"
 #include "catalog/mssql_ddl_translator.hpp"
+#include "connection/mssql_connection_provider.hpp"
 #include "copy/bcp_writer.hpp"
 #include "copy/target_resolver.hpp"
 #include "dml/insert/mssql_insert_executor.hpp"
@@ -57,34 +58,9 @@ CTASExecutionState::~CTASExecutionState() {
 }
 
 void CTASExecutionState::ReleaseBCPConnectionOnError() noexcept {
-	if (!connection) {
-		return;
-	}
-	// A CTAS that died mid-stream leaves the server awaiting bulk data on this
-	// session, so the connection is not reusable: closing it ends the session,
-	// rolls back the INSERT BULK transaction and drops the locks held on the
-	// target table. Returning it to the pool as-is would hand the next caller a
-	// connection stuck mid-bulk-load (observed as "Query timeout" on the next
-	// DDL statement).
-	auto conn_state = connection->GetState();
-	if (conn_state != tds::ConnectionState::Idle && conn_state != tds::ConnectionState::Disconnected) {
-		try {
-			connection->Close();
-		} catch (...) {
-			// Ignore — the shared_ptr destructor closes the socket regardless.
-		}
-	}
-	if (auto pool = pool_handle.lock()) {
-		try {
-			connection->SetNeedsReset(true);
-			pool->Release(std::move(connection));
-		} catch (...) {
-			connection.reset();
-		}
-	} else {
-		// Catalog torn down — dropping is the safe failure mode.
-		connection.reset();
-	}
+	// Shared mid-BCP release protocol (see ReleaseBcpConnectionOnError
+	// contract). CTAS never runs transaction-pinned.
+	ReleaseBcpConnectionOnError(connection, pool_handle, /*transaction_pinned=*/false);
 }
 
 void CTASExecutionState::Initialize(MSSQLCatalog &catalog_ref, CTASTarget target_p, vector<CTASColumnDef> columns_p,

--- a/src/include/codec/binary_codec.hpp
+++ b/src/include/codec/binary_codec.hpp
@@ -31,6 +31,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -45,6 +47,11 @@ namespace codec {
 namespace binary {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext ctx);

--- a/src/include/codec/binary_codec.hpp
+++ b/src/include/codec/binary_codec.hpp
@@ -51,7 +51,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext ctx);

--- a/src/include/codec/boolean_codec.hpp
+++ b/src/include/codec/boolean_codec.hpp
@@ -53,7 +53,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/boolean_codec.hpp
+++ b/src/include/codec/boolean_codec.hpp
@@ -33,6 +33,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -47,6 +49,11 @@ namespace codec {
 namespace boolean {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/datetime_codec.hpp
+++ b/src/include/codec/datetime_codec.hpp
@@ -48,6 +48,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -62,6 +64,11 @@ namespace codec {
 namespace datetime {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Single-Value overload for the BCPRowEncoder::EncodeValue public path.
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/datetime_codec.hpp
+++ b/src/include/codec/datetime_codec.hpp
@@ -68,7 +68,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Single-Value overload for the BCPRowEncoder::EncodeValue public path.
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/decimal_codec.hpp
+++ b/src/include/codec/decimal_codec.hpp
@@ -32,6 +32,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -46,6 +48,11 @@ namespace codec {
 namespace decimal {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext ctx);

--- a/src/include/codec/decimal_codec.hpp
+++ b/src/include/codec/decimal_codec.hpp
@@ -52,7 +52,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext ctx);

--- a/src/include/codec/float_codec.hpp
+++ b/src/include/codec/float_codec.hpp
@@ -64,7 +64,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/float_codec.hpp
+++ b/src/include/codec/float_codec.hpp
@@ -44,6 +44,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -58,6 +60,11 @@ namespace codec {
 namespace float_family {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/integer_codec.hpp
+++ b/src/include/codec/integer_codec.hpp
@@ -8,9 +8,10 @@
 // UBIGINT, HUGEINT.
 //
 // Special handling within Integer:
-//   - HUGEINT and UHUGEINT BCP encode are deferred to the Decimal family
-//     migration (spec 045 Phase 6); arms throw NotImplementedException
-//     for now, preserving the pre-spec-045 default-arm behavior.
+//   - HUGEINT and UHUGEINT BCP encode delegate to BCPRowEncoder::EncodeDecimal
+//     as DECIMAL(38,0) (issue #177 — SUM() aggregates return HUGEINT), with a
+//     client-side range guard: |v| > 10^38-1 (39 digits) cannot fit
+//     DECIMAL(38,0) and raises InvalidInputException naming the column.
 //   - UBIGINT BCP encode delegates to BCPRowEncoder::EncodeDecimal with
 //     (precision=20, scale=0) because BCP wire has no UNSIGNED BIGINT.
 //   - UTINYINT / USMALLINT / UINTEGER widen on encode.

--- a/src/include/codec/integer_codec.hpp
+++ b/src/include/codec/integer_codec.hpp
@@ -41,6 +41,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -55,6 +57,11 @@ namespace codec {
 namespace integer {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/integer_codec.hpp
+++ b/src/include/codec/integer_codec.hpp
@@ -61,7 +61,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/string_codec.hpp
+++ b/src/include/codec/string_codec.hpp
@@ -68,7 +68,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/string_codec.hpp
+++ b/src/include/codec/string_codec.hpp
@@ -48,6 +48,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -62,6 +64,11 @@ namespace codec {
 namespace string {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 // Overload for the single-Value path (BCPRowEncoder::EncodeValue public API).
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);

--- a/src/include/codec/type_family.hpp
+++ b/src/include/codec/type_family.hpp
@@ -41,6 +41,37 @@ enum class TypeFamily : uint8_t {
 	Uuid,
 };
 
+// Number of TypeFamily values. Anything sized per family (e.g. the D4 debug
+// counter arrays) must use this constant so adding a 10th family cannot
+// silently overflow a hand-sized [9] array.
+constexpr uint8_t TYPE_FAMILY_COUNT = 9;
+
+// Lower-case display name for a TypeFamily (D4 debug counter output).
+// Defined here, next to the enum, so name table and enum move in lockstep.
+inline const char *FamilyName(TypeFamily family) {
+	switch (family) {
+	case TypeFamily::Boolean:
+		return "boolean";
+	case TypeFamily::Integer:
+		return "integer";
+	case TypeFamily::Float:
+		return "float";
+	case TypeFamily::Decimal:
+		return "decimal";
+	case TypeFamily::Money:
+		return "money";
+	case TypeFamily::String:
+		return "string";
+	case TypeFamily::Binary:
+		return "binary";
+	case TypeFamily::DateTime:
+		return "datetime";
+	case TypeFamily::Uuid:
+		return "uuid";
+	}
+	return "unknown";
+}
+
 // Post-spec-045 both DdlContext values produce byte-identical T-SQL for
 // the same (LogicalType, CTASConfig) inputs (FR-024..FR-028). The enum
 // is retained for API uniformity across family `FormatDdlTypeName`

--- a/src/include/codec/uuid_codec.hpp
+++ b/src/include/codec/uuid_codec.hpp
@@ -30,6 +30,8 @@
 
 namespace duckdb {
 
+struct UnifiedVectorFormat;
+
 namespace tds {
 struct ColumnMetadata;
 }  // namespace tds
@@ -44,6 +46,11 @@ namespace codec {
 namespace uuid {
 
 void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata &col, Vector &out, idx_t row);
+// W1 (spec 054): format-threaded overload — fmt is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
+// wraps it for per-row callers (builds the format per call).
+void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
+                 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext ctx);

--- a/src/include/codec/uuid_codec.hpp
+++ b/src/include/codec/uuid_codec.hpp
@@ -50,7 +50,7 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 // chunk by BCPRowEncoder::EncodeChunk. The (Vector, row) overload below
 // wraps it for per-row callers (builds the format per call).
 void EncodeToBcp(Vector &in, const UnifiedVectorFormat &fmt, idx_t row, const mssql::BCPColumnMetadata &col,
-                 duckdb::vector<uint8_t> &buf);
+				 duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(Vector &in, idx_t row, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 void EncodeToBcp(const Value &value, const mssql::BCPColumnMetadata &col, duckdb::vector<uint8_t> &buf);
 std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralContext ctx);

--- a/src/include/codec/vector_format.hpp
+++ b/src/include/codec/vector_format.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB MSSQL Extension — spec 054
+//
+// codec/vector_format.hpp
+//
+// W1 (spec 054 D8): shared accessors for reading vector values through a
+// PRE-COMPUTED UnifiedVectorFormat. The format is built once per column per
+// chunk by BCPRowEncoder::EncodeChunk and threaded into every family
+// codec's EncodeToBcp — replacing the per-cell ToUnifiedFormat
+// reconstruction each family used to carry (the deleted GetVectorValue /
+// GetVectorBool / IsVectorNull helpers).
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/vector.hpp"
+
+namespace duckdb {
+namespace mssql {
+namespace codec {
+
+template <typename T>
+inline T FormatValue(const UnifiedVectorFormat &fmt, idx_t row) {
+	return UnifiedVectorFormat::GetData<T>(fmt)[fmt.sel->get_index(row)];
+}
+
+inline bool FormatIsNull(const UnifiedVectorFormat &fmt, idx_t row) {
+	return !fmt.validity.RowIsValid(fmt.sel->get_index(row));
+}
+
+}  // namespace codec
+}  // namespace mssql
+}  // namespace duckdb

--- a/src/include/codec/vector_format.hpp
+++ b/src/include/codec/vector_format.hpp
@@ -17,6 +17,9 @@
 
 namespace duckdb {
 namespace mssql {
+
+struct BCPColumnMetadata;
+
 namespace codec {
 
 template <typename T>
@@ -26,6 +29,21 @@ inline T FormatValue(const UnifiedVectorFormat &fmt, idx_t row) {
 
 inline bool FormatIsNull(const UnifiedVectorFormat &fmt, idx_t row) {
 	return !fmt.validity.RowIsValid(fmt.sel->get_index(row));
+}
+
+// Signature shared by every family's fmt-threaded EncodeToBcp overload.
+using BcpEncodeFmtFn = void (*)(Vector &, const UnifiedVectorFormat &, idx_t, const BCPColumnMetadata &,
+								duckdb::vector<uint8_t> &);
+
+// Per-row compat shim behind every family's EncodeToBcp(Vector&, idx_t, ...)
+// wrapper (unit-test API; production goes through BCPRowEncoder::EncodeChunk).
+// Keeps the format-construction protocol — the `row + 1` count — in ONE place
+// so no family can silently drift from the fmt-overload contract.
+inline void EncodeToBcpViaFormat(BcpEncodeFmtFn encode, Vector &in, idx_t row, const BCPColumnMetadata &col,
+								 duckdb::vector<uint8_t> &buf) {
+	UnifiedVectorFormat fmt;
+	in.ToUnifiedFormat(row + 1, fmt);
+	encode(in, fmt, row, col, buf);
 }
 
 }  // namespace codec

--- a/src/include/connection/mssql_connection_provider.hpp
+++ b/src/include/connection/mssql_connection_provider.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "duckdb/common/shared_ptr.hpp"
+
 #include <memory>
 
 namespace duckdb {
@@ -9,6 +11,7 @@ class MSSQLCatalog;
 
 namespace tds {
 class TdsConnection;
+class ConnectionPool;
 }  // namespace tds
 
 //===----------------------------------------------------------------------===//
@@ -70,5 +73,27 @@ public:
 	//! @return true if SQL Server transaction is active on pinned connection
 	static bool IsSqlServerTransactionActive(ClientContext &context, MSSQLCatalog &catalog);
 };
+
+namespace mssql {
+
+//! Release a connection that may have died mid-BCP bulk-load back to its pool.
+//! A COPY/CTAS that dies mid-stream leaves the server awaiting bulk data on
+//! the session, so the connection is closed first (ends the session, rolls
+//! back the INSERT BULK transaction, drops the target-table locks); returning
+//! it as-is would hand the next caller a connection stuck mid-bulk-load.
+//! Shared by ~MSSQLCopyGlobalState (issue #191) and
+//! CTASExecutionState::ReleaseBCPConnectionOnError — keep ONE copy of this
+//! protocol. Safe on worker threads (touches no ClientContext, issue #178);
+//! `connection` is always null on return.
+//! @param connection The (possibly mid-BCP) connection; reset on return
+//! @param pool_handle weak_ptr to the owning catalog's pool; a failed lock()
+//!        (catalog torn down) drops the connection instead
+//! @param transaction_pinned true if an MSSQLTransaction owns the pin — the
+//!        reference is dropped without a pool Release
+void ReleaseBcpConnectionOnError(std::shared_ptr<tds::TdsConnection> &connection,
+								 const duckdb::weak_ptr<tds::ConnectionPool> &pool_handle,
+								 bool transaction_pinned) noexcept;
+
+}  // namespace mssql
 
 }  // namespace duckdb

--- a/src/include/copy/bcp_writer.hpp
+++ b/src/include/copy/bcp_writer.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include "codec/type_family.hpp"
 #include "copy/target_resolver.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 
@@ -200,12 +201,12 @@ private:
 	// counts are precomputed once in the constructor.
 	bool counters_enabled_ = false;
 	uint64_t counter_chunks_ = 0;
-	uint64_t counter_values_per_family_[9] = {};
+	uint64_t counter_values_per_family_[codec::TYPE_FAMILY_COUNT] = {};
 	uint64_t counter_unknown_family_values_ = 0;
 	uint64_t counter_plp_values_ = 0;
 	uint64_t counter_utf16_fallbacks_ = 0;
 	uint64_t counter_write_rows_us_ = 0;
-	uint64_t family_col_count_[9] = {};	 // columns per family (per row)
+	uint64_t family_col_count_[codec::TYPE_FAMILY_COUNT] = {};	// columns per family (per row)
 	uint64_t unknown_family_col_count_ = 0;
 	uint64_t plp_col_count_ = 0;
 };

--- a/src/include/copy/bcp_writer.hpp
+++ b/src/include/copy/bcp_writer.hpp
@@ -44,6 +44,9 @@ public:
 	BCPWriter(tds::TdsConnection &conn, const BCPCopyTarget &target, vector<BCPColumnMetadata> columns,
 			  vector<int32_t> column_mapping = {});
 
+	// D4 (spec 054): prints the per-writer counter summary at MSSQL_DEBUG>=2.
+	~BCPWriter();
+
 	// Non-copyable
 	BCPWriter(const BCPWriter &) = delete;
 	BCPWriter &operator=(const BCPWriter &) = delete;
@@ -191,6 +194,23 @@ private:
 	// Used to send all data in a single message
 	// Note: Memory is released via swap trick in ResetForNextBatch()
 	vector<uint8_t> accumulator_buffer_;
+
+	// D4 (spec 054): per-writer debug counters, active only at MSSQL_DEBUG>=2
+	// (latched at construction). Mutated under write_mutex_ in WriteRows —
+	// plain integers, no extra atomics. values_per_family counts every
+	// (row × target column) encode INCLUDING NULLs (the NULL check happens
+	// inside BCPRowEncoder::EncodeRow, not visible here); family/PLP column
+	// counts are precomputed once in the constructor.
+	bool counters_enabled_ = false;
+	uint64_t counter_chunks_ = 0;
+	uint64_t counter_values_per_family_[9] = {};
+	uint64_t counter_unknown_family_values_ = 0;
+	uint64_t counter_plp_values_ = 0;
+	uint64_t counter_utf16_fallbacks_ = 0;
+	uint64_t counter_write_rows_us_ = 0;
+	uint64_t family_col_count_[9] = {};	 // columns per family (per row)
+	uint64_t unknown_family_col_count_ = 0;
+	uint64_t plp_col_count_ = 0;
 };
 
 }  // namespace mssql

--- a/src/include/copy/bcp_writer.hpp
+++ b/src/include/copy/bcp_writer.hpp
@@ -130,9 +130,6 @@ private:
 	// Build COLMETADATA token into buffer
 	void BuildColmetadataToken(vector<uint8_t> &buffer);
 
-	// Build ROW token for a single row into buffer
-	void BuildRowToken(vector<uint8_t> &buffer, DataChunk &chunk, idx_t row_idx);
-
 	// Build DONE token into buffer
 	void BuildDoneToken(vector<uint8_t> &buffer, idx_t row_count);
 

--- a/src/include/dml/ctas/mssql_ctas_executor.hpp
+++ b/src/include/dml/ctas/mssql_ctas_executor.hpp
@@ -8,6 +8,7 @@
 #include "dml/insert/mssql_insert_executor.hpp"
 #include "dml/insert/mssql_insert_target.hpp"
 #include "tds/tds_connection.hpp"
+#include "tds/tds_connection_pool.hpp"
 
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
@@ -75,6 +76,11 @@ struct CTASExecutionState {
 	// Connection (pinned for duration)
 	std::shared_ptr<tds::TdsConnection> connection;
 
+	// Weak handle to the catalog's pool so error/teardown paths can release the
+	// connection without touching the catalog pointer (issue #191 pattern from
+	// MSSQLCopyGlobalState; a failed lock() means the catalog is torn down).
+	weak_ptr<tds::ConnectionPool> pool_handle;
+
 	// Catalog reference for cache invalidation
 	MSSQLCatalog *catalog = nullptr;
 
@@ -86,6 +92,16 @@ struct CTASExecutionState {
 	std::chrono::steady_clock::time_point start_time;
 
 	CTASExecutionState() = default;
+
+	// Last-resort release of a connection left mid-BCP-stream by a sink error
+	// (mirrors MSSQLCopyGlobalState::~MSSQLCopyGlobalState, issue #191).
+	~CTASExecutionState();
+
+	// Close (if mid-stream) and return the BCP connection to the pool after an
+	// error. A connection abandoned mid-bulk-load must not be reused: closing
+	// the socket is what rolls back the INSERT BULK transaction server-side and
+	// drops the target-table locks. Safe to call repeatedly / with no connection.
+	void ReleaseBCPConnectionOnError() noexcept;
 
 	// Initialize for execution
 	void Initialize(MSSQLCatalog &catalog_ref, CTASTarget target_p, vector<CTASColumnDef> columns_p,

--- a/src/include/query/mssql_result_stream.hpp
+++ b/src/include/query/mssql_result_stream.hpp
@@ -206,11 +206,11 @@ private:
 		uint64_t nulls = 0;
 		uint64_t values_per_family[9] = {};	 // indexed by codec::TypeFamily
 		uint64_t unknown_family_values = 0;
-		uint64_t wire_bytes_in = 0;		 // TDS value bytes across all columns
-		uint64_t string_bytes_out = 0;	 // UTF-8 bytes written to string vectors
-		uint64_t plp_values = 0;		 // non-NULL values in PLP (MAX-typed) columns
-		uint64_t utf16_fallbacks = 0;	 // legacy-converter dispatches (invalid UTF-16)
-		uint64_t fill_total_us = 0;		 // wall time inside FillChunk, accumulated
+		uint64_t wire_bytes_in = 0;		// TDS value bytes across all columns
+		uint64_t string_bytes_out = 0;	// UTF-8 bytes written to string vectors
+		uint64_t plp_values = 0;		// non-NULL values in PLP (MAX-typed) columns
+		uint64_t utf16_fallbacks = 0;	// legacy-converter dispatches (invalid UTF-16)
+		uint64_t fill_total_us = 0;		// wall time inside FillChunk, accumulated
 		uint64_t fill_parse_us = 0;
 		uint64_t fill_read_us = 0;
 		uint64_t fill_process_us = 0;

--- a/src/include/query/mssql_result_stream.hpp
+++ b/src/include/query/mssql_result_stream.hpp
@@ -198,6 +198,38 @@ private:
 	// If non-empty, these vectors are used instead of chunk.data
 	vector<Vector *> target_vectors_;
 
+	// D4 (spec 054): per-stream debug counters, active only at MSSQL_DEBUG>=2
+	// (counters_enabled_ latched at construction). Plain integers — a stream
+	// is filled from one thread at a time. Printed once on destruction.
+	struct StreamDebugCounters {
+		uint64_t chunks = 0;
+		uint64_t nulls = 0;
+		uint64_t values_per_family[9] = {};	 // indexed by codec::TypeFamily
+		uint64_t unknown_family_values = 0;
+		uint64_t wire_bytes_in = 0;		 // TDS value bytes across all columns
+		uint64_t string_bytes_out = 0;	 // UTF-8 bytes written to string vectors
+		uint64_t plp_values = 0;		 // non-NULL values in PLP (MAX-typed) columns
+		uint64_t utf16_fallbacks = 0;	 // legacy-converter dispatches (invalid UTF-16)
+		uint64_t fill_total_us = 0;		 // wall time inside FillChunk, accumulated
+		uint64_t fill_parse_us = 0;
+		uint64_t fill_read_us = 0;
+		uint64_t fill_process_us = 0;
+	};
+
+	// Count one processed row into counters_ (called from ProcessRow when
+	// counters_enabled_; keeps the conversion hot loop untouched).
+	void CountRowForDebug(DataChunk &chunk, idx_t row_idx, idx_t cols_to_fill);
+
+	// Print the close summary to stderr (destructor, counters_enabled_ only).
+	void PrintDebugCounters();
+
+	bool counters_enabled_ = false;
+	StreamDebugCounters counters_;
+	// Per-column decode family (value = codec::TypeFamily, 0xFF = unknown)
+	// and PLP-ness, precomputed once after COLMETADATA.
+	std::vector<uint8_t> counter_col_family_;
+	std::vector<bool> counter_col_plp_;
+
 	// Timeouts
 	int read_timeout_ms_ = 30000;  // Normal read timeout (30 seconds)
 	// Cancel drain: read data as fast as possible, timeout runs in parallel

--- a/src/include/query/mssql_result_stream.hpp
+++ b/src/include/query/mssql_result_stream.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include "codec/type_family.hpp"
 #include "duckdb.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "tds/encoding/type_converter.hpp"
@@ -204,7 +205,7 @@ private:
 	struct StreamDebugCounters {
 		uint64_t chunks = 0;
 		uint64_t nulls = 0;
-		uint64_t values_per_family[9] = {};	 // indexed by codec::TypeFamily
+		uint64_t values_per_family[mssql::codec::TYPE_FAMILY_COUNT] = {};  // indexed by codec::TypeFamily
 		uint64_t unknown_family_values = 0;
 		uint64_t wire_bytes_in = 0;		// TDS value bytes across all columns
 		uint64_t string_bytes_out = 0;	// UTF-8 bytes written to string vectors

--- a/src/include/tds/encoding/bcp_row_encoder.hpp
+++ b/src/include/tds/encoding/bcp_row_encoder.hpp
@@ -35,8 +35,25 @@ public:
 	// Row-Level Encoding
 	//===----------------------------------------------------------------------===//
 
+	// Encode ALL rows of a DataChunk into buffer, one 0xD1 ROW token per row
+	// (token byte INCLUDED, unlike EncodeRow). W1+W2 (spec 054): per-column
+	// state — UnifiedVectorFormat, resolved family encoder, NULL wire kind —
+	// is hoisted once per chunk instead of being rebuilt per cell. This is
+	// the production write path (BCPWriter::WriteRows).
+	// @param buffer Output buffer (appended to)
+	// @param chunk Source DataChunk (chunk.size() rows are encoded)
+	// @param columns Column metadata for type information (target columns)
+	// @param column_mapping Optional mapping: mapping[target_idx] = source_idx, or -1 for NULL
+	//                       If nullptr, assumes 1:1 positional mapping
+	static void EncodeChunk(vector<uint8_t> &buffer, DataChunk &chunk,
+							const vector<mssql::BCPColumnMetadata> &columns,
+							const vector<int32_t> *column_mapping = nullptr);
+
 	// Encode a complete row from DataChunk into buffer
 	// Iterates columns and calls type-specific encoders
+	// Per-row compatibility path: rebuilds the per-column state (formats,
+	// encoder resolution) on every call — prefer EncodeChunk for whole-chunk
+	// encoding.
 	// @param buffer Output buffer (ROW token data, not including 0xD1)
 	// @param chunk Source DataChunk
 	// @param row_idx Row index within the chunk

--- a/src/include/tds/encoding/bcp_row_encoder.hpp
+++ b/src/include/tds/encoding/bcp_row_encoder.hpp
@@ -45,8 +45,7 @@ public:
 	// @param columns Column metadata for type information (target columns)
 	// @param column_mapping Optional mapping: mapping[target_idx] = source_idx, or -1 for NULL
 	//                       If nullptr, assumes 1:1 positional mapping
-	static void EncodeChunk(vector<uint8_t> &buffer, DataChunk &chunk,
-							const vector<mssql::BCPColumnMetadata> &columns,
+	static void EncodeChunk(vector<uint8_t> &buffer, DataChunk &chunk, const vector<mssql::BCPColumnMetadata> &columns,
 							const vector<int32_t> *column_mapping = nullptr);
 
 	// Encode a complete row from DataChunk into buffer

--- a/src/include/tds/encoding/utf16.hpp
+++ b/src/include/tds/encoding/utf16.hpp
@@ -54,6 +54,16 @@ size_t Utf16LEByteLength(const std::string &input);
 /// converter when `output` is not 2-byte aligned (defensive guard).
 size_t Utf16LEEncodeDirect(const char *input, size_t input_len, uint8_t *output);
 
+/// D4 debug counters (spec 054): number of conversions on THIS thread that
+/// took the legacy hand-rolled fallback instead of the simdutf fast path
+/// (invalid UTF input, plus the unaligned-output defensive guard in
+/// Utf16LEEncodeDirect). Thread-local so per-stream / per-writer deltas can
+/// be attributed without atomics: snapshot before a chunk, subtract after —
+/// each FillChunk / WriteRows call runs entirely on one thread. The sizing
+/// pass (Utf16LEByteLength) is deliberately NOT counted to avoid counting
+/// the same value twice on the size-then-encode path.
+uint64_t Utf16FallbackCount();
+
 //===----------------------------------------------------------------------===//
 // Test-only re-export of the private legacy hand-rolled converter.
 // Compiled only when MSSQL_BENCH_BUILD is defined (the microbenchmark and

--- a/src/include/tds/encoding/utf16.hpp
+++ b/src/include/tds/encoding/utf16.hpp
@@ -65,6 +65,19 @@ size_t Utf16LEByteLengthView(const char *input, size_t input_len, bool &valid_ut
 /// back to the scalar legacy converter. Returns bytes written.
 size_t Utf16LEEncodeValidDirect(const char *input, size_t input_len, uint8_t *output);
 
+/// R1 (spec 054): decode-side sized single-validation pair. Validates the
+/// UTF-16LE input once and returns the UTF-8 byte length the conversion
+/// will produce, or SIZE_MAX when the input is invalid (caller then uses
+/// the legacy Utf16LEDecode fallback, unchanged semantics). Unaligned
+/// `data` is handled via an internal scratch copy.
+size_t Utf8LengthFromUtf16LEView(const uint8_t *data, size_t byte_length);
+
+/// R1 (spec 054): convert KNOWN-VALID UTF-16LE (per a prior
+/// Utf8LengthFromUtf16LEView call on the same bytes) directly into `out`
+/// — no re-validation, no intermediate std::string. `out` needs capacity
+/// for the length that call returned. Returns bytes written.
+size_t Utf16LEDecodeValidInto(const uint8_t *data, size_t byte_length, char *out);
+
 /// Encode UTF-8 directly into a caller-owned output buffer. Returns the
 /// number of UTF-16LE bytes written. `output` must have capacity for at
 /// least `input_len * 2` bytes. Falls back to the private hand-rolled

--- a/src/include/tds/encoding/utf16.hpp
+++ b/src/include/tds/encoding/utf16.hpp
@@ -48,6 +48,23 @@ std::string Utf16LEDecode(const std::vector<uint8_t> &data);
 /// Equal to `Utf16LEEncode(input).size()` but avoids the allocation.
 size_t Utf16LEByteLength(const std::string &input);
 
+/// W3 (spec 054): sized single-validation variant. Returns the UTF-16LE
+/// byte length AND reports the validation verdict in one call, so the
+/// caller can follow up with Utf16LEEncodeValidDirect without re-validating
+/// (one validate + one length + one convert per value total). On invalid
+/// input `valid_utf8` is false and the returned length comes from the
+/// legacy hand-rolled counter — consistent with what the legacy encode
+/// fallback will then produce.
+size_t Utf16LEByteLengthView(const char *input, size_t input_len, bool &valid_utf8);
+
+/// W3 (spec 054): convert KNOWN-VALID UTF-8 (as established by a prior
+/// Utf16LEByteLengthView call on the same bytes) without re-validating.
+/// `output` needs capacity for the length that call returned. Unlike
+/// Utf16LEEncodeDirect, an unaligned `output` stays on the simdutf path
+/// (converted via a thread-local scratch and memcpy'd) instead of falling
+/// back to the scalar legacy converter. Returns bytes written.
+size_t Utf16LEEncodeValidDirect(const char *input, size_t input_len, uint8_t *output);
+
 /// Encode UTF-8 directly into a caller-owned output buffer. Returns the
 /// number of UTF-16LE bytes written. `output` must have capacity for at
 /// least `input_len * 2` bytes. Falls back to the private hand-rolled

--- a/src/include/tds/tds_connection_pool.hpp
+++ b/src/include/tds/tds_connection_pool.hpp
@@ -116,9 +116,13 @@ private:
 	std::queue<ConnectionMetadata> idle_connections_;
 	std::unordered_map<uint64_t, std::shared_ptr<TdsConnection>> active_connections_;
 
-	// Synchronization
+	// Synchronization. available_cv_ is reserved for Acquire() waiters —
+	// Release()'s notify_one must always reach a thread blocked on pool
+	// exhaustion. The cleanup thread parks on its own cleanup_cv_ (notified
+	// only by Shutdown()) so it can never consume that wakeup.
 	mutable std::mutex pool_mutex_;
 	std::condition_variable available_cv_;
+	std::condition_variable cleanup_cv_;
 
 	// Statistics
 	PoolStatistics stats_;

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -478,8 +478,6 @@ void MSSQLResultStream::CountRowForDebug(DataChunk &chunk, idx_t row_idx, idx_t 
 }
 
 void MSSQLResultStream::PrintDebugCounters() {
-	static const char *kFamilyNames[9] = {"boolean", "integer", "float",	"decimal", "money",
-										  "string",	 "binary",	"datetime", "uuid"};
 	fprintf(stderr,
 			"[MSSQL COUNTERS] stream close: rows=%llu chunks=%llu nulls=%llu wire_in=%lluB str_out=%lluB "
 			"plp=%llu utf16_fallback=%llu fill=%lluus (parse=%llu read=%llu process=%llu)\n",
@@ -489,10 +487,10 @@ void MSSQLResultStream::PrintDebugCounters() {
 			(unsigned long long)counters_.fill_total_us, (unsigned long long)counters_.fill_parse_us,
 			(unsigned long long)counters_.fill_read_us, (unsigned long long)counters_.fill_process_us);
 	std::string families;
-	for (int f = 0; f < 9; f++) {
+	for (uint8_t f = 0; f < mssql::codec::TYPE_FAMILY_COUNT; f++) {
 		if (counters_.values_per_family[f] > 0) {
 			families += " ";
-			families += kFamilyNames[f];
+			families += mssql::codec::FamilyName(static_cast<mssql::codec::TypeFamily>(f));
 			families += "=" + std::to_string(counters_.values_per_family[f]);
 		}
 	}

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -479,7 +479,7 @@ void MSSQLResultStream::CountRowForDebug(DataChunk &chunk, idx_t row_idx, idx_t 
 
 void MSSQLResultStream::PrintDebugCounters() {
 	static const char *kFamilyNames[9] = {"boolean", "integer", "float",	"decimal", "money",
-										  "string",  "binary",	"datetime", "uuid"};
+										  "string",	 "binary",	"datetime", "uuid"};
 	fprintf(stderr,
 			"[MSSQL COUNTERS] stream close: rows=%llu chunks=%llu nulls=%llu wire_in=%lluB str_out=%lluB "
 			"plp=%llu utf16_fallback=%llu fill=%lluus (parse=%llu read=%llu process=%llu)\n",

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -4,11 +4,13 @@
 #include <cstdlib>
 #include <iostream>
 #include "catalog/mssql_catalog.hpp"
+#include "codec/type_family.hpp"
 #include "connection/mssql_connection_provider.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "tds/encoding/type_converter.hpp"
+#include "tds/encoding/utf16.hpp"
 #include "tds/tds_packet.hpp"
 #include "tds/tds_socket.hpp"
 
@@ -45,7 +47,8 @@ MSSQLResultStream::MSSQLResultStream(std::shared_ptr<tds::TdsConnection> connect
 	  sql_(sql),
 	  state_(MSSQLResultStreamState::Initializing),
 	  is_cancelled_(false),
-	  rows_read_(0) {
+	  rows_read_(0),
+	  counters_enabled_(GetDebugLevel() >= 2) {
 	// Convert timeout from seconds to milliseconds
 	// 0 = no timeout (use INT_MAX for effectively infinite wait)
 	// Otherwise, multiply by 1000 to convert to milliseconds
@@ -57,6 +60,12 @@ MSSQLResultStream::MSSQLResultStream(std::shared_ptr<tds::TdsConnection> connect
 }
 
 MSSQLResultStream::~MSSQLResultStream() {
+	// D4 (spec 054): close summary. fprintf only — must stay safe on a worker
+	// thread (see the connection-release comment below).
+	if (counters_enabled_) {
+		PrintDebugCounters();
+	}
+
 	// If we're still in streaming state, try to cancel
 	if (state_ == MSSQLResultStreamState::Streaming) {
 		Cancel();
@@ -140,6 +149,24 @@ bool MSSQLResultStream::Initialize() {
 					column_types_.push_back(tds::encoding::TypeConverter::GetDuckDBType(col));
 				}
 
+				// D4 (spec 054): precompute per-column decode family + PLP-ness
+				// for the debug counters (FamilyFromTdsType is the same dispatch
+				// TypeConverter::ConvertValue uses per value).
+				if (counters_enabled_) {
+					counter_col_family_.clear();
+					counter_col_plp_.clear();
+					for (const auto &col : column_metadata_) {
+						uint8_t family = 0xFF;
+						try {
+							family = static_cast<uint8_t>(mssql::codec::FamilyFromTdsType(col.type_id));
+						} catch (...) {
+							// Unknown wire type — counted as unknown_family_values.
+						}
+						counter_col_family_.push_back(family);
+						counter_col_plp_.push_back(col.max_length == 0xFFFF);
+					}
+				}
+
 				row_reader_ = make_uniq<tds::RowReader>(parsed_columns);
 				state_ = MSSQLResultStreamState::Streaming;
 				return true;
@@ -220,6 +247,9 @@ idx_t MSSQLResultStream::FillChunk(DataChunk &chunk) {
 	uint64_t parse_time_us = 0;
 	uint64_t read_time_us = 0;
 	uint64_t process_time_us = 0;
+	// D4: snapshot the thread-local fallback counter; the delta at exit is
+	// this call's fallbacks (FillChunk runs entirely on one thread).
+	const uint64_t utf16_fallbacks_at_entry = counters_enabled_ ? tds::encoding::Utf16FallbackCount() : 0;
 
 	while (row_count < max_rows && state_ == MSSQLResultStreamState::Streaming) {
 		// Check for cancellation periodically
@@ -347,6 +377,17 @@ exit_loop:
 					(unsigned long long)row_count, (long)total_us, (long)parse_time_us, (long)read_time_us,
 					(long)process_time_us);
 
+	if (counters_enabled_) {
+		if (row_count > 0) {
+			counters_.chunks++;
+		}
+		counters_.fill_total_us += static_cast<uint64_t>(total_us);
+		counters_.fill_parse_us += parse_time_us;
+		counters_.fill_read_us += read_time_us;
+		counters_.fill_process_us += process_time_us;
+		counters_.utf16_fallbacks += tds::encoding::Utf16FallbackCount() - utf16_fallbacks_at_entry;
+	}
+
 	return row_count;
 }
 
@@ -394,6 +435,72 @@ void MSSQLResultStream::ProcessRow(DataChunk &chunk, idx_t row_idx) {
 
 		tds::encoding::TypeConverter::ConvertValue(row.values[col_idx], row.null_mask[col_idx],
 												   column_metadata_[col_idx], *target_vector, row_idx);
+	}
+
+	if (counters_enabled_) {
+		CountRowForDebug(chunk, row_idx, cols_to_fill);
+	}
+}
+
+void MSSQLResultStream::CountRowForDebug(DataChunk &chunk, idx_t row_idx, idx_t cols_to_fill) {
+	const auto &row = parser_.GetRow();
+	const auto string_family = static_cast<uint8_t>(mssql::codec::TypeFamily::String);
+	for (idx_t col_idx = 0; col_idx < cols_to_fill && col_idx < counter_col_family_.size(); col_idx++) {
+		counters_.wire_bytes_in += row.values[col_idx].size();
+		if (row.null_mask[col_idx]) {
+			counters_.nulls++;
+			continue;
+		}
+		const uint8_t family = counter_col_family_[col_idx];
+		if (family < 9) {
+			counters_.values_per_family[family]++;
+		} else {
+			counters_.unknown_family_values++;
+		}
+		if (counter_col_plp_[col_idx]) {
+			counters_.plp_values++;
+		}
+		if (family == string_family) {
+			// Same 3-way target resolution as the conversion loop above.
+			Vector *target_vector;
+			if (!target_vectors_.empty()) {
+				target_vector = target_vectors_[col_idx];
+			} else if (!output_column_mapping_.empty()) {
+				target_vector = &chunk.data[output_column_mapping_[col_idx]];
+			} else {
+				target_vector = &chunk.data[col_idx];
+			}
+			if (target_vector->GetType().InternalType() == PhysicalType::VARCHAR) {
+				counters_.string_bytes_out += FlatVector::GetData<string_t>(*target_vector)[row_idx].GetSize();
+			}
+		}
+	}
+}
+
+void MSSQLResultStream::PrintDebugCounters() {
+	static const char *kFamilyNames[9] = {"boolean", "integer", "float",	"decimal", "money",
+										  "string",  "binary",	"datetime", "uuid"};
+	fprintf(stderr,
+			"[MSSQL COUNTERS] stream close: rows=%llu chunks=%llu nulls=%llu wire_in=%lluB str_out=%lluB "
+			"plp=%llu utf16_fallback=%llu fill=%lluus (parse=%llu read=%llu process=%llu)\n",
+			(unsigned long long)rows_read_, (unsigned long long)counters_.chunks, (unsigned long long)counters_.nulls,
+			(unsigned long long)counters_.wire_bytes_in, (unsigned long long)counters_.string_bytes_out,
+			(unsigned long long)counters_.plp_values, (unsigned long long)counters_.utf16_fallbacks,
+			(unsigned long long)counters_.fill_total_us, (unsigned long long)counters_.fill_parse_us,
+			(unsigned long long)counters_.fill_read_us, (unsigned long long)counters_.fill_process_us);
+	std::string families;
+	for (int f = 0; f < 9; f++) {
+		if (counters_.values_per_family[f] > 0) {
+			families += " ";
+			families += kFamilyNames[f];
+			families += "=" + std::to_string(counters_.values_per_family[f]);
+		}
+	}
+	if (counters_.unknown_family_values > 0) {
+		families += " unknown=" + std::to_string(counters_.unknown_family_values);
+	}
+	if (!families.empty()) {
+		fprintf(stderr, "[MSSQL COUNTERS]   values/family:%s\n", families.c_str());
 	}
 }
 

--- a/src/tds/encoding/bcp_row_encoder.cpp
+++ b/src/tds/encoding/bcp_row_encoder.cpp
@@ -9,6 +9,7 @@
 #include "codec/string_codec.hpp"
 #include "codec/type_family.hpp"
 #include "codec/uuid_codec.hpp"
+#include "codec/vector_format.hpp"
 #include "copy/target_resolver.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -26,19 +27,6 @@ constexpr int32_t DAYS_FROM_0001_TO_EPOCH = 719162;
 // Microseconds per day
 constexpr int64_t MICROS_PER_DAY = 86400000000LL;
 
-//===----------------------------------------------------------------------===//
-// Helper: Get value from vector (handles both flat and constant vectors)
-//===----------------------------------------------------------------------===//
-
-template <typename T>
-static T GetVectorValue(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);	 // We only need format info, not count
-	auto data = UnifiedVectorFormat::GetData<T>(format);
-	auto idx = format.sel->get_index(row_idx);
-	return data[idx];
-}
-
 // Money family is decode-only (DuckDB has no MONEY LogicalType — SQL Server
 // MONEY/SMALLMONEY/MONEYN tokens surface as DECIMAL on decode). The Money arm
 // in BCP encode is a compile-required exhaustiveness placeholder + runtime
@@ -51,92 +39,142 @@ static T GetVectorValue(Vector &vec, idx_t row_idx) {
 		type.ToString());
 }
 
-static bool IsVectorNull(Vector &vec, idx_t row_idx) {
-	UnifiedVectorFormat format;
-	vec.ToUnifiedFormat(1, format);
-	auto idx = format.sel->get_index(row_idx);
-	return !format.validity.RowIsValid(idx);
+//===----------------------------------------------------------------------===//
+// W1+W2 (spec 054): per-column encode state, hoisted once per chunk.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// TDS BCP ROW token (written by EncodeChunk, one per row).
+constexpr uint8_t BCP_TOKEN_ROW = 0xD1;
+
+// Family encoder signature — the format-threaded codec overloads.
+using EncodeFn = void (*)(Vector &, const UnifiedVectorFormat &, idx_t, const mssql::BCPColumnMetadata &,
+						  vector<uint8_t> &);
+
+// Wire form of NULL for a column, resolved once (was an IsPLPType /
+// IsVariableLengthUSHORT branch pair per cell).
+enum class NullWireKind : uint8_t { Plp, VariableUShort, Fixed };
+
+[[noreturn]] static void EncodeMoneyUnreachable(Vector &vec, const UnifiedVectorFormat &, idx_t,
+												const mssql::BCPColumnMetadata &, vector<uint8_t> &) {
+	ThrowMoneyUnreachable(vec.GetType());
 }
 
+// W2: resolve the family encoder once per column (was a 9-way switch per row).
+EncodeFn ResolveEncoder(const mssql::BCPColumnMetadata &col) {
+	mssql::codec::TypeFamily family;
+	try {
+		family = mssql::codec::FamilyFromLogicalType(col.duckdb_type);
+	} catch (const NotImplementedException &) {
+		throw NotImplementedException("MSSQL: Unsupported type for BCP encoding: %s", col.duckdb_type.ToString());
+	}
+	switch (family) {
+	case mssql::codec::TypeFamily::Boolean:
+		return mssql::codec::boolean::EncodeToBcp;
+	case mssql::codec::TypeFamily::Integer:
+		return mssql::codec::integer::EncodeToBcp;
+	case mssql::codec::TypeFamily::Float:
+		return mssql::codec::float_family::EncodeToBcp;
+	case mssql::codec::TypeFamily::Decimal:
+		return mssql::codec::decimal::EncodeToBcp;
+	case mssql::codec::TypeFamily::String:
+		return mssql::codec::string::EncodeToBcp;
+	case mssql::codec::TypeFamily::Binary:
+		return mssql::codec::binary::EncodeToBcp;
+	case mssql::codec::TypeFamily::Uuid:
+		return mssql::codec::uuid::EncodeToBcp;
+	case mssql::codec::TypeFamily::DateTime:
+		return mssql::codec::datetime::EncodeToBcp;
+	case mssql::codec::TypeFamily::Money:
+		return EncodeMoneyUnreachable;
+	}
+	return EncodeMoneyUnreachable;	// unreachable — switch is exhaustive
+}
+
+struct ColumnEncodeState {
+	Vector *vec = nullptr;	// nullptr → source column missing: NULL every row
+	UnifiedVectorFormat fmt;
+	EncodeFn encode = nullptr;
+	NullWireKind null_kind = NullWireKind::Fixed;
+};
+
+void EncodeNullOfKind(vector<uint8_t> &buffer, NullWireKind kind) {
+	switch (kind) {
+	case NullWireKind::Plp:
+		BCPRowEncoder::EncodeNullPLP(buffer);
+		return;
+	case NullWireKind::VariableUShort:
+		BCPRowEncoder::EncodeNullVariable(buffer);
+		return;
+	case NullWireKind::Fixed:
+		BCPRowEncoder::EncodeNullFixed(buffer);
+		return;
+	}
+}
+
+// Build the hoisted per-column state. `format_count` is the row count the
+// UnifiedVectorFormat is computed for (chunk size for EncodeChunk; row+1 for
+// the per-row EncodeRow compatibility path).
+void PrepareColumnStates(DataChunk &chunk, idx_t format_count, const vector<mssql::BCPColumnMetadata> &columns,
+						 const vector<int32_t> *column_mapping, vector<ColumnEncodeState> &states) {
+	states.resize(columns.size());
+	for (idx_t target_idx = 0; target_idx < columns.size(); target_idx++) {
+		auto &col = columns[target_idx];
+		auto &state = states[target_idx];
+		state.null_kind = col.IsPLPType() ? NullWireKind::Plp
+										  : (col.IsVariableLengthUSHORT() ? NullWireKind::VariableUShort
+																		  : NullWireKind::Fixed);
+		// If source_idx is -1 or out of range, the column stays NULL for every row.
+		int32_t source_idx = column_mapping ? (*column_mapping)[target_idx] : static_cast<int32_t>(target_idx);
+		if (source_idx < 0 || static_cast<idx_t>(source_idx) >= chunk.ColumnCount()) {
+			continue;
+		}
+		state.vec = &chunk.data[source_idx];
+		state.vec->ToUnifiedFormat(format_count, state.fmt);
+		state.encode = ResolveEncoder(col);
+	}
+}
+
+// Encode one row from prepared states (no 0xD1 token byte).
+void EncodeRowFromStates(vector<uint8_t> &buffer, idx_t row_idx, const vector<mssql::BCPColumnMetadata> &columns,
+						 vector<ColumnEncodeState> &states) {
+	for (idx_t target_idx = 0; target_idx < columns.size(); target_idx++) {
+		auto &state = states[target_idx];
+		if (!state.vec || mssql::codec::FormatIsNull(state.fmt, row_idx)) {
+			EncodeNullOfKind(buffer, state.null_kind);
+			continue;
+		}
+		state.encode(*state.vec, state.fmt, row_idx, columns[target_idx], buffer);
+	}
+}
+
+}  // namespace
+
 //===----------------------------------------------------------------------===//
-// Row-Level Encoding
+// Chunk- and Row-Level Encoding
 //===----------------------------------------------------------------------===//
+
+void BCPRowEncoder::EncodeChunk(vector<uint8_t> &buffer, DataChunk &chunk,
+								const vector<mssql::BCPColumnMetadata> &columns,
+								const vector<int32_t> *column_mapping) {
+	const idx_t row_count = chunk.size();
+	if (row_count == 0) {
+		return;
+	}
+	vector<ColumnEncodeState> states;
+	PrepareColumnStates(chunk, row_count, columns, column_mapping, states);
+	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
+		buffer.push_back(BCP_TOKEN_ROW);
+		EncodeRowFromStates(buffer, row_idx, columns, states);
+	}
+}
 
 void BCPRowEncoder::EncodeRow(vector<uint8_t> &buffer, DataChunk &chunk, idx_t row_idx,
 							  const vector<mssql::BCPColumnMetadata> &columns, const vector<int32_t> *column_mapping) {
-	for (idx_t target_idx = 0; target_idx < columns.size(); target_idx++) {
-		auto &col = columns[target_idx];
-
-		// Determine source column index
-		// If column_mapping is provided, use it; otherwise assume 1:1 positional mapping
-		int32_t source_idx = column_mapping ? (*column_mapping)[target_idx] : static_cast<int32_t>(target_idx);
-
-		// If source_idx is -1 or out of range, encode NULL for this target column
-		if (source_idx < 0 || static_cast<idx_t>(source_idx) >= chunk.ColumnCount()) {
-			// Encode NULL based on type
-			if (col.IsPLPType()) {
-				EncodeNullPLP(buffer);
-			} else if (col.IsVariableLengthUSHORT()) {
-				EncodeNullVariable(buffer);
-			} else {
-				EncodeNullFixed(buffer);
-			}
-			continue;
-		}
-
-		auto &vec = chunk.data[source_idx];
-
-		// Check for NULL (handles both flat and constant vectors)
-		if (IsVectorNull(vec, row_idx)) {
-			// Encode NULL based on type
-			if (col.IsPLPType()) {
-				EncodeNullPLP(buffer);
-			} else if (col.IsVariableLengthUSHORT()) {
-				EncodeNullVariable(buffer);
-			} else {
-				EncodeNullFixed(buffer);
-			}
-			continue;
-		}
-
-		// Family-level dispatch — the per-type LogicalTypeId fan-out lives
-		// inside FamilyFromLogicalType (spec 045). FamilyFromLogicalType throws
-		// NotImplementedException for unsupported types; rethrow with BCP-specific message.
-		mssql::codec::TypeFamily family;
-		try {
-			family = mssql::codec::FamilyFromLogicalType(col.duckdb_type);
-		} catch (const NotImplementedException &) {
-			throw NotImplementedException("MSSQL: Unsupported type for BCP encoding: %s", col.duckdb_type.ToString());
-		}
-		switch (family) {
-		case mssql::codec::TypeFamily::Boolean:
-			mssql::codec::boolean::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::Integer:
-			mssql::codec::integer::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::Float:
-			mssql::codec::float_family::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::Decimal:
-			mssql::codec::decimal::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::String:
-			mssql::codec::string::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::Binary:
-			mssql::codec::binary::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::Uuid:
-			mssql::codec::uuid::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::DateTime:
-			mssql::codec::datetime::EncodeToBcp(vec, row_idx, col, buffer);
-			break;
-		case mssql::codec::TypeFamily::Money:
-			ThrowMoneyUnreachable(col.duckdb_type);
-		}
-	}
+	vector<ColumnEncodeState> states;
+	PrepareColumnStates(chunk, row_idx + 1, columns, column_mapping, states);
+	EncodeRowFromStates(buffer, row_idx, columns, states);
 }
 
 void BCPRowEncoder::EncodeValue(vector<uint8_t> &buffer, const Value &value, const mssql::BCPColumnMetadata &col) {

--- a/src/tds/encoding/bcp_row_encoder.cpp
+++ b/src/tds/encoding/bcp_row_encoder.cpp
@@ -179,7 +179,14 @@ void BCPRowEncoder::EncodeChunk(vector<uint8_t> &buffer, DataChunk &chunk,
 			per_row_estimate += 1 + col.max_length;
 		}
 	}
-	buffer.reserve(buffer.size() + row_count * per_row_estimate);
+	// Amplify to at least 2x the current capacity: reserve() allocates
+	// exactly what is requested, so asking for size+estimate every chunk
+	// would make capacity track size and memcpy the whole accumulator per
+	// chunk (quadratic across a large batch).
+	const size_t needed = buffer.size() + row_count * per_row_estimate;
+	if (needed > buffer.capacity()) {
+		buffer.reserve(MaxValue<size_t>(needed, 2 * buffer.capacity()));
+	}
 
 	vector<ColumnEncodeState> states;
 	PrepareColumnStates(chunk, row_count, columns, column_mapping, states);

--- a/src/tds/encoding/bcp_row_encoder.cpp
+++ b/src/tds/encoding/bcp_row_encoder.cpp
@@ -122,9 +122,9 @@ void PrepareColumnStates(DataChunk &chunk, idx_t format_count, const vector<mssq
 	for (idx_t target_idx = 0; target_idx < columns.size(); target_idx++) {
 		auto &col = columns[target_idx];
 		auto &state = states[target_idx];
-		state.null_kind = col.IsPLPType() ? NullWireKind::Plp
-										  : (col.IsVariableLengthUSHORT() ? NullWireKind::VariableUShort
-																		  : NullWireKind::Fixed);
+		state.null_kind = col.IsPLPType()
+							  ? NullWireKind::Plp
+							  : (col.IsVariableLengthUSHORT() ? NullWireKind::VariableUShort : NullWireKind::Fixed);
 		// If source_idx is -1 or out of range, the column stays NULL for every row.
 		int32_t source_idx = column_mapping ? (*column_mapping)[target_idx] : static_cast<int32_t>(target_idx);
 		if (source_idx < 0 || static_cast<idx_t>(source_idx) >= chunk.ColumnCount()) {
@@ -162,6 +162,25 @@ void BCPRowEncoder::EncodeChunk(vector<uint8_t> &buffer, DataChunk &chunk,
 	if (row_count == 0) {
 		return;
 	}
+
+	// W4 (spec 054): reserve the accumulator once per chunk from a cheap
+	// per-row estimate, so the per-value appends below rarely reallocate.
+	// Fixed-width columns are exact (+1 length byte); variable/PLP columns
+	// use a modest payload guess — an under-estimate only costs a vector
+	// grow, an exact max_length bound could over-reserve by orders of
+	// magnitude (2048 rows x nvarchar(4000) = 16 MB).
+	size_t per_row_estimate = 1;  // 0xD1 ROW token
+	for (auto &col : columns) {
+		if (col.IsPLPType()) {
+			per_row_estimate += 8 + 4 + 64 + 4;
+		} else if (col.IsVariableLengthUSHORT()) {
+			per_row_estimate += 2 + MinValue<size_t>(col.max_length, 64);
+		} else {
+			per_row_estimate += 1 + col.max_length;
+		}
+	}
+	buffer.reserve(buffer.size() + row_count * per_row_estimate);
+
 	vector<ColumnEncodeState> states;
 	PrepareColumnStates(chunk, row_count, columns, column_mapping, states);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {

--- a/src/tds/encoding/utf16.cpp
+++ b/src/tds/encoding/utf16.cpp
@@ -312,6 +312,15 @@ bool ValidateAlignedUtf16Le(const uint8_t *data, size_t byte_length, std::vector
 // Public simdutf-backed UTF-16LE conversion primitives.
 //===----------------------------------------------------------------------===//
 
+// D4 (spec 054): per-thread count of legacy-fallback conversions — see the
+// header comment on Utf16FallbackCount(). Incremented only on the fallback
+// (already-slow) path; never read on the fast path.
+static thread_local uint64_t utf16_fallback_count = 0;
+
+uint64_t Utf16FallbackCount() {
+	return utf16_fallback_count;
+}
+
 std::vector<uint8_t> Utf16LEEncode(const std::string &input) {
 	if (input.empty()) {
 		return {};
@@ -321,6 +330,7 @@ std::vector<uint8_t> Utf16LEEncode(const std::string &input) {
 	const size_t src_len = input.size();
 
 	if (!simdutf::validate_utf8(src, src_len)) {
+		utf16_fallback_count++;
 		return LegacyUtf16LEEncode(input);
 	}
 
@@ -342,12 +352,14 @@ size_t Utf16LEEncodeDirect(const char *input, size_t input_len, uint8_t *output)
 	}
 
 	if (!simdutf::validate_utf8(input, input_len)) {
+		utf16_fallback_count++;
 		return LegacyUtf16LEEncodeDirect(input, input_len, output);
 	}
 
 	// Defensive guard against unaligned output buffers; in practice every
 	// known call site passes a 2-byte-aligned destination.
 	if ((reinterpret_cast<uintptr_t>(output) & 0x1u) != 0u) {
+		utf16_fallback_count++;
 		return LegacyUtf16LEEncodeDirect(input, input_len, output);
 	}
 
@@ -375,6 +387,7 @@ std::string Utf16LEDecode(const uint8_t *data, size_t byte_length) {
 
 	std::vector<char16_t> aligned_scratch;
 	if (!ValidateAlignedUtf16Le(data, byte_length, aligned_scratch)) {
+		utf16_fallback_count++;
 		return LegacyUtf16LEDecode(data, byte_length);
 	}
 

--- a/src/tds/encoding/utf16.cpp
+++ b/src/tds/encoding/utf16.cpp
@@ -380,6 +380,42 @@ size_t Utf16LEByteLength(const std::string &input) {
 	return simdutf::utf16_length_from_utf8(input.data(), input.size()) * 2;
 }
 
+size_t Utf16LEByteLengthView(const char *input, size_t input_len, bool &valid_utf8) {
+	if (input_len == 0) {
+		valid_utf8 = true;
+		return 0;
+	}
+	valid_utf8 = simdutf::validate_utf8(input, input_len);
+	if (!valid_utf8) {
+		// NOT counted as a fallback here — the follow-up encode call counts
+		// it once (see the Utf16FallbackCount contract in the header).
+		return LegacyUtf16LEByteLength(std::string(input, input_len));
+	}
+	return simdutf::utf16_length_from_utf8(input, input_len) * 2;
+}
+
+size_t Utf16LEEncodeValidDirect(const char *input, size_t input_len, uint8_t *output) {
+	if (input_len == 0) {
+		return 0;
+	}
+	if ((reinterpret_cast<uintptr_t>(output) & 0x1u) == 0u) {
+		char16_t *out = reinterpret_cast<char16_t *>(output);
+		return simdutf::convert_valid_utf8_to_utf16le(input, input_len, out) * 2;
+	}
+	// Unaligned destination (odd offset inside a packet buffer): convert via
+	// a reused thread-local scratch, then memcpy. Stays on the simdutf path —
+	// the old Utf16LEEncodeDirect fell back to the scalar legacy converter
+	// here, which silently serialized ~half of all BCP string values through
+	// the slow path (buffer parity is arbitrary after variable-width tokens).
+	static thread_local std::vector<char16_t> scratch;
+	if (scratch.size() < input_len) {
+		scratch.resize(input_len);
+	}
+	const size_t units = simdutf::convert_valid_utf8_to_utf16le(input, input_len, scratch.data());
+	std::memcpy(output, scratch.data(), units * 2);
+	return units * 2;
+}
+
 std::string Utf16LEDecode(const uint8_t *data, size_t byte_length) {
 	if (byte_length == 0) {
 		return {};

--- a/src/tds/encoding/utf16.cpp
+++ b/src/tds/encoding/utf16.cpp
@@ -454,6 +454,49 @@ std::string Utf16LEDecode(const std::vector<uint8_t> &data) {
 	return Utf16LEDecode(data.data(), data.size());
 }
 
+size_t Utf8LengthFromUtf16LEView(const uint8_t *data, size_t byte_length) {
+	if (byte_length == 0) {
+		return 0;
+	}
+	const size_t code_units = byte_length / 2;
+	// TDS wire payloads come out of vector<uint8_t> (malloc-aligned), so the
+	// unaligned branch is defensive only.
+	if ((reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u) {
+		const char16_t *src = reinterpret_cast<const char16_t *>(data);
+		if (!simdutf::validate_utf16le(src, code_units)) {
+			// NOT counted as a fallback — the caller's legacy decode call
+			// counts it once (Utf16FallbackCount contract).
+			return SIZE_MAX;
+		}
+		return simdutf::utf8_length_from_utf16le(src, code_units);
+	}
+	static thread_local std::vector<char16_t> scratch;
+	if (scratch.size() < code_units) {
+		scratch.resize(code_units);
+	}
+	std::memcpy(scratch.data(), data, code_units * 2);
+	if (!simdutf::validate_utf16le(scratch.data(), code_units)) {
+		return SIZE_MAX;
+	}
+	return simdutf::utf8_length_from_utf16le(scratch.data(), code_units);
+}
+
+size_t Utf16LEDecodeValidInto(const uint8_t *data, size_t byte_length, char *out) {
+	if (byte_length == 0) {
+		return 0;
+	}
+	const size_t code_units = byte_length / 2;
+	if ((reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u) {
+		return simdutf::convert_valid_utf16le_to_utf8(reinterpret_cast<const char16_t *>(data), code_units, out);
+	}
+	static thread_local std::vector<char16_t> scratch;
+	if (scratch.size() < code_units) {
+		scratch.resize(code_units);
+	}
+	std::memcpy(scratch.data(), data, code_units * 2);
+	return simdutf::convert_valid_utf16le_to_utf8(scratch.data(), code_units, out);
+}
+
 //===----------------------------------------------------------------------===//
 // Test-only re-export of the private legacy hand-rolled converter.
 // Visible only when MSSQL_BENCH_BUILD is defined at compile time (the

--- a/src/tds/encoding/utf16.cpp
+++ b/src/tds/encoding/utf16.cpp
@@ -292,18 +292,37 @@ size_t LegacyUtf16LEEncodeDirect(const char *input, size_t input_len, uint8_t *o
 	return out_pos;
 }
 
-bool ValidateAlignedUtf16Le(const uint8_t *data, size_t byte_length, std::vector<char16_t> &scratch) {
-	if (byte_length == 0) {
-		return true;
+// Retention cap for the reusable per-thread scratch buffer, in char16_t
+// units (64K units = 128 KB per thread). Inputs above the cap are serviced
+// through the caller's local vector — freed at scope exit — so a single huge
+// nvarchar(max) value cannot pin ~2x its size in every worker thread for the
+// thread's remaining lifetime.
+constexpr size_t MAX_RETAINED_SCRATCH_UNITS = 64 * 1024;
+
+// Pick the scratch buffer for `units` char16_t: the grow-only per-thread
+// buffer below the retention cap, else the caller's `local`. The returned
+// buffer has size() >= units.
+std::vector<char16_t> &ScratchFor(size_t units, std::vector<char16_t> &local) {
+	static thread_local std::vector<char16_t> retained;
+	std::vector<char16_t> &chosen = units <= MAX_RETAINED_SCRATCH_UNITS ? retained : local;
+	if (chosen.size() < units) {
+		chosen.resize(units);
 	}
-	const bool aligned = (reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u;
-	const size_t code_units = byte_length / 2;
-	if (aligned) {
-		return simdutf::validate_utf16le(reinterpret_cast<const char16_t *>(data), code_units);
+	return chosen;
+}
+
+// Return a 2-byte-aligned char16_t view of `data` (code_units > 0). Aligned
+// input is returned directly; unaligned input is copied into a scratch
+// buffer (thread-local under the retention cap, else `local`) first. The
+// view is valid until the next ScratchFor/AlignedUtf16View call on this
+// thread or until `local` is destroyed, whichever the copy landed in.
+const char16_t *AlignedUtf16View(const uint8_t *data, size_t code_units, std::vector<char16_t> &local) {
+	if ((reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u) {
+		return reinterpret_cast<const char16_t *>(data);
 	}
-	scratch.resize(code_units);
+	std::vector<char16_t> &scratch = ScratchFor(code_units, local);
 	std::memcpy(scratch.data(), data, code_units * 2);
-	return simdutf::validate_utf16le(scratch.data(), code_units);
+	return scratch.data();
 }
 
 }  // anonymous namespace
@@ -403,14 +422,12 @@ size_t Utf16LEEncodeValidDirect(const char *input, size_t input_len, uint8_t *ou
 		return simdutf::convert_valid_utf8_to_utf16le(input, input_len, out) * 2;
 	}
 	// Unaligned destination (odd offset inside a packet buffer): convert via
-	// a reused thread-local scratch, then memcpy. Stays on the simdutf path —
-	// the old Utf16LEEncodeDirect fell back to the scalar legacy converter
-	// here, which silently serialized ~half of all BCP string values through
-	// the slow path (buffer parity is arbitrary after variable-width tokens).
-	static thread_local std::vector<char16_t> scratch;
-	if (scratch.size() < input_len) {
-		scratch.resize(input_len);
-	}
+	// a scratch buffer, then memcpy. Stays on the simdutf path — the old
+	// Utf16LEEncodeDirect fell back to the scalar legacy converter here, which
+	// silently serialized ~half of all BCP string values through the slow
+	// path (buffer parity is arbitrary after variable-width tokens).
+	std::vector<char16_t> local;
+	std::vector<char16_t> &scratch = ScratchFor(input_len, local);
 	const size_t units = simdutf::convert_valid_utf8_to_utf16le(input, input_len, scratch.data());
 	std::memcpy(output, scratch.data(), units * 2);
 	return units * 2;
@@ -421,23 +438,12 @@ std::string Utf16LEDecode(const uint8_t *data, size_t byte_length) {
 		return {};
 	}
 
-	std::vector<char16_t> aligned_scratch;
-	if (!ValidateAlignedUtf16Le(data, byte_length, aligned_scratch)) {
+	const size_t code_units = byte_length / 2;
+	std::vector<char16_t> local;
+	const char16_t *src = AlignedUtf16View(data, code_units, local);
+	if (!simdutf::validate_utf16le(src, code_units)) {
 		utf16_fallback_count++;
 		return LegacyUtf16LEDecode(data, byte_length);
-	}
-
-	const size_t code_units = byte_length / 2;
-	const char16_t *src;
-	std::vector<char16_t> copy;
-	if ((reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u) {
-		src = reinterpret_cast<const char16_t *>(data);
-	} else if (!aligned_scratch.empty()) {
-		src = aligned_scratch.data();
-	} else {
-		copy.resize(code_units);
-		std::memcpy(copy.data(), data, code_units * 2);
-		src = copy.data();
 	}
 
 	const size_t out_bytes = simdutf::utf8_length_from_utf16le(src, code_units);
@@ -460,25 +466,15 @@ size_t Utf8LengthFromUtf16LEView(const uint8_t *data, size_t byte_length) {
 	}
 	const size_t code_units = byte_length / 2;
 	// TDS wire payloads come out of vector<uint8_t> (malloc-aligned), so the
-	// unaligned branch is defensive only.
-	if ((reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u) {
-		const char16_t *src = reinterpret_cast<const char16_t *>(data);
-		if (!simdutf::validate_utf16le(src, code_units)) {
-			// NOT counted as a fallback — the caller's legacy decode call
-			// counts it once (Utf16FallbackCount contract).
-			return SIZE_MAX;
-		}
-		return simdutf::utf8_length_from_utf16le(src, code_units);
-	}
-	static thread_local std::vector<char16_t> scratch;
-	if (scratch.size() < code_units) {
-		scratch.resize(code_units);
-	}
-	std::memcpy(scratch.data(), data, code_units * 2);
-	if (!simdutf::validate_utf16le(scratch.data(), code_units)) {
+	// unaligned copy inside AlignedUtf16View is defensive only.
+	std::vector<char16_t> local;
+	const char16_t *src = AlignedUtf16View(data, code_units, local);
+	if (!simdutf::validate_utf16le(src, code_units)) {
+		// NOT counted as a fallback — the caller's legacy decode call
+		// counts it once (Utf16FallbackCount contract).
 		return SIZE_MAX;
 	}
-	return simdutf::utf8_length_from_utf16le(scratch.data(), code_units);
+	return simdutf::utf8_length_from_utf16le(src, code_units);
 }
 
 size_t Utf16LEDecodeValidInto(const uint8_t *data, size_t byte_length, char *out) {
@@ -486,15 +482,9 @@ size_t Utf16LEDecodeValidInto(const uint8_t *data, size_t byte_length, char *out
 		return 0;
 	}
 	const size_t code_units = byte_length / 2;
-	if ((reinterpret_cast<uintptr_t>(data) & 0x1u) == 0u) {
-		return simdutf::convert_valid_utf16le_to_utf8(reinterpret_cast<const char16_t *>(data), code_units, out);
-	}
-	static thread_local std::vector<char16_t> scratch;
-	if (scratch.size() < code_units) {
-		scratch.resize(code_units);
-	}
-	std::memcpy(scratch.data(), data, code_units * 2);
-	return simdutf::convert_valid_utf16le_to_utf8(scratch.data(), code_units, out);
+	std::vector<char16_t> local;
+	const char16_t *src = AlignedUtf16View(data, code_units, local);
+	return simdutf::convert_valid_utf16le_to_utf8(src, code_units, out);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/tds/tds_connection_pool.cpp
+++ b/src/tds/tds_connection_pool.cpp
@@ -73,8 +73,14 @@ void ConnectionPool::Shutdown() {
 	// even if the trailing assert later throws.
 	const size_t leaked = active_connections_.size();
 
-	// Signal shutdown
-	shutdown_flag_.store(true);
+	// Signal shutdown. The flag is set under pool_mutex_ so the cleanup
+	// thread cannot check it (false) and then enter its cv wait AFTER the
+	// notify below — that missed-wakeup race would put the join back on the
+	// 1-second wait_for timeout.
+	{
+		std::lock_guard<std::mutex> signal_lock(pool_mutex_);
+		shutdown_flag_.store(true);
+	}
 
 	// Wake up cleanup thread
 	available_cv_.notify_all();
@@ -333,8 +339,15 @@ bool ConnectionPool::ValidateConnection(std::shared_ptr<TdsConnection> &conn) {
 
 void ConnectionPool::CleanupThreadFunc() {
 	while (!shutdown_flag_.load()) {
-		// Sleep for 1 second between cleanup cycles
-		std::this_thread::sleep_for(std::chrono::seconds(1));
+		// Wait up to 1 second between cleanup cycles. Waits on available_cv_
+		// (which Shutdown() notifies) instead of a blind sleep: ~ConnectionPool
+		// joins this thread, so a plain sleep_for(1s) here made every DETACH /
+		// catalog teardown — and with it every short-lived CLI session — pay up
+		// to a full second before the pool could shut down.
+		{
+			std::unique_lock<std::mutex> wait_lock(pool_mutex_);
+			available_cv_.wait_for(wait_lock, std::chrono::seconds(1), [this] { return shutdown_flag_.load(); });
+		}
 
 		if (shutdown_flag_.load()) {
 			break;

--- a/src/tds/tds_connection_pool.cpp
+++ b/src/tds/tds_connection_pool.cpp
@@ -82,7 +82,8 @@ void ConnectionPool::Shutdown() {
 		shutdown_flag_.store(true);
 	}
 
-	// Wake up cleanup thread
+	// Wake up cleanup thread (its own CV) and any Acquire() waiters.
+	cleanup_cv_.notify_all();
 	available_cv_.notify_all();
 
 	// Wait for cleanup thread to finish (do this BEFORE the assert that may
@@ -339,14 +340,16 @@ bool ConnectionPool::ValidateConnection(std::shared_ptr<TdsConnection> &conn) {
 
 void ConnectionPool::CleanupThreadFunc() {
 	while (!shutdown_flag_.load()) {
-		// Wait up to 1 second between cleanup cycles. Waits on available_cv_
+		// Wait up to 1 second between cleanup cycles. Waits on cleanup_cv_
 		// (which Shutdown() notifies) instead of a blind sleep: ~ConnectionPool
 		// joins this thread, so a plain sleep_for(1s) here made every DETACH /
 		// catalog teardown — and with it every short-lived CLI session — pay up
-		// to a full second before the pool could shut down.
+		// to a full second before the pool could shut down. Must NOT wait on
+		// available_cv_: a predicated wait there consumes Release()'s
+		// notify_one meant for a pool-exhausted Acquire() waiter.
 		{
 			std::unique_lock<std::mutex> wait_lock(pool_mutex_);
-			available_cv_.wait_for(wait_lock, std::chrono::seconds(1), [this] { return shutdown_flag_.load(); });
+			cleanup_cv_.wait_for(wait_lock, std::chrono::seconds(1), [this] { return shutdown_flag_.load(); });
 		}
 
 		if (shutdown_flag_.load()) {

--- a/test/bench/bench_extension_config.cmake
+++ b/test/bench/bench_extension_config.cmake
@@ -1,0 +1,11 @@
+# Spec 054 D2: benchmark-only extension config.
+#
+# Loads TPC-H (dbgen) for the e2e materialization benches
+# (test/bench/bench_tpch_e2e.sh). This file is appended to
+# DUCKDB_EXTENSION_CONFIGS by `make bench-build` via the ci-tools
+# EXTRA_EXTENSION_CONFIGS hook.
+#
+# It must NEVER be referenced from extension_config.cmake — that file ships
+# to DuckDB community-extension builds, and tpch has no place there.
+
+duckdb_extension_load(tpch)

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -224,6 +224,34 @@ Reading of the delta:
   noise, per the baseline note. Full D3 re-run happens after all D8 wins
   (T12) against the recorded constants.
 
+## Delta — W3+W4 single-pass NVARCHAR encode + accumulator reserve (T10, 2026-07-28)
+
+W3: `EncodeNVarcharFromUtf8` now validates + measures ONCE per value
+(`Utf16LEByteLengthView`) and converts with no re-validation
+(`Utf16LEEncodeValidDirect`); the per-value temporary `std::string` in the
+FR-023 check is gone, and the valid path appends at the exact final size
+(length prefix up front — no oversize-resize-then-shrink). Bonus: an
+unaligned destination now stays on the simdutf path via a thread-local
+scratch — the old code silently sent ~half of all BCP string values
+through the scalar legacy converter (buffer parity after variable-width
+tokens is arbitrary). Invalid UTF-8 keeps the legacy flow bit-for-bit;
+FR-023 wording unchanged. W4: `EncodeChunk` reserves the accumulator once
+per chunk from a per-row column estimate (fixed widths exact, modest
+guess for variable/PLP).
+
+nvarchar16 hoisted cells (ns/value): flat 27.4 → 22.9, dict100 28.1 →
+22.9, const 27.6 → 22.6, null50 15.7 → 14.0. Cumulative vs the pre-W1
+baseline: 37.7 → 22.9 = 1.65× on short-ASCII cells — the bench matrix is
+ASCII-16 only; the unaligned/simdutf fix should show larger effects on
+long or non-ASCII payloads (not separately benched here). Non-string
+cells unchanged (within noise) as expected.
+
+e2e (same-session alternating medians-of-3, SF 0.1): copy_customer −3.8%,
+copy_part −2.8%, copy_lineitem −1.8%, scans flat; no step regressed
+beyond noise. Verified: unit tests + full SQL suite green (incl. the
+FR-023 wording test), `diff_check.sh` pre-T10 vs post-T10 build 13/13
+byte-identical (incl. the BCP write-back and its Cyrillic payloads).
+
 ## e2e — TPC-H baseline (median of 3 full runs, SF 0.01 / 0.1 / 1, 2026-07-28)
 
 `test/bench/bench_tpch_e2e.sh`, tree commit `722caf8`, 3 sequential full

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -15,6 +15,7 @@ Status of the baseline capture (D6):
 | Micro: bcp-encode group, macOS ARM64 | captured below (2026-07-28) |
 | Micro: Linux x86_64 run | pending — needs a real x86_64 host (QEMU-on-ARM timing is meaningless); run `make bench-build && make bench-materialize` on a Linux box or CI runner |
 | e2e: TPC-H SF 0.01/0.1/1 median-of-3 | captured below (2026-07-28) |
+| Final phase-0 delta (T12): full D1+D3 re-run, gate check | captured below (2026-07-28) — gate PASS |
 | Pre-merge: release comparison — TPC-H on SQL Server, lineitem ≥ 10M rows (SF 2), query steps from DuckDB, current release (v0.2.2) vs new build, median-of-≥3 | pending (gates the phase-0 merge) |
 
 ## Environment (macOS reference machine)
@@ -297,6 +298,60 @@ Reading of the delta:
   Verified: unit + full SQL suite green; diff_check pre-T11 vs post-T11
   13/13 byte-identical (incl. NCHAR trailing-space trim and empty-vs-NULL
   MAX cells).
+
+## Final phase-0 delta (T12, 2026-07-28) — after W1+W2, W3+W4, R1
+
+Full D1 + D3 re-run on the final tree (`c29202f`). **Acceptance gate
+(criterion 6: no step regresses > 3%): PASS** — see the drift analysis
+below; every flagged step was re-measured with same-session interleaved
+A/B against the pre-W1 build and came back flat or improved.
+
+Micro, final state (ns/value; baseline → final):
+
+- BCP encode (hoisted production path): bigint flat 18.3 → 8.2–9.1
+  (~2.2×); dict cells 22.9–23.6 → 8.3–8.6 (~2.8×, penalty gone); NULL
+  floor 6.9 → 3.6–3.9; nvarchar16 37.7 → 22.4–23.8 (~1.6×); decimal18s6
+  23.5 → 11.4–11.9 (~2×).
+- String decode: len32 45.7 → 17.9 (2.6×), len64 2.0×, len256 1.5×,
+  non-ASCII ~2× (see the T11 table for the full matrix).
+- Fixed decode: unchanged (path untouched this phase) — DECIMAL at
+  17.5/34.2/78.7 ns remains the top phase-1 target.
+
+e2e, final medians-of-3 (seconds; recorded-baseline → final):
+
+| step | SF 0.01 | SF 0.1 | SF 1 |
+| --- | --- | --- | --- |
+| copy_lineitem | 0.724 → 0.730 | 6.683 → 6.630 | 65.899 → 65.946 |
+| copy_orders | 0.199 → 0.205 | 1.440 → 1.517 | 13.643 → 13.833 |
+| copy_part | 0.083 → 0.081 | 0.305 → 0.297 | 2.361 → 2.627 |
+| copy_customer | 0.072 → 0.069 | 0.239 → 0.233 | 1.743 → 1.891 |
+| copy_sum_agg | 0.056 → 0.052 | 0.065 → 0.053 | 0.061 → 0.066 |
+| scan_full_lineitem | 0.169 → 0.165 | 1.221 → 1.222 | 11.667 → 12.519 |
+| scan_strings | 0.060 → 0.061 | 0.123 → 0.149 | 0.437 → 0.513 |
+| scan_lowcard | 0.078 → 0.079 | 0.337 → 0.344 | 3.041 → 2.975 |
+| scan_limit | 0.054 → 0.052 | 0.052 → 0.050 | 0.051 → 0.052 |
+| q1_local | 0.132 → 0.131 | 0.516 → 0.528 | 4.418 → 4.492 |
+| q6_local | 0.143 → 0.146 | 0.119 → 0.118 | 0.252 → 0.251 |
+
+Drift analysis (why the cross-session table above cannot be read as a
+gate by itself): the recorded constants were captured in a different
+server/host session; the same-session interleaved SF 1 control
+(3 alternating pre-W1 / final pairs) shows **copy_lineitem −5.6%,
+copy_orders −4.8%, scan_full_lineitem −1.8%, scan_lowcard −0.4%** — the
+apparent +7–11% flags on scan_full / copy_part above are cross-session
+drift. copy_customer flagged +14.9% even interleaved (high post-run
+variance 1.86–2.27 s), so it got a targeted alternating A/B (5 pairs,
+customer copy only): pre median 1.780 s vs final 1.804 s = **+1.3%,
+noise** (the one 2.36 s outlier landed on the PRE side). Sub-300 ms
+steps (scan_strings, copy_sum_agg, q6) swing ±20% in both directions on
+untouched code paths and are smoke-only, per the baseline note.
+
+Phase-0 summary: client-side encode 1.6–2.8× faster per value, string
+decode 1.5–2.6× past the inline threshold, byte-identical wire output
+end to end (diff_check at every step), no e2e regression. e2e stays
+server-dominated as predicted — the wins show as modest improvements on
+the largest copy steps and become load-bearing at higher client
+concurrency / faster servers.
 
 ## e2e — TPC-H baseline (median of 3 full runs, SF 0.01 / 0.1 / 1, 2026-07-28)
 

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -11,7 +11,8 @@ Status of the baseline capture (D6):
 | piece | status |
 | --- | --- |
 | Micro: string-decode group, macOS ARM64 | captured below (2026-07-28) |
-| Micro: fixed-decode + bcp-encode groups | pending (T6) |
+| Micro: fixed-decode group, macOS ARM64 | captured below (2026-07-28) |
+| Micro: bcp-encode group, macOS ARM64 | captured below (2026-07-28) |
 | Micro: Linux x86_64 run | pending (T7) |
 | e2e: TPC-H SF 0.01/0.1/1 median-of-≥3 | pending (T7; single smoke run noted below) |
 | Pre-merge: release comparison — TPC-H on SQL Server, lineitem ≥ 10M rows (SF 2), query steps from DuckDB, current release (v0.2.2) vs new build, median-of-≥3 | pending (gates the phase-0 merge) |
@@ -22,6 +23,8 @@ Status of the baseline capture (D6):
 - Compiler: Apple clang 17.0.0 (clang-1700.0.13.5), `-O3 -DMSSQL_BENCH_BUILD`
 - DuckDB: v1.5.5 (pinned submodule), release `libduckdb`; simdutf 6.1.1 (vcpkg release)
 - Tree: branch `spec/054-simd-baseline-quick-wins`, commit `703795d` + T1 harness
+  (string/fixed-decode groups); bcp-encode group captured at `46eb3e6` + T6p2
+  working tree
 - Invocation: `GEN=ninja make bench-materialize`
 - SQL Server (e2e smoke): mcr.microsoft.com/mssql/server:2022-latest (amd64,
   emulated) in Docker 28.5.1, localhost
@@ -101,6 +104,68 @@ kernels there. DATETIME2 is moderate (5.4 ns). **DECIMAL is the outlier**:
 17–82 ns/value, 10–45× the integer path, scaling with mantissa width
 (`ConvertDecimal`'s per-value big-number assembly) — the highest-value
 fixed-decode target for the phase-1 staging work.
+
+## Micro — BCP encode, CURRENT path (baseline, 2026-07-28)
+
+The production write shape: one `BCPRowEncoder::EncodeRow` call per row
+(family dispatch; `ToUnifiedFormat(1, …)` per cell in BOTH the NULL check and
+the codec value read) into one reused buffer (`clear()` keeps capacity, like
+the per-batch packet buffer). 2048-row single-column chunks; median/p10/p90
+of 400 chunk encodes. Dictionary inputs built with
+`Vector::Dictionary(dict, dict_size, sel, count)` — the construction the
+phase-2 scan will emit and phase-3 will detect via
+`DictionaryVector::DictionarySize`; NULL rows in dict cells point at a
+trailing NULL child slot. Correctness: byte-identical to a per-row
+`GetValue` + Value-encoder reference (DECIMAL referenced against the raw
+mantissa — the Value overload is documented legacy-divergent there, see
+`codec::decimal::EncodeToBcp(Value...)`).
+
+| cell | µs/chunk (median) | p10 | p90 | ns/value | wire out B |
+| --- | --- | --- | --- | --- | --- |
+| bigint_flat_unique | 37.5 | 36.8 | 41.5 | 18.3 | 18432 |
+| bigint_flat_card10 | 37.5 | 37.5 | 39.7 | 18.3 | 18432 |
+| bigint_dict1 | 46.9 | 46.6 | 49.8 | 22.9 | 18432 |
+| bigint_dict10 | 47.7 | 47.3 | 50.5 | 23.3 | 18432 |
+| bigint_dict100 | 48.4 | 47.5 | 53.0 | 23.6 | 18432 |
+| bigint_const | 30.2 | 29.9 | 33.3 | 14.8 | 18432 |
+| bigint_flat_unique_null50 | 30.2 | 29.4 | 33.2 | 14.7 | 10048 |
+| bigint_dict100_null50 | 37.9 | 36.5 | 41.0 | 18.5 | 10048 |
+| bigint_const_null | 14.2 | 14.2 | 14.3 | 6.9 | 2048 |
+| nvarchar16_flat_unique | 77.3 | 69.8 | 84.0 | 37.7 | 69632 |
+| nvarchar16_flat_card10 | 77.5 | 77.2 | 83.0 | 37.9 | 69632 |
+| nvarchar16_dict1 | 83.2 | 81.3 | 88.0 | 40.6 | 69632 |
+| nvarchar16_dict10 | 83.7 | 77.7 | 87.8 | 40.9 | 69632 |
+| nvarchar16_dict100 | 82.6 | 82.3 | 86.6 | 40.3 | 69632 |
+| nvarchar16_const | 67.7 | 67.0 | 71.9 | 33.1 | 69632 |
+| nvarchar16_flat_unique_null50 | 49.1 | 44.3 | 54.4 | 24.0 | 36096 |
+| decimal18s6_flat_unique | 48.2 | 48.1 | 51.2 | 23.5 | 20480 |
+| decimal18s6_dict100 | 51.8 | 51.1 | 55.4 | 25.3 | 20480 |
+| decimal18s6_const | 39.2 | 39.0 | 42.1 | 19.1 | 20480 |
+
+Reading of the baseline (what W1/W2 and phase 3 target):
+
+- Encode is ~10× decode per value for BIGINT (18.3 vs 1.8 ns): two
+  `ToUnifiedFormat` calls per cell (NULL check + value read) plus per-value
+  buffer append dominate over the 9 wire bytes actually produced. Even the
+  pure-NULL path (`bigint_const_null`) costs 6.9 ns/value — that is the
+  per-cell dispatch + null-check floor, and the direct headroom for the
+  W1/W2 format-hoisting quick wins.
+- The current path is representation-blind the WRONG way around: dictionary
+  inputs are 15–25% SLOWER than flat (per-cell sel indirection, no reuse of
+  the repeated value's encoding), and cardinality within a representation
+  does not matter (card10 ≈ unique for both flat and dict). Consequence for
+  phasing: if the phase-2 scan starts emitting dictionary vectors before the
+  phase-3 representation-aware encoder lands, scan→COPY round-trips will
+  mildly regress on the write side — phase 3 must detect
+  `DictionaryVector::DictionarySize` and encode each distinct value once.
+- Constant vectors are already the cheapest input (~20% under flat) but still
+  pay the full per-row encode; a constant-aware encoder (encode once, replay
+  bytes) would collapse `*_const` cells to near the buffer-append floor.
+- NVARCHAR encode (37.7 ns/value at 16 ASCII chars) is ~1.6× its decode
+  (23.3): UTF-8→UTF-16 conversion into a fresh `vector<uint8_t>` per value
+  (`StringToUTF16LE`) plus the USHORT-prefixed append. DECIMAL encode
+  (23.5 ns) is cheaper than DECIMAL decode (36.0) but still ~4.4× the
+  datetime2 line — same big-number handling, milder than the decode side.
 
 ## e2e — TPC-H smoke (NOT baseline; single run, SF 0.01 only)
 

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -167,6 +167,63 @@ Reading of the baseline (what W1/W2 and phase 3 target):
   (23.5 ns) is cheaper than DECIMAL decode (36.0) but still ~4.4× the
   datetime2 line — same big-number handling, milder than the decode side.
 
+## Delta — W1+W2 hoisted BCP encode (T9, 2026-07-28)
+
+W1: `UnifiedVectorFormat` built once per column per chunk (was twice per
+CELL — null check + value read). W2: family encoder + NULL wire kind
+resolved once per column per chunk (was a 9-way switch + two branch pairs
+per cell). New production path `BCPRowEncoder::EncodeChunk` (writes the
+0xD1 ROW token per row — hoisted wire bytes below include it);
+`BCPWriter::WriteRows` switched to it; `BuildRowToken` deleted. Per-cell
+byte-equivalence against the per-row path asserted in-bench for all 19
+cells; `diff_check.sh` pre-W1 binary vs post-W1 build: 13/13 byte-identical
+(incl. the BCP write-back case). Bonus fix: uuid/binary codecs read via
+`FlatVector::GetData` before — wrong for dictionary/constant inputs; now
+format-based.
+
+| cell | baseline ns/value | hoisted ns/value | speedup |
+| --- | --- | --- | --- |
+| bigint_flat_unique | 18.3 | 8.2 | 2.2× |
+| bigint_flat_card10 | 18.3 | 8.5 | 2.2× |
+| bigint_dict1 | 22.9 | 8.3 | 2.8× |
+| bigint_dict10 | 23.3 | 8.3 | 2.8× |
+| bigint_dict100 | 23.6 | 8.5 | 2.8× |
+| bigint_const | 14.8 | 8.3 | 1.8× |
+| bigint_flat_unique_null50 | 14.7 | 6.0 | 2.5× |
+| bigint_dict100_null50 | 18.5 | 6.1 | 3.0× |
+| bigint_const_null | 6.9 | 3.9 | 1.8× |
+| nvarchar16_flat_unique | 37.7 | 27.4 | 1.4× |
+| nvarchar16_flat_card10 | 37.9 | 27.4 | 1.4× |
+| nvarchar16_dict1 | 40.6 | 27.9 | 1.5× |
+| nvarchar16_dict10 | 40.9 | 27.6 | 1.5× |
+| nvarchar16_dict100 | 40.3 | 28.1 | 1.4× |
+| nvarchar16_const | 33.1 | 27.6 | 1.2× |
+| nvarchar16_flat_unique_null50 | 24.0 | 15.7 | 1.5× |
+| decimal18s6_flat_unique | 23.5 | 12.4 | 1.9× |
+| decimal18s6_dict100 | 25.3 | 11.7 | 2.2× |
+| decimal18s6_const | 19.1 | 11.7 | 1.6× |
+
+Reading of the delta:
+
+- The dictionary penalty is GONE (dict cells now equal flat at ~8.3 ns for
+  bigint; were 15–25% slower) — the per-cell sel indirection cost was
+  entirely in the repeated ToUnifiedFormat, not in the sel lookup itself.
+  This unblocks the phase-2/3 sequencing concern from the baseline reading.
+- NULL handling floor halved (6.9 → 3.9 ns for a constant-NULL column;
+  null50 cells 2.5–3.0×) — the null check now reuses the hoisted format.
+- Remaining nvarchar cost (27.4 ns/value) is dominated by the per-value
+  UTF-16 conversion + double validation — the W3 target. DECIMAL encode is
+  down to 12 ns (big-number assembly remains).
+- The per-row `EncodeRow` API survives as a compatibility path only (bench
+  group renamed `bcp_encode_perrow`); it now heap-allocates its column
+  state per call and has NO production callers — do not reintroduce it in
+  hot paths.
+- e2e (same-session interleaved medians-of-3, SF 0.1): copy_lineitem
+  −7.5%, copy_customer −6.2%, scan steps flat (decode untouched);
+  sub-200 ms steps swing ±18% in both directions on untouched code —
+  noise, per the baseline note. Full D3 re-run happens after all D8 wins
+  (T12) against the recorded constants.
+
 ## e2e — TPC-H baseline (median of 3 full runs, SF 0.01 / 0.1 / 1, 2026-07-28)
 
 `test/bench/bench_tpch_e2e.sh`, tree commit `722caf8`, 3 sequential full

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -1,0 +1,97 @@
+# Materialization series — benchmark results (spec 054 D6, append-only)
+
+Baseline-first record for the batch/SIMD materialization series (design:
+`docs/proposals/simd-chunk-materialization-design.md`, spec:
+`specs/054-simd-baseline-and-quick-wins/spec.md`). Each later phase appends its
+column/section next to the baseline it is compared against — do not rewrite
+existing numbers.
+
+Status of the baseline capture (D6):
+
+| piece | status |
+| --- | --- |
+| Micro: string-decode group, macOS ARM64 | captured below (2026-07-28) |
+| Micro: fixed-decode + bcp-encode groups | pending (T6) |
+| Micro: Linux x86_64 run | pending (T7) |
+| e2e: TPC-H SF 0.01/0.1/1 median-of-≥3 | pending (T7; single smoke run noted below) |
+
+## Environment (macOS reference machine)
+
+- Host: Apple M4 Max, 16 cores, 128 GB RAM, Darwin 25.5.0 arm64
+- Compiler: Apple clang 17.0.0 (clang-1700.0.13.5), `-O3 -DMSSQL_BENCH_BUILD`
+- DuckDB: v1.5.5 (pinned submodule), release `libduckdb`; simdutf 6.1.1 (vcpkg release)
+- Tree: branch `spec/054-simd-baseline-quick-wins`, commit `703795d` + T1 harness
+- Invocation: `GEN=ninja make bench-materialize`
+- SQL Server (e2e smoke): mcr.microsoft.com/mssql/server:2022-latest (amd64,
+  emulated) in Docker 28.5.1, localhost
+
+## Micro — string decode, CURRENT path (baseline, 2026-07-28)
+
+`codec::string::DecodeFromTds` (`Utf16LEDecode` → `std::string` → `AddString`)
+into a 2048-row `DataChunk`. One sample = one chunk fill; median/p10/p90 over
+400 iterations (50 for the 4096-unit cell) after 10 warm-up fills. All cells
+byte-identical to the per-value reference decode (correct=PASS).
+
+| cell | µs/chunk (median) | p10 | p90 | ns/value | utf16 in B | utf8 out B |
+| --- | --- | --- | --- | --- | --- | --- |
+| len0_ascii_null0_card2048 | 11.4 | 11.1 | 12.7 | 5.6 | 0 | 0 |
+| len4_ascii_null0_card2048 | 40.3 | 40.0 | 42.0 | 19.7 | 16384 | 8192 |
+| len8_ascii_null0_card2048 | 44.1 | 42.7 | 49.3 | 21.5 | 32768 | 16384 |
+| len16_ascii_null0_card2048 | 47.8 | 45.0 | 50.8 | 23.3 | 65536 | 32768 |
+| len32_ascii_null0_card2048 | 93.6 | 86.5 | 101.5 | 45.7 | 131072 | 65536 |
+| len64_ascii_null0_card2048 | 95.3 | 94.0 | 103.5 | 46.5 | 262144 | 131072 |
+| len256_ascii_null0_card2048 | 175.8 | 172.4 | 182.7 | 85.8 | 1048576 | 524288 |
+| len4096_ascii_null0_card2048 | 2063.6 | 2031.7 | 2120.4 | 1007.6 | 16777216 | 8388608 |
+| len16_cyrillic_null0_card2048 | 103.7 | 103.2 | 109.6 | 50.6 | 65536 | 57344 |
+| len16_cjk_null0_card2048 | 111.2 | 106.5 | 118.4 | 54.3 | 65536 | 81920 |
+| len16_surrogate_null0_card2048 | 97.5 | 96.1 | 102.2 | 47.6 | 65536 | 57344 |
+| len16_ascii_null10_card2048 | 43.3 | 42.2 | 47.9 | 21.2 | 58816 | 29408 |
+| len16_ascii_null50_card2048 | 26.1 | 25.0 | 28.4 | 12.7 | 32000 | 16000 |
+| len16_ascii_null100_card2048 | 3.7 | 3.7 | 3.7 | 1.8 | 0 | 0 |
+| len16_ascii_null0_card1 | 52.1 | 47.5 | 56.6 | 25.5 | 65536 | 32768 |
+| len16_ascii_null0_card2 | 51.1 | 46.8 | 55.4 | 24.9 | 65536 | 32768 |
+| len16_ascii_null0_card10 | 49.7 | 47.0 | 54.2 | 24.3 | 65536 | 32768 |
+| len16_ascii_null0_card100 | 49.8 | 48.2 | 54.2 | 24.3 | 65536 | 32768 |
+| len16_ascii_null0_card101 | 48.1 | 42.8 | 59.4 | 23.5 | 65536 | 32768 |
+| len16_ascii_null0_card512 | 53.3 | 43.8 | 60.5 | 26.0 | 65536 | 32768 |
+| len16_ascii_embedded_nul | 47.8 | 42.8 | 55.3 | 23.3 | 65536 | 32768 |
+| len16_ascii_lone_high_surrogate | 131.3 | 129.2 | 136.3 | 64.1 | 65536 | 30720 |
+
+Reading of the baseline (what the later phases target):
+
+- ~23 ns/value floor for short ASCII; ~5.6 ns/value pure per-slot overhead
+  (len 0), ~1.8 ns/value for an all-NULL chunk.
+- The `string_t` 12-byte inline threshold is visible across len 4→8→16
+  (19.7 → 21.5 → 23.3 ns/value; len 32 jumps to 45.7 as values leave the
+  inline path and the `std::string` temporary starts allocating).
+- Non-ASCII costs ~2.2× ASCII at equal code-unit length (50–54 vs 23 ns) —
+  the two-pass simdutf wrapper plus non-ASCII conversion cost.
+- Invalid UTF-16 tail (lone high surrogate → legacy fallback converter) is
+  2.7× the valid-input path (64.1 vs 23.3 ns) — the fallback must stay
+  correctness-only, never on the hot path.
+- Cardinality does NOT matter to the current path (card1 ≈ card2048) — the
+  dictionary win (phases 2+) has to come from emitting dictionary vectors,
+  not from any caching in the current code.
+
+## e2e — TPC-H smoke (NOT baseline; single run, SF 0.01 only)
+
+`test/bench/bench_tpch_e2e.sh`, 2026-07-28, single run (baseline capture with
+median-of-≥3 and SF 0.1/1 lands with T7). Recorded here because it validated
+the harness and the post-pool-fix step constants:
+
+| step | seconds | rows |
+| --- | --- | --- |
+| copy_lineitem_sf0_01 | 0.777 | 60175 |
+| copy_orders_sf0_01 | 0.219 | 15000 |
+| copy_part_sf0_01 | 0.090 | 2000 |
+| copy_customer_sf0_01 | 0.079 | 1500 |
+| copy_sum_agg_sf0_01 | 0.066 | — |
+| scan_full_lineitem_sf0_01 | 0.196 | 60175 |
+| scan_strings_sf0_01 | 0.113 | — |
+| scan_lowcard_sf0_01 | 0.078 | 60175 |
+| scan_limit_sf0_01 | 0.049 | 10 |
+| q1_local_sf0_01 | 0.132 | 60175 |
+
+Note: before commit `9ce479d` (pool cleanup-thread wakeup fix) every step had
+a flat ~2.05 s floor from two 1 s pool-teardown sleeps per CLI invocation;
+comparisons against any pre-`9ce479d` e2e numbers are invalid.

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -13,8 +13,8 @@ Status of the baseline capture (D6):
 | Micro: string-decode group, macOS ARM64 | captured below (2026-07-28) |
 | Micro: fixed-decode group, macOS ARM64 | captured below (2026-07-28) |
 | Micro: bcp-encode group, macOS ARM64 | captured below (2026-07-28) |
-| Micro: Linux x86_64 run | pending (T7) |
-| e2e: TPC-H SF 0.01/0.1/1 median-of-≥3 | pending (T7; single smoke run noted below) |
+| Micro: Linux x86_64 run | pending — needs a real x86_64 host (QEMU-on-ARM timing is meaningless); run `make bench-build && make bench-materialize` on a Linux box or CI runner |
+| e2e: TPC-H SF 0.01/0.1/1 median-of-3 | captured below (2026-07-28) |
 | Pre-merge: release comparison — TPC-H on SQL Server, lineitem ≥ 10M rows (SF 2), query steps from DuckDB, current release (v0.2.2) vs new build, median-of-≥3 | pending (gates the phase-0 merge) |
 
 ## Environment (macOS reference machine)
@@ -166,6 +166,46 @@ Reading of the baseline (what W1/W2 and phase 3 target):
   (`StringToUTF16LE`) plus the USHORT-prefixed append. DECIMAL encode
   (23.5 ns) is cheaper than DECIMAL decode (36.0) but still ~4.4× the
   datetime2 line — same big-number handling, milder than the decode side.
+
+## e2e — TPC-H baseline (median of 3 full runs, SF 0.01 / 0.1 / 1, 2026-07-28)
+
+`test/bench/bench_tpch_e2e.sh`, tree commit `722caf8`, 3 sequential full
+runs, median per step. SQL Server 2022 (amd64 image, emulated) in Docker on
+the reference macOS host; server and dockerized I/O are a CONSTANT term
+shared by any two builds compared on this host — these numbers are the
+no-regression comparison constants for the phase merges (the optimization
+signal lives in the micro tables above; acceptance gate: no step regresses
+> 3%, spec criterion 6). `dbgen` rows: lineitem 60,175 / 600,572 /
+6,001,215 at SF 0.01 / 0.1 / 1.
+
+| step (seconds, median of 3) | SF 0.01 | SF 0.1 | SF 1 |
+| --- | --- | --- | --- |
+| dbgen (excluded from comparison) | 0.172 | 0.986 | 6.428 |
+| copy_lineitem | 0.724 | 6.683 | 65.899 |
+| copy_orders | 0.199 | 1.440 | 13.643 |
+| copy_part | 0.083 | 0.305 | 2.361 |
+| copy_customer | 0.072 | 0.239 | 1.743 |
+| copy_sum_agg (#177 case) | 0.056 | 0.065 | 0.061 |
+| scan_full_lineitem | 0.169 | 1.221 | 11.667 |
+| scan_strings | 0.060 | 0.123 | 0.437 |
+| scan_lowcard | 0.078 | 0.337 | 3.041 |
+| scan_limit | 0.054 | 0.052 | 0.051 |
+| q1_local | 0.132 | 0.516 | 4.418 |
+| q6_local | 0.143 | 0.119 | 0.252 |
+
+Reading:
+
+- SF 1 throughput: BCP write ≈ 91k rows/s (copy_lineitem, 16 columns), full
+  scan ≈ 514k rows/s, 2-column low-cardinality scan ≈ 2.0M rows/s. These are
+  the end-to-end constants the micro-level decode/encode wins have to move.
+- Run-to-run spread is ≤ ~5% on multi-second steps (run 1 is typically the
+  slowest — cold caches); sub-100 ms steps are noise-dominated and serve
+  only as smoke checks, not regression evidence.
+- `scan_limit` is flat across SF (~0.05 s) — pure per-query/bind overhead,
+  confirming the pool-fix (`9ce479d`) removed the old 2 s floor.
+- `q6_local` stays sub-second even at SF 1: the selective filter is pushed
+  down, so almost nothing crosses the wire — a control step that measures
+  pushdown health rather than materialization.
 
 ## e2e — TPC-H smoke (NOT baseline; single run, SF 0.01 only)
 

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -252,6 +252,52 @@ beyond noise. Verified: unit tests + full SQL suite green (incl. the
 FR-023 wording test), `diff_check.sh` pre-T10 vs post-T10 build 13/13
 byte-identical (incl. the BCP write-back and its Cyrillic payloads).
 
+## Delta — R1 string decode without temporaries (T11, 2026-07-28)
+
+`codec::string::DecodeFromTds` now converts straight into the vector's
+string slot: `Utf8LengthFromUtf16LEView` (one validation + exact UTF-8
+length) → `StringVector::EmptyString(out, len)` →
+`Utf16LEDecodeValidInto` — no intermediate `std::string`. The trailing-
+space trim for fixed-length CHAR/NCHAR moved to the INPUT (a trailing
+U+0020 is a trailing 0x0020 unit / 0x20 byte — no other sequence produces
+one; bit-identical output). Single-byte CHAR/VARCHAR likewise appends the
+raw bytes directly. Invalid UTF-16 keeps the legacy per-value fallback.
+
+string-decode cells (ns/value, baseline → post-R1):
+
+| cell | baseline | post-R1 | speedup |
+| --- | --- | --- | --- |
+| len4_ascii | 19.7 | 17.2 | 1.1× |
+| len8_ascii | 21.5 | 21.4 | 1.0× |
+| len16_ascii | 23.3 | 18.8 | 1.2× |
+| len32_ascii | 45.7 | 17.9 | 2.6× |
+| len64_ascii | 46.5 | 23.8 | 2.0× |
+| len256_ascii | 85.8 | 58.3 | 1.5× |
+| len4096_ascii | 1007.6 | 911.8 | 1.1× |
+| len16_cyrillic | 50.6 | 24.9 | 2.0× |
+| len16_cjk | 54.3 | 26.2 | 2.1× |
+| len16_surrogate | 47.6 | 21.8 | 2.2× |
+| len16_null50 | 12.7 | 9.7 | 1.3× |
+| len16_lone_high_surrogate (invalid) | 64.1 | 67.2 | 0.95× |
+
+Reading of the delta:
+
+- The big win is exactly where the baseline predicted: past the 12-byte
+  string_t inline threshold (len32: 2.6×) and on non-ASCII (~2×) — the
+  `std::string` temporary's allocation + copy is gone, and the length is
+  computed exactly instead of worst-case.
+- Short inline strings (len8/len16) move little — they never allocated.
+  len0 regressed 5.6 → 10.4 ns (cross-TU call overhead now dominates the
+  empty case) — negligible in absolute terms, noted for honesty.
+- The invalid-input fallback pays one extra validation (~5%) — cold path,
+  contract unchanged.
+- e2e (alternating medians-of-3, SF 0.1): q1_local −4.7%, scan_strings
+  −32% (noisy step, right direction), scan_full +2.5% (lineitem strings
+  are short/low-card → inline path, within noise); copies flat.
+  Verified: unit + full SQL suite green; diff_check pre-T11 vs post-T11
+  13/13 byte-identical (incl. NCHAR trailing-space trim and empty-vs-NULL
+  MAX cells).
+
 ## e2e — TPC-H baseline (median of 3 full runs, SF 0.01 / 0.1 / 1, 2026-07-28)
 
 `test/bench/bench_tpch_e2e.sh`, tree commit `722caf8`, 3 sequential full

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -16,7 +16,7 @@ Status of the baseline capture (D6):
 | Micro: Linux x86_64 run | pending — needs a real x86_64 host (QEMU-on-ARM timing is meaningless); run `make bench-build && make bench-materialize` on a Linux box or CI runner |
 | e2e: TPC-H SF 0.01/0.1/1 median-of-3 | captured below (2026-07-28) |
 | Final phase-0 delta (T12): full D1+D3 re-run, gate check | captured below (2026-07-28) — gate PASS |
-| Pre-merge: release comparison — TPC-H on SQL Server, lineitem ≥ 10M rows (SF 2), query steps from DuckDB, current release (v0.2.2) vs new build, median-of-≥3 | pending (gates the phase-0 merge) |
+| Pre-merge: release comparison — TPC-H on SQL Server, lineitem ≥ 10M rows (SF 2), query steps from DuckDB, current release (v0.2.2) vs new build, median-of-≥3 | captured below (2026-07-28) — every step improved |
 
 ## Environment (macOS reference machine)
 
@@ -352,6 +352,47 @@ end to end (diff_check at every step), no e2e regression. e2e stays
 server-dominated as predicted — the wins show as modest improvements on
 the largest copy steps and become load-bearing at higher client
 concurrency / faster servers.
+
+## Pre-merge release comparison — v0.2.2 vs new build, SF 2 (2026-07-28)
+
+Maintainer requirement (D3 amendment): TPC-H at SF 2 — lineitem
+11,997,996 rows (≥ 10M) — 3 same-session interleaved pairs, median per
+step. Side A: stock DuckDB CLI v1.5.5 + the official v0.2.2 release
+artifact (`mssql-0.2.2-osx_arm64.duckdb_extension` from the GitHub
+release, loaded `-unsigned` and renamed to `mssql.duckdb_extension` —
+the entrypoint name derives from the filename; the community CDN still
+served 0.2.1 at capture time). Side B: this branch's bench-build CLI.
+`copy_sum_agg` runs via `time_step_optional` (would abort pre-054 sides
+on some #177 routes; at SF 2 through COPY+CREATE_TABLE it happens to
+succeed on v0.2.2).
+
+| step (seconds, median of 3) | v0.2.2 | new build | delta |
+| --- | --- | --- | --- |
+| copy_lineitem | 137.403 | 126.734 | **−7.8%** |
+| copy_orders | 29.150 | 26.614 | **−8.7%** |
+| copy_part | 6.082 | 4.571 | **−24.8%** |
+| copy_customer | 5.078 | 3.417 | **−32.7%** |
+| copy_sum_agg | 2.069 | 0.065 | −96.9% * |
+| scan_full_lineitem | 25.092 | 23.214 | **−7.5%** |
+| scan_strings | 2.067 | 0.799 | −61.3% * |
+| scan_lowcard | 7.064 | 5.874 | −16.8% |
+| scan_limit | 2.062 | 0.050 | −97.6% * |
+| q1_local | 10.089 | 8.914 | **−11.6%** |
+| q6_local | 2.068 | 0.386 | −81.3% * |
+
+\* v0.2.2 lacks the pool cleanup-thread wakeup fix (`9ce479d`), so every
+CLI invocation there carries ~2.0 s of teardown sleeps — the starred
+short steps are dominated by that fix (a real user-facing win of this
+branch: interactive queries drop from a 2 s floor to instant), and say
+little about the codec paths. The unstarred multi-second steps are where
+the W1–W4/R1 encode/decode work shows through the server-dominated e2e:
+string-heavy tables largest (part −25%, customer −33% — W3 single-pass
+NVARCHAR + the unaligned-simdutf fix), numeric-heavy smaller but solid
+(lineitem −8%, orders −9%, full scan −7.5%, Q1 −12%).
+
+Verdict: **every step improved; phase-0 merge unblocked.** Remaining
+open item in the status table: the Linux x86_64 micro run (needs a real
+x86_64 host).
 
 ## e2e — TPC-H baseline (median of 3 full runs, SF 0.01 / 0.1 / 1, 2026-07-28)
 

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -74,6 +74,34 @@ Reading of the baseline (what the later phases target):
   dictionary win (phases 2+) has to come from emitting dictionary vectors,
   not from any caching in the current code.
 
+## Micro — fixed decode, CURRENT path (baseline, 2026-07-28)
+
+Per-family `codec::<family>::DecodeFromTds` into a 2048-row `DataChunk`;
+same protocol as the string table (median/p10/p90 of 400 chunk fills).
+int/float cells verified against independently reconstructed values;
+datetime/decimal/uuid additionally by decode-twice determinism.
+
+| cell | µs/chunk (median) | p10 | p90 | ns/value | wire in B |
+| --- | --- | --- | --- | --- | --- |
+| int1_utinyint | 3.5 | 3.5 | 4.2 | 1.7 | 2048 |
+| int2_smallint | 3.6 | 3.5 | 3.8 | 1.8 | 4096 |
+| int4_integer | 3.8 | 3.7 | 3.8 | 1.8 | 8192 |
+| int8_bigint | 3.7 | 3.5 | 4.5 | 1.8 | 16384 |
+| int8_bigint_null50 | 3.6 | 3.5 | 4.5 | 1.8 | 8000 |
+| float8_double | 4.4 | 4.4 | 4.5 | 2.2 | 16384 |
+| datetime2_s6_timestamp | 11.1 | 11.0 | 11.2 | 5.4 | 16384 |
+| decimal_p4s2_int16 | 34.5 | 31.0 | 37.5 | 16.9 | 10240 |
+| decimal_p18s6_int64 | 73.8 | 70.1 | 80.5 | 36.0 | 18432 |
+| decimal_p38s0_int128 | 167.3 | 155.9 | 180.3 | 81.7 | 34816 |
+| uuid | 4.1 | 3.7 | 4.2 | 2.0 | 32768 |
+
+Reading: integer/float/uuid decode is already near per-slot overhead
+(~1.7–2.2 ns/value ≈ the len0 string floor) — little headroom for phase-1
+kernels there. DATETIME2 is moderate (5.4 ns). **DECIMAL is the outlier**:
+17–82 ns/value, 10–45× the integer path, scaling with mantissa width
+(`ConvertDecimal`'s per-value big-number assembly) — the highest-value
+fixed-decode target for the phase-1 staging work.
+
 ## e2e — TPC-H smoke (NOT baseline; single run, SF 0.01 only)
 
 `test/bench/bench_tpch_e2e.sh`, 2026-07-28, single run (baseline capture with

--- a/test/bench/bench_results_simd_baseline.md
+++ b/test/bench/bench_results_simd_baseline.md
@@ -14,6 +14,7 @@ Status of the baseline capture (D6):
 | Micro: fixed-decode + bcp-encode groups | pending (T6) |
 | Micro: Linux x86_64 run | pending (T7) |
 | e2e: TPC-H SF 0.01/0.1/1 median-of-≥3 | pending (T7; single smoke run noted below) |
+| Pre-merge: release comparison — TPC-H on SQL Server, lineitem ≥ 10M rows (SF 2), query steps from DuckDB, current release (v0.2.2) vs new build, median-of-≥3 | pending (gates the phase-0 merge) |
 
 ## Environment (macOS reference machine)
 

--- a/test/bench/bench_tpch_e2e.sh
+++ b/test/bench/bench_tpch_e2e.sh
@@ -23,7 +23,19 @@
 #   MSSQL_TEST_PASS         default: TestPassword1
 #   MSSQL_TEST_DB           default: TestDB
 #   MSSQL_BENCH_SF_LIST     default: "0.01 0.1 1"  (spec: SF 10 optional,
-#                           append it when the Docker volume allows)
+#                           append it when the Docker volume allows; the
+#                           pre-merge release comparison uses SF 2 so that
+#                           lineitem holds >= 10M rows)
+#   MSSQL_BENCH_LOAD_SQL    SQL prefix to load the mssql extension; empty
+#                           (default) relies on the bench-build CLI's
+#                           built-in mssql. For the pre-merge release
+#                           comparison run a STOCK duckdb CLI with e.g.
+#                             "INSTALL mssql FROM community; LOAD mssql;"
+#                           or an unsigned local build with
+#                             "LOAD '/abs/path/mssql.duckdb_extension';"
+#                           (dbgen autoloads core tpch in a stock CLI)
+#   MSSQL_BENCH_UNSIGNED    set to 1 to pass -unsigned (needed for LOAD of
+#                           a local unsigned extension into a stock CLI)
 #   MSSQL_BENCH_OUTPUT      default: /tmp/bench_tpch_e2e_<epoch>.txt
 #
 # Output:
@@ -49,6 +61,19 @@ USER="${MSSQL_TEST_USER:-sa}"
 PASS="${MSSQL_TEST_PASS:-TestPassword1}"
 DB="${MSSQL_TEST_DB:-TestDB}"
 SF_LIST="${MSSQL_BENCH_SF_LIST:-0.01 0.1 1}"
+LOAD_SQL="${MSSQL_BENCH_LOAD_SQL:-}"
+
+# Plain string (not an array): empty-array expansion errors under set -u on
+# macOS's bash 3.2. Single-token flag, so unquoted expansion is safe.
+UNSIGNED_FLAG=""
+if [ "${MSSQL_BENCH_UNSIGNED:-0}" = "1" ]; then
+	UNSIGNED_FLAG="-unsigned"
+fi
+
+# Every SQL invocation goes through this wrapper so LOAD_SQL applies uniformly.
+run_sql() {
+	"$DUCKDB_BIN" $UNSIGNED_FLAG -c "${LOAD_SQL} $1"
+}
 
 OUTPUT_DEFAULT="/tmp/bench_tpch_e2e_$(date +%s).txt"
 OUTPUT_FILE="${MSSQL_BENCH_OUTPUT:-$OUTPUT_DEFAULT}"
@@ -66,9 +91,10 @@ echo "[bench_tpch_e2e] Scale factors: ${SF_LIST}"
 echo "[bench_tpch_e2e] Output file: ${OUTPUT_FILE}"
 echo ""
 
-# Pre-flight: the CLI must have tpch (dbgen) AND mssql (ATTACH) built in.
+# Pre-flight: the CLI must provide tpch (dbgen) and mssql (built-in for a
+# bench-build CLI, or via MSSQL_BENCH_LOAD_SQL for a stock one).
 echo "[bench_tpch_e2e] Pre-flight: dbgen(sf=0) + ATTACH + SELECT 1..."
-preflight_out=$("$DUCKDB_BIN" -c "CALL dbgen(sf=0); ATTACH '${DSN}' AS db (TYPE mssql); SELECT 1 AS ok;" 2>&1)
+preflight_out=$(run_sql "CALL dbgen(sf=0); ATTACH '${DSN}' AS db (TYPE mssql); SELECT 1 AS ok;" 2>&1)
 if ! echo "$preflight_out" | grep -q "ok"; then
 	echo "ERROR: pre-flight failed. Build with 'make bench-build' and check the DSN. Last output:" >&2
 	echo "$preflight_out" >&2
@@ -100,9 +126,9 @@ time_step() {
 	local t1
 	local seconds
 	t0=$(date +%s.%N)
-	if ! "$DUCKDB_BIN" -c "$sql" >/dev/null 2>&1; then
+	if ! run_sql "$sql" >/dev/null 2>&1; then
 		echo "ERROR: step '$step' failed. Aborting." >&2
-		"$DUCKDB_BIN" -c "$(cleanup_sql)" >/dev/null 2>&1 || true
+		run_sql "$(cleanup_sql)" >/dev/null 2>&1 || true
 		exit 4
 	fi
 	t1=$(date +%s.%N)
@@ -128,7 +154,7 @@ for SF in $SF_LIST; do
 	echo "[bench_tpch_e2e] === SF ${SF} ==="
 
 	echo "[bench_tpch_e2e] Cleanup: dropping bench_tpch_* server tables..."
-	"$DUCKDB_BIN" -c "$(cleanup_sql)" >/dev/null 2>&1 || true
+	run_sql "$(cleanup_sql)" >/dev/null 2>&1 || true
 	rm -f "$SRC_DB"
 
 	# dbgen — data generation into a persistent DuckDB file so each step is a
@@ -230,12 +256,22 @@ for SF in $SF_LIST; do
 		ORDER BY l_returnflag, l_linestatus;
 	" "${LINEITEM_ROWS}" "TPC-H Q1 over attached table (scan + aggregate)"
 
+	time_step "q6_local_${SFX}" "
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		SELECT SUM(l_extendedprice * l_discount) AS revenue
+		FROM db.dbo.bench_tpch_lineitem
+		WHERE l_shipdate >= DATE '1994-01-01'
+		  AND l_shipdate < DATE '1995-01-01'
+		  AND l_discount BETWEEN 0.05 AND 0.07
+		  AND l_quantity < 24;
+	" "${LINEITEM_ROWS}" "TPC-H Q6 over attached table (selective filter pushdown)"
+
 	rm -f "$SRC_DB"
 done
 
 echo ""
 echo "[bench_tpch_e2e] Cleanup: dropping bench_tpch_* server tables..."
-"$DUCKDB_BIN" -c "$(cleanup_sql)" >/dev/null 2>&1 || true
+run_sql "$(cleanup_sql)" >/dev/null 2>&1 || true
 
 {
 	echo ""

--- a/test/bench/bench_tpch_e2e.sh
+++ b/test/bench/bench_tpch_e2e.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# test/bench/bench_tpch_e2e.sh
+#
+# Spec 054 D3: end-to-end TPC-H benchmark for the materialization series.
+# Times BCP write (DuckDB→SQL Server) and scan read (SQL Server→DuckDB) steps
+# over dbgen data at several scale factors. Same TSV protocol + host-metadata
+# footer as bench_codec_e2e.sh (spec 044).
+#
+# e2e numbers are NO-REGRESSION EVIDENCE, not the optimization signal —
+# SQL-Server-in-Docker I/O dominates at scale; microbenchmarks
+# (make bench-materialize) carry the signal. See spec 054 §2.
+#
+# Requires a DuckDB CLI with BOTH mssql and tpch built in: `make bench-build`
+# (tpch is bench-only and never ships in extension_config.cmake).
+#
+# Manual target; NOT run as part of `make test` or any CI workflow.
+#
+# Env vars:
+#   MSSQL_BENCH_DUCKDB_BIN  path to the bench-build DuckDB CLI (REQUIRED)
+#   MSSQL_TEST_HOST         default: localhost
+#   MSSQL_TEST_PORT         default: 1433
+#   MSSQL_TEST_USER         default: sa
+#   MSSQL_TEST_PASS         default: TestPassword1
+#   MSSQL_TEST_DB           default: TestDB
+#   MSSQL_BENCH_SF_LIST     default: "0.01 0.1 1"  (spec: SF 10 optional,
+#                           append it when the Docker volume allows)
+#   MSSQL_BENCH_OUTPUT      default: /tmp/bench_tpch_e2e_<epoch>.txt
+#
+# Output:
+#   step_name<TAB>seconds<TAB>row_count<TAB>notes
+#   (steps are suffixed _sf<sf>; dbgen is timed but excluded from comparison)
+
+set -uo pipefail
+
+DUCKDB_BIN="${MSSQL_BENCH_DUCKDB_BIN:-}"
+if [ -z "$DUCKDB_BIN" ]; then
+	echo "ERROR: MSSQL_BENCH_DUCKDB_BIN must be set (a 'make bench-build' CLI with mssql+tpch)." >&2
+	echo "Example: MSSQL_BENCH_DUCKDB_BIN=./build/release/duckdb bash test/bench/bench_tpch_e2e.sh" >&2
+	exit 2
+fi
+if [ ! -x "$DUCKDB_BIN" ]; then
+	echo "ERROR: $DUCKDB_BIN is not executable." >&2
+	exit 2
+fi
+
+HOST="${MSSQL_TEST_HOST:-localhost}"
+PORT="${MSSQL_TEST_PORT:-1433}"
+USER="${MSSQL_TEST_USER:-sa}"
+PASS="${MSSQL_TEST_PASS:-TestPassword1}"
+DB="${MSSQL_TEST_DB:-TestDB}"
+SF_LIST="${MSSQL_BENCH_SF_LIST:-0.01 0.1 1}"
+
+OUTPUT_DEFAULT="/tmp/bench_tpch_e2e_$(date +%s).txt"
+OUTPUT_FILE="${MSSQL_BENCH_OUTPUT:-$OUTPUT_DEFAULT}"
+
+DSN="Server=${HOST},${PORT};Database=${DB};User Id=${USER};Password=${PASS}"
+
+case "$(uname -s 2>/dev/null)" in
+	MINGW*|MSYS*|CYGWIN*) NULL_DEV="NUL" ;;
+	*)                    NULL_DEV="/dev/null" ;;
+esac
+
+echo "[bench_tpch_e2e] DuckDB CLI: $DUCKDB_BIN"
+echo "[bench_tpch_e2e] DSN: Server=${HOST},${PORT};Database=${DB};User Id=${USER};Password=***"
+echo "[bench_tpch_e2e] Scale factors: ${SF_LIST}"
+echo "[bench_tpch_e2e] Output file: ${OUTPUT_FILE}"
+echo ""
+
+# Pre-flight: the CLI must have tpch (dbgen) AND mssql (ATTACH) built in.
+echo "[bench_tpch_e2e] Pre-flight: dbgen(sf=0) + ATTACH + SELECT 1..."
+preflight_out=$("$DUCKDB_BIN" -c "CALL dbgen(sf=0); ATTACH '${DSN}' AS db (TYPE mssql); SELECT 1 AS ok;" 2>&1)
+if ! echo "$preflight_out" | grep -q "ok"; then
+	echo "ERROR: pre-flight failed. Build with 'make bench-build' and check the DSN. Last output:" >&2
+	echo "$preflight_out" >&2
+	exit 3
+fi
+echo "[bench_tpch_e2e] Pre-flight OK."
+echo ""
+
+# All server-side tables carry the bench_tpch_ prefix; cleanup is idempotent.
+cleanup_sql() {
+	cat <<-EOF
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		DROP TABLE IF EXISTS db.dbo.bench_tpch_lineitem;
+		DROP TABLE IF EXISTS db.dbo.bench_tpch_orders;
+		DROP TABLE IF EXISTS db.dbo.bench_tpch_part;
+		DROP TABLE IF EXISTS db.dbo.bench_tpch_customer;
+		DROP TABLE IF EXISTS db.dbo.bench_tpch_sum_agg;
+		DETACH db;
+	EOF
+}
+
+# Time a single CLI invocation. Args: <step> <sql> <rows> <notes>.
+time_step() {
+	local step="$1"
+	local sql="$2"
+	local rows="$3"
+	local notes="$4"
+	local t0
+	local t1
+	local seconds
+	t0=$(date +%s.%N)
+	if ! "$DUCKDB_BIN" -c "$sql" >/dev/null 2>&1; then
+		echo "ERROR: step '$step' failed. Aborting." >&2
+		"$DUCKDB_BIN" -c "$(cleanup_sql)" >/dev/null 2>&1 || true
+		exit 4
+	fi
+	t1=$(date +%s.%N)
+	seconds=$(awk "BEGIN {printf \"%.3f\", $t1 - $t0}")
+	printf '%s\t%s\t%s\t%s\n' "$step" "$seconds" "$rows" "$notes" | tee -a "$OUTPUT_FILE"
+}
+
+{
+	echo "# bench_tpch_e2e output"
+	echo "# date: $(date -Iseconds 2>/dev/null || date)"
+	echo "# duckdb_bin: $DUCKDB_BIN"
+	echo "# host: ${HOST}:${PORT}/${DB}"
+	echo "# sf_list: ${SF_LIST}"
+	echo "step	seconds	row_count	notes"
+} > "$OUTPUT_FILE"
+
+for SF in $SF_LIST; do
+	SFX="sf$(echo "$SF" | tr '.' '_')"
+	SRC_DB="/tmp/bench_tpch_src_${SFX}_$$.duckdb"
+	trap 'rm -f /tmp/bench_tpch_src_*_$$.duckdb' EXIT
+
+	echo ""
+	echo "[bench_tpch_e2e] === SF ${SF} ==="
+
+	echo "[bench_tpch_e2e] Cleanup: dropping bench_tpch_* server tables..."
+	"$DUCKDB_BIN" -c "$(cleanup_sql)" >/dev/null 2>&1 || true
+	rm -f "$SRC_DB"
+
+	# dbgen — data generation into a persistent DuckDB file so each step is a
+	# fresh CLI process sharing the same source (bench_codec_e2e pattern).
+	# Excluded from before/after comparison.
+	time_step "dbgen_${SFX}" "
+		ATTACH '${SRC_DB}' AS src;
+		USE src;
+		CALL dbgen(sf=${SF});
+	" "-" "data generation (excluded from comparison)"
+
+	LINEITEM_ROWS=$("$DUCKDB_BIN" -noheader -list -c "ATTACH '${SRC_DB}' AS src; SELECT count(*) FROM src.lineitem;" 2>/dev/null | tail -1)
+	ORDERS_ROWS=$("$DUCKDB_BIN" -noheader -list -c "ATTACH '${SRC_DB}' AS src; SELECT count(*) FROM src.orders;" 2>/dev/null | tail -1)
+	PART_ROWS=$("$DUCKDB_BIN" -noheader -list -c "ATTACH '${SRC_DB}' AS src; SELECT count(*) FROM src.part;" 2>/dev/null | tail -1)
+	CUSTOMER_ROWS=$("$DUCKDB_BIN" -noheader -list -c "ATTACH '${SRC_DB}' AS src; SELECT count(*) FROM src.customer;" 2>/dev/null | tail -1)
+	echo "[bench_tpch_e2e] rows: lineitem=${LINEITEM_ROWS} orders=${ORDERS_ROWS} part=${PART_ROWS} customer=${CUSTOMER_ROWS}"
+
+	# --- Write path (DuckDB → BCP) ---
+
+	time_step "copy_lineitem_${SFX}" "
+		ATTACH '${SRC_DB}' AS src;
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT * FROM src.lineitem)
+			TO 'mssql://db/dbo/bench_tpch_lineitem' (FORMAT 'bcp', CREATE_TABLE true);
+	" "${LINEITEM_ROWS}" "numeric/date-heavy + low-cardinality strings"
+
+	time_step "copy_orders_${SFX}" "
+		ATTACH '${SRC_DB}' AS src;
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT * FROM src.orders)
+			TO 'mssql://db/dbo/bench_tpch_orders' (FORMAT 'bcp', CREATE_TABLE true);
+	" "${ORDERS_ROWS}" "mixed numeric/string"
+
+	time_step "copy_part_${SFX}" "
+		ATTACH '${SRC_DB}' AS src;
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT * FROM src.part)
+			TO 'mssql://db/dbo/bench_tpch_part' (FORMAT 'bcp', CREATE_TABLE true);
+	" "${PART_ROWS}" "string-heavy"
+
+	time_step "copy_customer_${SFX}" "
+		ATTACH '${SRC_DB}' AS src;
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT * FROM src.customer)
+			TO 'mssql://db/dbo/bench_tpch_customer' (FORMAT 'bcp', CREATE_TABLE true);
+	" "${CUSTOMER_ROWS}" "string-heavy"
+
+	# SUM(BIGINT) → HUGEINT → DECIMAL(38,0) on the wire: the #177 regression
+	# case (works natively since spec 054 T4; no ::DECIMAL cast workaround).
+	time_step "copy_sum_agg_${SFX}" "
+		ATTACH '${SRC_DB}' AS src;
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT l_returnflag, l_linestatus, SUM(l_orderkey) AS key_sum, COUNT(*) AS cnt
+			  FROM src.lineitem GROUP BY l_returnflag, l_linestatus)
+			TO 'mssql://db/dbo/bench_tpch_sum_agg' (FORMAT 'bcp', CREATE_TABLE true);
+	" "-" "aggregate-then-COPY (HUGEINT -> DECIMAL(38,0), #177)"
+
+	# --- Read path (TDS → DuckDB) ---
+
+	time_step "scan_full_lineitem_${SFX}" "
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT * FROM db.dbo.bench_tpch_lineitem)
+			TO '${NULL_DEV}' (FORMAT csv);
+	" "${LINEITEM_ROWS}" "drain scan, all columns"
+
+	time_step "scan_strings_${SFX}" "
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT p_name, p_type, p_comment FROM db.dbo.bench_tpch_part)
+			TO '${NULL_DEV}' (FORMAT csv);
+		COPY (SELECT c_name, c_address, c_comment FROM db.dbo.bench_tpch_customer)
+			TO '${NULL_DEV}' (FORMAT csv);
+	" "-" "part+customer string columns"
+
+	time_step "scan_lowcard_${SFX}" "
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		COPY (SELECT l_shipmode, l_returnflag FROM db.dbo.bench_tpch_lineitem)
+			TO '${NULL_DEV}' (FORMAT csv);
+	" "${LINEITEM_ROWS}" "low-cardinality projection (dictionary case, phases 2+)"
+
+	time_step "scan_limit_${SFX}" "
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		SELECT * FROM db.dbo.bench_tpch_lineitem LIMIT 10;
+	" "10" "cold bind + early abandon (per-chunk overhead)"
+
+	time_step "q1_local_${SFX}" "
+		ATTACH '${DSN}' AS db (TYPE mssql);
+		SELECT l_returnflag, l_linestatus,
+			   SUM(l_quantity) AS sum_qty,
+			   SUM(l_extendedprice) AS sum_base_price,
+			   SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+			   SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+			   AVG(l_quantity) AS avg_qty,
+			   AVG(l_extendedprice) AS avg_price,
+			   AVG(l_discount) AS avg_disc,
+			   COUNT(*) AS count_order
+		FROM db.dbo.bench_tpch_lineitem
+		WHERE l_shipdate <= DATE '1998-09-02'
+		GROUP BY l_returnflag, l_linestatus
+		ORDER BY l_returnflag, l_linestatus;
+	" "${LINEITEM_ROWS}" "TPC-H Q1 over attached table (scan + aggregate)"
+
+	rm -f "$SRC_DB"
+done
+
+echo ""
+echo "[bench_tpch_e2e] Cleanup: dropping bench_tpch_* server tables..."
+"$DUCKDB_BIN" -c "$(cleanup_sql)" >/dev/null 2>&1 || true
+
+{
+	echo ""
+	echo "# end of bench_tpch_e2e"
+	echo "# uname: $(uname -srm 2>/dev/null || uname -a)"
+	if [ -r /proc/cpuinfo ]; then
+		echo "# cpu_model: $(grep -m1 'model name' /proc/cpuinfo | sed 's/.*:[[:space:]]*//')"
+	else
+		echo "# cpu_model: $(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)"
+	fi
+	echo "# cores: $(getconf _NPROCESSORS_ONLN 2>/dev/null || echo unknown)"
+	if [ -r /proc/meminfo ]; then
+		echo "# ram_gb: $(awk '/MemTotal/ {printf \"%.1f\", $2 / 1024 / 1024}' /proc/meminfo)"
+	else
+		echo "# ram_gb: $(sysctl -n hw.memsize 2>/dev/null | awk '{printf \"%.1f\", $1 / 1024 / 1024 / 1024}' || echo unknown)"
+	fi
+	echo "# docker: $(docker --version 2>/dev/null || echo not-available)"
+	echo "# sql_server_image: $(docker inspect mssql-dev --format '{{.Image}}' 2>/dev/null || echo unknown)"
+} >> "$OUTPUT_FILE"
+
+echo ""
+echo "[bench_tpch_e2e] DONE. Output written to: $OUTPUT_FILE"
+cat "$OUTPUT_FILE"

--- a/test/bench/bench_tpch_e2e.sh
+++ b/test/bench/bench_tpch_e2e.sh
@@ -136,6 +136,29 @@ time_step() {
 	printf '%s\t%s\t%s\t%s\n' "$step" "$seconds" "$rows" "$notes" | tee -a "$OUTPUT_FILE"
 }
 
+# Non-fatal variant: records FAILED and continues. Used for the #177
+# copy_sum_agg step, which is EXPECTED to fail on pre-spec-054 builds
+# (HUGEINT -> BCP threw NotImplemented before the T4 fix) — the pre-merge
+# release comparison runs this script against v0.2.x sides.
+time_step_optional() {
+	local step="$1"
+	local sql="$2"
+	local rows="$3"
+	local notes="$4"
+	local t0
+	local t1
+	local seconds
+	t0=$(date +%s.%N)
+	if ! run_sql "$sql" >/dev/null 2>&1; then
+		printf '%s\t-\t%s\t%s\n' "$step" "$rows" "FAILED (expected on pre-054 builds: #177) — $notes" |
+			tee -a "$OUTPUT_FILE"
+		return 0
+	fi
+	t1=$(date +%s.%N)
+	seconds=$(awk "BEGIN {printf \"%.3f\", $t1 - $t0}")
+	printf '%s\t%s\t%s\t%s\n' "$step" "$seconds" "$rows" "$notes" | tee -a "$OUTPUT_FILE"
+}
+
 {
 	echo "# bench_tpch_e2e output"
 	echo "# date: $(date -Iseconds 2>/dev/null || date)"
@@ -204,7 +227,7 @@ for SF in $SF_LIST; do
 
 	# SUM(BIGINT) → HUGEINT → DECIMAL(38,0) on the wire: the #177 regression
 	# case (works natively since spec 054 T4; no ::DECIMAL cast workaround).
-	time_step "copy_sum_agg_${SFX}" "
+	time_step_optional "copy_sum_agg_${SFX}" "
 		ATTACH '${SRC_DB}' AS src;
 		ATTACH '${DSN}' AS db (TYPE mssql);
 		COPY (SELECT l_returnflag, l_linestatus, SUM(l_orderkey) AS key_sum, COUNT(*) AS cnt

--- a/test/bench/diff_check.sh
+++ b/test/bench/diff_check.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# test/bench/diff_check.sh
+#
+# Spec 054 D5: differential harness. Runs an identical query list through
+# TWO extension builds against the SAME SQL Server and compares the full
+# ordered result sets byte-for-byte (COPY ... TO csv + cmp). Used from
+# phase 0 onward as a merge gate for every conversion-touching PR in the
+# materialization series.
+#
+# Coverage (fixtures from docker/init/init.sql, loaded by `make docker-up`):
+#   - every type family            AllDataTypes (catalog scan + mssql_scan)
+#   - NULL-heavy                   NullableTypes, NullableDatetimeScales
+#   - PLP/MAX values               MaxTypes (incl. 8000-char values)
+#   - empty-string vs NULL         MaxTypes rows 2/3 + explicit probe
+#   - embedded NUL                 NCHAR(0) expression via mssql_scan
+#   - non-UTF8 collations          CollationTest
+#   - 0-row / 1-row results        AllDataTypes filters
+#   - >2048-row results            LargeTable (10k-row slice + full checksum)
+#   - BCP encode (write path)      write-back: COPY TO mssql + ordered readback
+#
+# Env vars:
+#   MSSQL_DIFF_DUCKDB_A   duckdb CLI for side A (default ./build/release/duckdb)
+#   MSSQL_DIFF_DUCKDB_B   duckdb CLI for side B (default: same as A)
+#   MSSQL_DIFF_LOAD_SQL_A SQL prefix loading mssql on side A; empty relies on
+#                         a built-in mssql. For a stock CLI use e.g.
+#                           "INSTALL mssql FROM community; LOAD mssql;"
+#                         or an unsigned local build:
+#                           "LOAD '/abs/path/mssql.duckdb_extension';"
+#   MSSQL_DIFF_LOAD_SQL_B same for side B
+#   MSSQL_DIFF_UNSIGNED_A set to 1 to pass -unsigned to side A
+#   MSSQL_DIFF_UNSIGNED_B set to 1 to pass -unsigned to side B
+#   MSSQL_TEST_HOST/PORT/USER/PASS/DB   same defaults as bench_tpch_e2e.sh
+#   MSSQL_DIFF_OUTPUT_DIR default: /tmp/mssql_diff_check_<pid>
+#
+# Exit codes: 0 all identical; 1 at least one query differs; 2 setup error;
+# 4 a side failed to execute its statement list.
+#
+# Manual target; NOT run as part of `make test` or any CI workflow.
+
+set -uo pipefail
+
+DUCKDB_A="${MSSQL_DIFF_DUCKDB_A:-./build/release/duckdb}"
+DUCKDB_B="${MSSQL_DIFF_DUCKDB_B:-$DUCKDB_A}"
+LOAD_SQL_A="${MSSQL_DIFF_LOAD_SQL_A:-}"
+LOAD_SQL_B="${MSSQL_DIFF_LOAD_SQL_B:-}"
+
+for bin in "$DUCKDB_A" "$DUCKDB_B"; do
+	if [ ! -x "$bin" ]; then
+		echo "ERROR: duckdb CLI '$bin' is not executable." >&2
+		exit 2
+	fi
+done
+
+HOST="${MSSQL_TEST_HOST:-localhost}"
+PORT="${MSSQL_TEST_PORT:-1433}"
+USER="${MSSQL_TEST_USER:-sa}"
+PASS="${MSSQL_TEST_PASS:-TestPassword1}"
+DB="${MSSQL_TEST_DB:-TestDB}"
+DSN="Server=${HOST},${PORT};Database=${DB};User Id=${USER};Password=${PASS}"
+
+OUT_DIR="${MSSQL_DIFF_OUTPUT_DIR:-/tmp/mssql_diff_check_$$}"
+mkdir -p "$OUT_DIR"
+
+# Plain strings, not arrays (bash 3.2 + set -u). Single-token flags.
+UNSIGNED_A=""
+UNSIGNED_B=""
+[ "${MSSQL_DIFF_UNSIGNED_A:-0}" = "1" ] && UNSIGNED_A="-unsigned"
+[ "${MSSQL_DIFF_UNSIGNED_B:-0}" = "1" ] && UNSIGNED_B="-unsigned"
+
+# The cmp loop below iterates this list; emit_side_script must write one
+# ${OUT_DIR}/<name>.<side>.csv per entry.
+QUERY_NAMES="alldatatypes_catalog alldatatypes_scan nullable_types datetime_scales maxtypes_plp empty_vs_null embedded_nul collation zero_rows one_row large_over_2048 large_checksum writeback_bcp"
+
+# Emit the full statement list for one side into a .sql file. $1 = side (a|b).
+# Every result lands in a csv named <query>.<side>.csv; the write-back case
+# additionally creates dbo.diff_check_wb_<side> on the server (dropped at the
+# end of this script).
+emit_side_script() {
+	local side="$1"
+	local load_sql="$2"
+	cat <<-EOF
+		${load_sql}
+		ATTACH '${DSN}' AS db (TYPE mssql);
+
+		COPY (SELECT * FROM db.dbo.AllDataTypes ORDER BY id)
+			TO '${OUT_DIR}/alldatatypes_catalog.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM mssql_scan('db', 'SELECT * FROM dbo.AllDataTypes ORDER BY id'))
+			TO '${OUT_DIR}/alldatatypes_scan.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.NullableTypes ORDER BY id)
+			TO '${OUT_DIR}/nullable_types.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.NullableDatetimeScales ORDER BY id)
+			TO '${OUT_DIR}/datetime_scales.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.MaxTypes ORDER BY id)
+			TO '${OUT_DIR}/maxtypes_plp.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT id,
+					 col_nvarchar_max IS NULL AS nv_is_null,
+					 coalesce(length(col_nvarchar_max), -1) AS nv_len,
+					 col_varchar_max IS NULL AS v_is_null,
+					 coalesce(length(col_varchar_max), -1) AS v_len,
+					 col_varbinary_max IS NULL AS vb_is_null,
+					 coalesce(octet_length(col_varbinary_max), -1) AS vb_len
+			  FROM db.dbo.MaxTypes ORDER BY id)
+			TO '${OUT_DIR}/empty_vs_null.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM mssql_scan('db',
+				'SELECT id, CONCAT(N''pre'', NCHAR(0), N''post'') AS s, NCHAR(0) AS only_nul FROM dbo.AllDataTypes ORDER BY id'))
+			TO '${OUT_DIR}/embedded_nul.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.CollationTest ORDER BY id)
+			TO '${OUT_DIR}/collation.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.AllDataTypes WHERE id < 0 ORDER BY id)
+			TO '${OUT_DIR}/zero_rows.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.AllDataTypes WHERE id = 1 ORDER BY id)
+			TO '${OUT_DIR}/one_row.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT * FROM db.dbo.LargeTable WHERE id <= 10000 ORDER BY id)
+			TO '${OUT_DIR}/large_over_2048.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT count(*) AS cnt,
+					 sum(id) AS sum_id,
+					 sum(category) AS sum_cat,
+					 sum(value) AS sum_value,
+					 min(created_date) AS min_date,
+					 max(created_date) AS max_date,
+					 sum(length(name)) AS name_len,
+					 sum(length(coalesce(description, ''))) AS desc_len,
+					 sum(CASE WHEN is_active THEN 1 ELSE 0 END) AS active_cnt
+			  FROM db.dbo.LargeTable)
+			TO '${OUT_DIR}/large_checksum.${side}.csv' (FORMAT csv, HEADER);
+
+		COPY (SELECT range::BIGINT AS id,
+					 'тест_' || range AS s_unique,
+					 CASE WHEN range % 7 = 0 THEN NULL
+						  WHEN range % 5 = 0 THEN ''
+						  ELSE 'val_' || (range % 10) END AS s_nullable,
+					 (range * 1.5)::DECIMAL(18,6) AS d18,
+					 (range % 2 = 0) AS flag,
+					 (range * 0.001)::DOUBLE AS dbl,
+					 TIMESTAMP '2024-01-01 00:00:00' + INTERVAL (range % 86400) SECOND AS ts,
+					 DATE '2024-01-01' + INTERVAL (range % 365) DAY AS dt
+			  FROM range(5000))
+			TO 'mssql://db/dbo/diff_check_wb_${side}' (FORMAT 'bcp', CREATE_TABLE true, OVERWRITE true);
+
+		COPY (SELECT * FROM mssql_scan('db',
+				'SELECT id, s_unique, s_nullable, d18, flag, dbl, ts, dt FROM dbo.diff_check_wb_${side} ORDER BY id'))
+			TO '${OUT_DIR}/writeback_bcp.${side}.csv' (FORMAT csv, HEADER);
+	EOF
+}
+
+echo "[diff_check] side A: $DUCKDB_A ${UNSIGNED_A} load='${LOAD_SQL_A}'"
+echo "[diff_check] side B: $DUCKDB_B ${UNSIGNED_B} load='${LOAD_SQL_B}'"
+echo "[diff_check] DSN: Server=${HOST},${PORT};Database=${DB};User Id=${USER};Password=***"
+echo "[diff_check] output dir: $OUT_DIR"
+echo ""
+
+# Pre-flight: fixtures must exist (docker/init/init.sql via `make docker-up`).
+preflight_out=$("$DUCKDB_A" $UNSIGNED_A -c "${LOAD_SQL_A} ATTACH '${DSN}' AS db (TYPE mssql); SELECT count(*) AS ok FROM db.dbo.AllDataTypes;" 2>&1)
+if ! echo "$preflight_out" | grep -q "ok"; then
+	echo "ERROR: pre-flight failed — dbo.AllDataTypes not reachable. Run 'make docker-up'" >&2
+	echo "       (fixtures come from docker/init/init.sql) and check the DSN. Last output:" >&2
+	echo "$preflight_out" >&2
+	exit 2
+fi
+echo "[diff_check] Pre-flight OK."
+
+run_side() {
+	local side="$1"
+	local bin="$2"
+	local unsigned_flag="$3"
+	local load_sql="$4"
+	local script="${OUT_DIR}/side_${side}.sql"
+	emit_side_script "$side" "$load_sql" > "$script"
+	echo "[diff_check] running side ${side}..."
+	if ! "$bin" $unsigned_flag < "$script" > "${OUT_DIR}/side_${side}.log" 2>&1; then
+		echo "ERROR: side ${side} failed. Log:" >&2
+		cat "${OUT_DIR}/side_${side}.log" >&2
+		exit 4
+	fi
+}
+
+run_side a "$DUCKDB_A" "$UNSIGNED_A" "$LOAD_SQL_A"
+run_side b "$DUCKDB_B" "$UNSIGNED_B" "$LOAD_SQL_B"
+
+echo ""
+failures=0
+for name in $QUERY_NAMES; do
+	fa="${OUT_DIR}/${name}.a.csv"
+	fb="${OUT_DIR}/${name}.b.csv"
+	if [ ! -f "$fa" ] || [ ! -f "$fb" ]; then
+		printf '%-24s MISSING (a:%s b:%s)\n' "$name" "$([ -f "$fa" ] && echo ok || echo absent)" "$([ -f "$fb" ] && echo ok || echo absent)"
+		failures=$((failures + 1))
+		continue
+	fi
+	if cmp -s "$fa" "$fb"; then
+		printf '%-24s PASS (%s bytes)\n' "$name" "$(wc -c < "$fa" | tr -d ' ')"
+	else
+		printf '%-24s DIFF — see %s vs %s\n' "$name" "$fa" "$fb"
+		failures=$((failures + 1))
+	fi
+done
+
+# Cleanup the server-side write-back tables (idempotent).
+"$DUCKDB_A" $UNSIGNED_A -c "${LOAD_SQL_A} ATTACH '${DSN}' AS db (TYPE mssql); DROP TABLE IF EXISTS db.dbo.diff_check_wb_a; DROP TABLE IF EXISTS db.dbo.diff_check_wb_b;" >/dev/null 2>&1 || true
+
+echo ""
+if [ "$failures" -gt 0 ]; then
+	echo "[diff_check] FAILED: ${failures} quer(y/ies) differ or are missing. Artifacts kept in $OUT_DIR"
+	exit 1
+fi
+echo "[diff_check] OK: all queries byte-identical across the two builds."
+exit 0

--- a/test/cpp/bench_materialize.cpp
+++ b/test/cpp/bench_materialize.cpp
@@ -31,7 +31,12 @@
 //     mssql_scan_dictionary_max default planned in phase 2)
 //   - flags   {embedded U+0000, trailing lone high surrogate}
 
+#include "codec/datetime_codec.hpp"
+#include "codec/decimal_codec.hpp"
+#include "codec/float_codec.hpp"
+#include "codec/integer_codec.hpp"
 #include "codec/string_codec.hpp"
+#include "codec/uuid_codec.hpp"
 #include "tds/encoding/utf16.hpp"
 #include "tds/tds_column_metadata.hpp"
 #include "tds/tds_types.hpp"
@@ -319,6 +324,196 @@ std::vector<CellSpec> BuildCells() {
 	return cells;
 }
 
+//===----------------------------------------------------------------------===//
+// Fixed-decode group (T6): per-family CURRENT per-value decode path.
+// Wire payloads are generated from a deterministic per-row value so the
+// integer/float/decimal cells can be verified against independently
+// reconstructed expectations; datetime/uuid cells assert determinism
+// (two decodes produce identical chunks).
+//===----------------------------------------------------------------------===//
+
+using DecodeFn = void (*)(const std::vector<uint8_t> &, const duckdb::tds::ColumnMetadata &, Vector &, idx_t);
+
+struct FixedCell {
+	std::string name;
+	LogicalType type;
+	duckdb::tds::ColumnMetadata col;
+	DecodeFn decode;
+	std::vector<std::vector<uint8_t>> rows;	 // per-row wire payloads
+	size_t in_bytes = 0;
+	int null_pct = 0;
+};
+
+void AppendLe(std::vector<uint8_t> &b, uint64_t v, int n) {
+	for (int i = 0; i < n; ++i) {
+		b.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xFF));
+	}
+}
+
+uint64_t RowValue(idx_t row) {
+	return row * 2654435761ULL + 17;  // deterministic, mixes bits
+}
+
+FixedCell MakeFixedCell(const std::string &name, LogicalType type, uint8_t tds_type, uint8_t precision, uint8_t scale,
+						DecodeFn decode, size_t wire_bytes_per_value, int null_pct = 0) {
+	FixedCell c;
+	c.name = name;
+	c.type = type;
+	c.col.name = "c";
+	c.col.type_id = tds_type;
+	c.col.max_length = static_cast<uint16_t>(wire_bytes_per_value);
+	c.col.precision = precision;
+	c.col.scale = scale;
+	c.col.collation = 0;
+	c.col.flags = 0;
+	c.decode = decode;
+	c.null_pct = null_pct;
+	c.rows.reserve(CHUNK_ROWS);
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		if (null_pct >= 100 || (null_pct > 0 && (row % 100) < static_cast<idx_t>(null_pct))) {
+			c.rows.emplace_back();	// NULL
+			continue;
+		}
+		std::vector<uint8_t> b;
+		uint64_t v = RowValue(row);
+		switch (tds_type) {
+		case duckdb::tds::TDS_TYPE_INTN:
+			AppendLe(b, v, static_cast<int>(wire_bytes_per_value));
+			break;
+		case duckdb::tds::TDS_TYPE_FLOATN: {
+			double d = static_cast<double>(v) * 1.5;
+			uint64_t bits;
+			std::memcpy(&bits, &d, 8);
+			AppendLe(b, bits, 8);
+			break;
+		}
+		case duckdb::tds::TDS_TYPE_DATETIME2: {
+			// scale 6: 5-byte time (µs units) + 3-byte date (days since 0001-01-01)
+			AppendLe(b, v % 86400000000ULL, 5);
+			AppendLe(b, 738000 + (v % 1000), 3);
+			break;
+		}
+		case duckdb::tds::TDS_TYPE_DECIMAL: {
+			// sign + LE mantissa (bucket size = wire_bytes_per_value - 1)
+			b.push_back(0x01);
+			uint64_t mantissa = (precision <= 4) ? (v % 9999) : v;
+			AppendLe(b, mantissa, static_cast<int>(wire_bytes_per_value) - 1);
+			break;
+		}
+		case duckdb::tds::TDS_TYPE_UNIQUEIDENTIFIER:
+			AppendLe(b, v, 8);
+			AppendLe(b, ~v, 8);
+			break;
+		default:
+			break;
+		}
+		c.in_bytes += b.size();
+		c.rows.push_back(std::move(b));
+	}
+	return c;
+}
+
+size_t FillChunkFixed(const FixedCell &c, DataChunk &chunk) {
+	chunk.Reset();
+	auto &vec = chunk.data[0];
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		if (c.rows[row].empty()) {
+			FlatVector::SetNull(vec, row, true);
+			continue;
+		}
+		c.decode(c.rows[row], c.col, vec, row);
+	}
+	chunk.SetCardinality(CHUNK_ROWS);
+	g_sink ^= CHUNK_ROWS;
+	return c.in_bytes;
+}
+
+// Integer/float/decimal: verify against independently reconstructed values.
+// Datetime/uuid: verify two decodes agree (determinism).
+bool VerifyFixed(const FixedCell &c, DataChunk &chunk) {
+	auto &vec = chunk.data[0];
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		bool expect_null = c.rows[row].empty();
+		if (FlatVector::IsNull(vec, row) != expect_null) {
+			return false;
+		}
+		if (expect_null) {
+			continue;
+		}
+		uint64_t v = RowValue(row);
+		switch (c.type.id()) {
+		case duckdb::LogicalTypeId::BIGINT:
+			if (FlatVector::GetData<int64_t>(vec)[row] != static_cast<int64_t>(v)) {
+				return false;
+			}
+			break;
+		case duckdb::LogicalTypeId::INTEGER:
+			if (FlatVector::GetData<int32_t>(vec)[row] != static_cast<int32_t>(v & 0xFFFFFFFF)) {
+				return false;
+			}
+			break;
+		case duckdb::LogicalTypeId::SMALLINT:
+			if (FlatVector::GetData<int16_t>(vec)[row] != static_cast<int16_t>(v & 0xFFFF)) {
+				return false;
+			}
+			break;
+		case duckdb::LogicalTypeId::UTINYINT:
+			if (FlatVector::GetData<uint8_t>(vec)[row] != static_cast<uint8_t>(v & 0xFF)) {
+				return false;
+			}
+			break;
+		case duckdb::LogicalTypeId::DOUBLE:
+			if (FlatVector::GetData<double>(vec)[row] != static_cast<double>(v) * 1.5) {
+				return false;
+			}
+			break;
+		default:
+			break;	// datetime/uuid/decimal buckets: determinism check below
+		}
+	}
+	// Determinism: a second decode into a fresh chunk must be value-identical.
+	DataChunk chunk2;
+	chunk2.Initialize(duckdb::Allocator::DefaultAllocator(), {c.type});
+	FillChunkFixed(c, chunk2);
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		if (c.rows[row].empty()) {
+			continue;  // NULL rows verified via the mask above; Value comparison on NULLs throws
+		}
+		if (chunk.data[0].GetValue(row) != chunk2.data[0].GetValue(row)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+std::vector<FixedCell> BuildFixedCells() {
+	namespace t = duckdb::tds;
+	std::vector<FixedCell> cells;
+	cells.push_back(MakeFixedCell("int1_utinyint", LogicalType::UTINYINT, t::TDS_TYPE_INTN, 0, 0,
+								  duckdb::mssql::codec::integer::DecodeFromTds, 1));
+	cells.push_back(MakeFixedCell("int2_smallint", LogicalType::SMALLINT, t::TDS_TYPE_INTN, 0, 0,
+								  duckdb::mssql::codec::integer::DecodeFromTds, 2));
+	cells.push_back(MakeFixedCell("int4_integer", LogicalType::INTEGER, t::TDS_TYPE_INTN, 0, 0,
+								  duckdb::mssql::codec::integer::DecodeFromTds, 4));
+	cells.push_back(MakeFixedCell("int8_bigint", LogicalType::BIGINT, t::TDS_TYPE_INTN, 0, 0,
+								  duckdb::mssql::codec::integer::DecodeFromTds, 8));
+	cells.push_back(MakeFixedCell("int8_bigint_null50", LogicalType::BIGINT, t::TDS_TYPE_INTN, 0, 0,
+								  duckdb::mssql::codec::integer::DecodeFromTds, 8, 50));
+	cells.push_back(MakeFixedCell("float8_double", LogicalType::DOUBLE, t::TDS_TYPE_FLOATN, 0, 0,
+								  duckdb::mssql::codec::float_family::DecodeFromTds, 8));
+	cells.push_back(MakeFixedCell("datetime2_s6_timestamp", LogicalType::TIMESTAMP, t::TDS_TYPE_DATETIME2, 0, 6,
+								  duckdb::mssql::codec::datetime::DecodeFromTds, 8));
+	cells.push_back(MakeFixedCell("decimal_p4s2_int16", LogicalType::DECIMAL(4, 2), t::TDS_TYPE_DECIMAL, 4, 2,
+								  duckdb::mssql::codec::decimal::DecodeFromTds, 5));
+	cells.push_back(MakeFixedCell("decimal_p18s6_int64", LogicalType::DECIMAL(18, 6), t::TDS_TYPE_DECIMAL, 18, 6,
+								  duckdb::mssql::codec::decimal::DecodeFromTds, 9));
+	cells.push_back(MakeFixedCell("decimal_p38s0_int128", LogicalType::DECIMAL(38, 0), t::TDS_TYPE_DECIMAL, 38, 0,
+								  duckdb::mssql::codec::decimal::DecodeFromTds, 17));
+	cells.push_back(MakeFixedCell("uuid", LogicalType::UUID, t::TDS_TYPE_UNIQUEIDENTIFIER, 0, 0,
+								  duckdb::mssql::codec::uuid::DecodeFromTds, 16));
+	return cells;
+}
+
 }  // namespace
 
 int main() {
@@ -355,6 +550,28 @@ int main() {
 		std::printf("string_decode_current\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t%zu\t%zu\t%s\n", spec.name.c_str(),
 					r.median_us_per_chunk, r.p10_us_per_chunk, r.p90_us_per_chunk, r.median_ns_per_value,
 					f.utf16_bytes, out_bytes, correct ? "PASS" : "FAIL");
+	}
+
+	for (const auto &fc : BuildFixedCells()) {
+		try {
+		DataChunk chunk;
+		chunk.Initialize(duckdb::Allocator::DefaultAllocator(), {fc.type});
+
+		FillChunkFixed(fc, chunk);
+		bool correct = VerifyFixed(fc, chunk);
+		if (!correct) {
+			failures++;
+		}
+
+		auto r = TimeCell([&]() { FillChunkFixed(fc, chunk); }, 400);
+
+		std::printf("fixed_decode_current\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t%zu\t-\t%s\n", fc.name.c_str(),
+					r.median_us_per_chunk, r.p10_us_per_chunk, r.p90_us_per_chunk, r.median_ns_per_value, fc.in_bytes,
+					correct ? "PASS" : "FAIL");
+		} catch (std::exception &ex) {
+			std::fprintf(stderr, "cell %s threw: %s\n", fc.name.c_str(), ex.what());
+			failures++;
+		}
 	}
 
 	if (failures > 0) {

--- a/test/cpp/bench_materialize.cpp
+++ b/test/cpp/bench_materialize.cpp
@@ -1,0 +1,366 @@
+// test/cpp/bench_materialize.cpp
+//
+// Spec 054 D1: micro-benchmark harness for the materialization series
+// (TDS → DuckDB chunk fill and DuckDB → BCP encode).
+//
+// T1 scope: harness skeleton + the string-decode group, CURRENT path only
+// (codec::string::DecodeFromTds — Utf16LEDecode → std::string → AddString
+// into a DataChunk, exactly the scan hot path). Strategy variants
+// (A-lite / A) and the fixed-decode / bcp-encode groups land in later
+// tasks; the fixture matrix already covers the gating cases for the
+// deferred strategies B (value ending in a lone high surrogate) and C
+// (embedded U+0000).
+//
+// Follows the bench_utf16.cpp pattern (spec 044): -O3 -DMSSQL_BENCH_BUILD,
+// warm-up + median-of-N steady_clock timing, per-cell correctness
+// assertion, manual target only (`make bench-materialize`) — NOT part of
+// `make test` or any CI workflow.
+//
+// Metrics per cell (TSV): ns/value median, p10, p90, utf16 input bytes and
+// utf8 output bytes per chunk. Allocation counting (design §7.1) needs
+// malloc interposition and is deferred to the Linux baseline run.
+//
+// Cell design: the full cross of the design-§7.1 matrix is ~3.5k cells;
+// the harness instead sweeps ONE dimension at a time around a base cell
+// (len=16 code units, ascii, nulls 0%, cardinality 2048 = all-unique):
+//   - length  {0,4,8,16,32,64,256,4096}   (12-byte string_t inline
+//     threshold makes 4/8/16 mandatory)
+//   - script  {ascii, cyrillic, cjk, surrogate}
+//   - nulls   {0,10,50,100}%
+//   - cardinality {1,2,10,100,101,512,2048}  (101 = one past the
+//     mssql_scan_dictionary_max default planned in phase 2)
+//   - flags   {embedded U+0000, trailing lone high surrogate}
+
+#include "codec/string_codec.hpp"
+#include "tds/encoding/utf16.hpp"
+#include "tds/tds_column_metadata.hpp"
+#include "tds/tds_types.hpp"
+
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/vector.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using duckdb::DataChunk;
+using duckdb::FlatVector;
+using duckdb::idx_t;
+using duckdb::LogicalType;
+using duckdb::string_t;
+using duckdb::Vector;
+
+namespace {
+
+constexpr idx_t CHUNK_ROWS = 2048;	// STANDARD_VECTOR_SIZE
+
+//===----------------------------------------------------------------------===//
+// Fixture generation — UTF-16LE payloads, one per row of a 2048-row chunk.
+//===----------------------------------------------------------------------===//
+
+enum class Script { Ascii, Cyrillic, Cjk, Surrogate };
+
+struct CellSpec {
+	std::string name;
+	size_t len_units = 16;	// UTF-16 code units per value
+	Script script = Script::Ascii;
+	int null_pct = 0;			   // % of NULL rows
+	size_t cardinality = 2048;	   // distinct values in the chunk
+	bool embedded_nul = false;	   // strategy-C gating case
+	bool lone_high_surr = false;   // strategy-B gating case (invalid UTF-16 tail)
+};
+
+void AppendUnit(std::vector<uint8_t> &buf, uint16_t unit) {
+	buf.push_back(static_cast<uint8_t>(unit & 0xFF));
+	buf.push_back(static_cast<uint8_t>(unit >> 8));
+}
+
+// Build one UTF-16LE payload. `distinct_id` is mixed into the tail as hex
+// digits so cells with cardinality > 1 get genuinely distinct byte content.
+std::vector<uint8_t> BuildPayload(const CellSpec &c, size_t distinct_id) {
+	std::vector<uint8_t> buf;
+	buf.reserve(c.len_units * 2);
+
+	size_t units_left = c.len_units;
+
+	// Reserve up to 4 tail units for the distinct-id hex digits (fewer when
+	// the value is shorter; len 0 stays empty → cardinality collapses to 1).
+	size_t id_units = std::min<size_t>(4, units_left);
+
+	size_t body_units = units_left - id_units;
+	size_t i = 0;
+	while (i < body_units) {
+		switch (c.script) {
+		case Script::Ascii:
+			AppendUnit(buf, static_cast<uint16_t>('a' + (i % 26)));
+			i += 1;
+			break;
+		case Script::Cyrillic:
+			AppendUnit(buf, static_cast<uint16_t>(0x0410 + (i % 32)));	// А..Я
+			i += 1;
+			break;
+		case Script::Cjk:
+			AppendUnit(buf, static_cast<uint16_t>(0x4E00 + (i % 256)));
+			i += 1;
+			break;
+		case Script::Surrogate:
+			if (i + 2 <= body_units) {
+				// U+1F600.. as a surrogate pair.
+				AppendUnit(buf, 0xD83D);
+				AppendUnit(buf, static_cast<uint16_t>(0xDE00 + (i % 64)));
+				i += 2;
+			} else {
+				AppendUnit(buf, static_cast<uint16_t>('a' + (i % 26)));
+				i += 1;
+			}
+			break;
+		}
+	}
+
+	for (size_t d = 0; d < id_units; ++d) {
+		AppendUnit(buf, static_cast<uint16_t>("0123456789abcdef"[(distinct_id >> (4 * d)) & 0xF]));
+	}
+
+	if (c.embedded_nul && buf.size() >= 4) {
+		// Overwrite the first unit with U+0000 (valid UTF-16, embedded NUL).
+		buf[0] = 0x00;
+		buf[1] = 0x00;
+	}
+	if (c.lone_high_surr && buf.size() >= 2) {
+		// Overwrite the LAST unit with an unpaired high surrogate — invalid
+		// UTF-16; the current path must route through the legacy fallback.
+		buf[buf.size() - 2] = 0x00;
+		buf[buf.size() - 1] = 0xD8;
+	}
+	return buf;
+}
+
+struct Fixture {
+	CellSpec spec;
+	// Per-row payloads (empty vector at index i + null_mask[i] => NULL row).
+	std::vector<std::vector<uint8_t>> rows;
+	std::vector<bool> null_mask;
+	size_t utf16_bytes = 0;	 // total non-NULL input bytes per chunk
+};
+
+Fixture BuildFixture(const CellSpec &c) {
+	Fixture f;
+	f.spec = c;
+	f.rows.reserve(CHUNK_ROWS);
+	f.null_mask.reserve(CHUNK_ROWS);
+
+	// Distinct payload pool.
+	size_t card = std::max<size_t>(1, std::min<size_t>(c.cardinality, CHUNK_ROWS));
+	std::vector<std::vector<uint8_t>> pool;
+	pool.reserve(card);
+	for (size_t v = 0; v < card; ++v) {
+		pool.push_back(BuildPayload(c, v));
+	}
+
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		// Deterministic NULL spread: null_pct rows out of every 100, striped.
+		bool is_null = c.null_pct >= 100 || (c.null_pct > 0 && (row % 100) < static_cast<idx_t>(c.null_pct));
+		f.null_mask.push_back(is_null);
+		if (is_null) {
+			f.rows.emplace_back();
+		} else {
+			f.rows.push_back(pool[row % card]);
+			f.utf16_bytes += f.rows.back().size();
+		}
+	}
+	return f;
+}
+
+//===----------------------------------------------------------------------===//
+// Timed body — the CURRENT scan path, per value:
+// codec::string::DecodeFromTds (Utf16LEDecode → std::string → AddString).
+//===----------------------------------------------------------------------===//
+
+volatile uint64_t g_sink = 0;
+
+// One chunk fill. Returns total utf8 output bytes (fed to g_sink so the
+// optimizer cannot drop the work).
+size_t FillChunkCurrent(const Fixture &f, DataChunk &chunk, const duckdb::tds::ColumnMetadata &col) {
+	chunk.Reset();
+	auto &vec = chunk.data[0];
+	size_t out_bytes = 0;
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		if (f.null_mask[row]) {
+			FlatVector::SetNull(vec, row, true);
+			continue;
+		}
+		duckdb::mssql::codec::string::DecodeFromTds(f.rows[row], col, vec, row);
+		out_bytes += FlatVector::GetData<string_t>(vec)[row].GetSize();
+	}
+	chunk.SetCardinality(CHUNK_ROWS);
+	g_sink ^= out_bytes;
+	return out_bytes;
+}
+
+//===----------------------------------------------------------------------===//
+// Correctness: the vector contents must equal a direct per-value reference
+// decode (later strategy variants are asserted against the same reference).
+//===----------------------------------------------------------------------===//
+
+bool VerifyChunk(const Fixture &f, DataChunk &chunk, const duckdb::tds::ColumnMetadata &col) {
+	auto &vec = chunk.data[0];
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		if (f.null_mask[row]) {
+			if (!FlatVector::IsNull(vec, row)) {
+				return false;
+			}
+			continue;
+		}
+		std::string expect = duckdb::tds::encoding::Utf16LEDecode(f.rows[row].data(), f.rows[row].size());
+		auto got = FlatVector::GetData<string_t>(vec)[row];
+		if (std::string(got.GetData(), got.GetSize()) != expect) {
+			return false;
+		}
+	}
+	return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Timing: warm-up + median / p10 / p90 of N iterations.
+//===----------------------------------------------------------------------===//
+
+// One sample = one full 2048-row chunk fill. Reported at BOTH granularities:
+// per-chunk (µs — what FillChunk actually costs per iteration) and per-value
+// (ns — comparable across cells with different NULL ratios only via the
+// chunk number, since NULL rows still occupy a slot).
+struct CellResult {
+	double median_us_per_chunk;
+	double p10_us_per_chunk;
+	double p90_us_per_chunk;
+	double median_ns_per_value;	 // median_us_per_chunk * 1000 / CHUNK_ROWS
+};
+
+template <typename Fn>
+CellResult TimeCell(Fn fn, size_t iterations) {
+	using clock = std::chrono::steady_clock;
+	for (size_t w = 0; w < 10; ++w) {
+		fn();
+	}
+	std::vector<double> samples;  // ns per chunk
+	samples.reserve(iterations);
+	for (size_t i = 0; i < iterations; ++i) {
+		const auto t0 = clock::now();
+		fn();
+		const auto t1 = clock::now();
+		samples.push_back(static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()));
+	}
+	std::sort(samples.begin(), samples.end());
+	CellResult r;
+	r.median_us_per_chunk = samples[samples.size() / 2] / 1e3;
+	r.p10_us_per_chunk = samples[samples.size() / 10] / 1e3;
+	r.p90_us_per_chunk = samples[(samples.size() * 9) / 10] / 1e3;
+	r.median_ns_per_value = samples[samples.size() / 2] / static_cast<double>(CHUNK_ROWS);
+	return r;
+}
+
+size_t IterationsFor(size_t utf16_bytes) {
+	// Keep each cell around a comparable wall budget: big payloads run fewer
+	// iterations. ~1 MB per chunk → 50; small cells → 400.
+	return (utf16_bytes >= 1 << 20) ? 50 : 400;
+}
+
+//===----------------------------------------------------------------------===//
+// Cell list — base + one-dimension sweeps (see header comment).
+//===----------------------------------------------------------------------===//
+
+std::vector<CellSpec> BuildCells() {
+	std::vector<CellSpec> cells;
+	auto add = [&](CellSpec c, const std::string &name) {
+		c.name = name;
+		cells.push_back(c);
+	};
+
+	CellSpec base;	// len=16 ascii null0 card2048
+
+	for (size_t len : {0, 4, 8, 16, 32, 64, 256, 4096}) {
+		CellSpec c = base;
+		c.len_units = len;
+		add(c, "len" + std::to_string(len) + "_ascii_null0_card2048");
+	}
+	{
+		CellSpec c = base;
+		c.script = Script::Cyrillic;
+		add(c, "len16_cyrillic_null0_card2048");
+		c.script = Script::Cjk;
+		add(c, "len16_cjk_null0_card2048");
+		c.script = Script::Surrogate;
+		add(c, "len16_surrogate_null0_card2048");
+	}
+	for (int nulls : {10, 50, 100}) {
+		CellSpec c = base;
+		c.null_pct = nulls;
+		add(c, "len16_ascii_null" + std::to_string(nulls) + "_card2048");
+	}
+	for (size_t card : {1, 2, 10, 100, 101, 512}) {
+		CellSpec c = base;
+		c.cardinality = card;
+		add(c, "len16_ascii_null0_card" + std::to_string(card));
+	}
+	{
+		CellSpec c = base;
+		c.embedded_nul = true;
+		add(c, "len16_ascii_embedded_nul");
+	}
+	{
+		CellSpec c = base;
+		c.lone_high_surr = true;
+		add(c, "len16_ascii_lone_high_surrogate");
+	}
+	return cells;
+}
+
+}  // namespace
+
+int main() {
+	std::printf("[bench_materialize] spec 054 D1 — string decode group (current path)\n");
+	std::printf("group\tcell\tus_per_chunk_median\tus_p10\tus_p90\tns_per_value_median"
+				"\tutf16_in_bytes\tutf8_out_bytes\tcorrect\n");
+
+	duckdb::tds::ColumnMetadata col;
+	col.name = "c";
+	col.type_id = duckdb::tds::TDS_TYPE_NVARCHAR;
+	col.max_length = 0x1FFE;
+	col.precision = 0;
+	col.scale = 0;
+	col.collation = 0;
+	col.flags = 0;
+
+	int failures = 0;
+	auto cells = BuildCells();
+	for (const auto &spec : cells) {
+		Fixture f = BuildFixture(spec);
+
+		DataChunk chunk;
+		chunk.Initialize(duckdb::Allocator::DefaultAllocator(), {LogicalType::VARCHAR});
+
+		// Correctness once, outside timing.
+		size_t out_bytes = FillChunkCurrent(f, chunk, col);
+		bool correct = VerifyChunk(f, chunk, col);
+		if (!correct) {
+			failures++;
+		}
+
+		auto r = TimeCell([&]() { FillChunkCurrent(f, chunk, col); }, IterationsFor(f.utf16_bytes));
+
+		std::printf("string_decode_current\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t%zu\t%zu\t%s\n", spec.name.c_str(),
+					r.median_us_per_chunk, r.p10_us_per_chunk, r.p90_us_per_chunk, r.median_ns_per_value,
+					f.utf16_bytes, out_bytes, correct ? "PASS" : "FAIL");
+	}
+
+	if (failures > 0) {
+		std::fprintf(stderr, "\n%d cell(s) FAILED correctness.\n", failures);
+		return 1;
+	}
+	std::printf("\n[bench_materialize] all cells correct. sink=%llu\n", (unsigned long long)g_sink);
+	return 0;
+}

--- a/test/cpp/bench_materialize.cpp
+++ b/test/cpp/bench_materialize.cpp
@@ -661,15 +661,37 @@ BcpFixture BuildBcpFixture(const BcpCellSpec &s) {
 	return f;
 }
 
-// One chunk encode — production shape: EncodeRow per row into one buffer
-// (clear() keeps capacity, matching the reused per-batch packet buffer).
-size_t EncodeChunkCurrent(BcpFixture &f, duckdb::vector<uint8_t> &buf) {
+// Per-row compatibility path: EncodeRow per row into one buffer (clear()
+// keeps capacity). Pre-W1 this was the production shape (group
+// bcp_encode_current in the baseline tables); post-W1 it is the per-row
+// API (one format build per cell) and reports as bcp_encode_perrow.
+size_t EncodeChunkPerRow(BcpFixture &f, duckdb::vector<uint8_t> &buf) {
 	buf.clear();
 	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
 		duckdb::tds::encoding::BCPRowEncoder::EncodeRow(buf, *f.chunk, row, f.cols, nullptr);
 	}
 	g_sink ^= buf.size();
 	return buf.size();
+}
+
+// Production shape post-W1/W2: one EncodeChunk call — per-column format /
+// encoder / NULL-kind hoisted once, 0xD1 ROW token written per row.
+size_t EncodeChunkHoisted(BcpFixture &f, duckdb::vector<uint8_t> &buf) {
+	buf.clear();
+	duckdb::tds::encoding::BCPRowEncoder::EncodeChunk(buf, *f.chunk, f.cols, nullptr);
+	g_sink ^= buf.size();
+	return buf.size();
+}
+
+// Hoisted output must equal the per-row path's output with one 0xD1 token
+// injected per row — old-vs-new byte equivalence inside one binary.
+bool VerifyHoisted(BcpFixture &f, const duckdb::vector<uint8_t> &got) {
+	duckdb::vector<uint8_t> expect;
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		expect.push_back(0xD1);
+		duckdb::tds::encoding::BCPRowEncoder::EncodeRow(expect, *f.chunk, row, f.cols, nullptr);
+	}
+	return expect.size() == got.size() && std::equal(expect.begin(), expect.end(), got.begin());
 }
 
 // Reference: the Value-based encoder over GetValue(row) (resolves dict /
@@ -793,17 +815,29 @@ int main() {
 			duckdb::vector<uint8_t> buf;
 			buf.reserve(1 << 20);
 
-			size_t out_bytes = EncodeChunkCurrent(f, buf);
+			size_t out_bytes = EncodeChunkPerRow(f, buf);
 			bool correct = VerifyBcp(f, buf);
 			if (!correct) {
 				failures++;
 			}
 
-			auto r = TimeCell([&]() { EncodeChunkCurrent(f, buf); }, 400);
+			auto r = TimeCell([&]() { EncodeChunkPerRow(f, buf); }, 400);
 
-			std::printf("bcp_encode_current\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t-\t%zu\t%s\n", bspec.name.c_str(),
+			std::printf("bcp_encode_perrow\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t-\t%zu\t%s\n", bspec.name.c_str(),
 						r.median_us_per_chunk, r.p10_us_per_chunk, r.p90_us_per_chunk, r.median_ns_per_value, out_bytes,
 						correct ? "PASS" : "FAIL");
+
+			size_t hoisted_bytes = EncodeChunkHoisted(f, buf);
+			bool hoisted_correct = VerifyHoisted(f, buf);
+			if (!hoisted_correct) {
+				failures++;
+			}
+
+			auto rh = TimeCell([&]() { EncodeChunkHoisted(f, buf); }, 400);
+
+			std::printf("bcp_encode_hoisted\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t-\t%zu\t%s\n", bspec.name.c_str(),
+						rh.median_us_per_chunk, rh.p10_us_per_chunk, rh.p90_us_per_chunk, rh.median_ns_per_value,
+						hoisted_bytes, hoisted_correct ? "PASS" : "FAIL");
 		} catch (std::exception &ex) {
 			std::fprintf(stderr, "cell %s threw: %s\n", bspec.name.c_str(), ex.what());
 			failures++;

--- a/test/cpp/bench_materialize.cpp
+++ b/test/cpp/bench_materialize.cpp
@@ -37,6 +37,8 @@
 #include "codec/integer_codec.hpp"
 #include "codec/string_codec.hpp"
 #include "codec/uuid_codec.hpp"
+#include "copy/target_resolver.hpp"
+#include "tds/encoding/bcp_row_encoder.hpp"
 #include "tds/encoding/utf16.hpp"
 #include "tds/tds_column_metadata.hpp"
 #include "tds/tds_types.hpp"
@@ -44,14 +46,32 @@
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
+
+namespace duckdb {
+namespace mssql {
+
+// The bench links bcp_row_encoder.cpp but NOT target_resolver.cpp (that TU
+// drags in the catalog / ClientContext). EncodeRow's NULL path needs this one
+// method; the body mirrors target_resolver.cpp verbatim.
+bool BCPColumnMetadata::IsVariableLengthUSHORT() const {
+	// NVARCHARTYPE (0xE7) and BIGVARBINARYTYPE (0xA5) use USHORTLEN
+	return tds_type_token == 0xE7 || tds_type_token == 0xA5;
+}
+
+}  // namespace mssql
+}  // namespace duckdb
 
 using duckdb::DataChunk;
 using duckdb::FlatVector;
@@ -514,10 +534,203 @@ std::vector<FixedCell> BuildFixedCells() {
 	return cells;
 }
 
+//===----------------------------------------------------------------------===//
+// BCP-encode group (T6 part 2): the CURRENT write path — one
+// BCPRowEncoder::EncodeRow call per row (family dispatch; per-cell
+// ToUnifiedFormat in BOTH the NULL check and the codec value read), on
+// flat-unique / flat-low-cardinality / dictionary {1,10,100} / constant
+// inputs × NULL ratios. Dictionary inputs are built with
+// Vector::Dictionary(dict, dict_size, sel, count) — the same construction
+// the phase-2 scan will emit and the phase-3 representation-aware encoder
+// will detect via DictionaryVector::DictionarySize; the current path is
+// expected to be representation-blind (dict ≈ flat at equal value bytes).
+//===----------------------------------------------------------------------===//
+
+enum class VecRep { FlatUnique, FlatLowCard, Dict, Constant };
+
+struct BcpCellSpec {
+	enum class Kind { Bigint, Varchar16, Decimal18s6 };
+	std::string name;
+	Kind kind = Kind::Bigint;
+	VecRep rep = VecRep::FlatUnique;
+	size_t card = 2048;	 // distinct values (FlatLowCard / Dict)
+	int null_pct = 0;
+};
+
+bool RowIsNull(int null_pct, idx_t row) {
+	return null_pct >= 100 || (null_pct > 0 && (row % 100) < static_cast<idx_t>(null_pct));
+}
+
+LogicalType BcpTypeFor(BcpCellSpec::Kind k) {
+	switch (k) {
+	case BcpCellSpec::Kind::Bigint:
+		return LogicalType::BIGINT;
+	case BcpCellSpec::Kind::Varchar16:
+		return LogicalType::VARCHAR;
+	case BcpCellSpec::Kind::Decimal18s6:
+		return LogicalType::DECIMAL(18, 6);
+	}
+	return LogicalType::BIGINT;
+}
+
+duckdb::Value MakeBcpValue(BcpCellSpec::Kind k, size_t id) {
+	using duckdb::Value;
+	switch (k) {
+	case BcpCellSpec::Kind::Bigint:
+		return Value::BIGINT(static_cast<int64_t>(RowValue(id)));
+	case BcpCellSpec::Kind::Varchar16: {
+		// 16 ASCII chars: 8-char body + 8 hex digits of the distinct id.
+		char s[17];
+		std::snprintf(s, sizeof(s), "abcdefgh%08lx", static_cast<unsigned long>(id) & 0xFFFFFFFFUL);
+		return Value(std::string(s, 16));
+	}
+	case BcpCellSpec::Kind::Decimal18s6:
+		// Mantissa < 10^18 so the precision-18 range guard never fires.
+		return Value::DECIMAL(static_cast<int64_t>(RowValue(id) % 1000000000000000000ULL), 18, 6);
+	}
+	return Value();
+}
+
+struct BcpFixture {
+	BcpCellSpec spec;
+	std::unique_ptr<Vector> dict_base;	// keep the dictionary child alive
+	std::unique_ptr<DataChunk> chunk;
+	duckdb::vector<duckdb::mssql::BCPColumnMetadata> cols;
+};
+
+BcpFixture BuildBcpFixture(const BcpCellSpec &s) {
+	BcpFixture f;
+	f.spec = s;
+	LogicalType type = BcpTypeFor(s.kind);
+	f.chunk.reset(new DataChunk());
+	f.chunk->Initialize(duckdb::Allocator::DefaultAllocator(), {type});
+	auto &vec = f.chunk->data[0];
+
+	switch (s.rep) {
+	case VecRep::FlatUnique:
+	case VecRep::FlatLowCard: {
+		const size_t card = (s.rep == VecRep::FlatUnique) ? CHUNK_ROWS : s.card;
+		for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+			vec.SetValue(row, RowIsNull(s.null_pct, row) ? duckdb::Value(type) : MakeBcpValue(s.kind, row % card));
+		}
+		break;
+	}
+	case VecRep::Dict: {
+		// NULL rows point at a trailing NULL child slot — the emission shape
+		// planned for the phase-2 scan.
+		const bool has_null = s.null_pct > 0;
+		const idx_t dict_size = s.card + (has_null ? 1 : 0);
+		f.dict_base.reset(new Vector(type, dict_size));
+		for (idx_t i = 0; i < s.card; ++i) {
+			f.dict_base->SetValue(i, MakeBcpValue(s.kind, i));
+		}
+		if (has_null) {
+			f.dict_base->SetValue(s.card, duckdb::Value(type));
+		}
+		duckdb::SelectionVector sel(CHUNK_ROWS);
+		for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+			sel.set_index(row, RowIsNull(s.null_pct, row) ? s.card : (row % s.card));
+		}
+		vec.Dictionary(*f.dict_base, dict_size, sel, CHUNK_ROWS);
+		break;
+	}
+	case VecRep::Constant:
+		vec.Reference(s.null_pct >= 100 ? duckdb::Value(type) : MakeBcpValue(s.kind, 0));
+		break;
+	}
+	f.chunk->SetCardinality(CHUNK_ROWS);
+
+	duckdb::mssql::BCPColumnMetadata col("c", type, true);
+	switch (s.kind) {
+	case BcpCellSpec::Kind::Bigint:
+		col.tds_type_token = 0x26;	// INTNTYPE
+		col.max_length = 8;
+		break;
+	case BcpCellSpec::Kind::Varchar16:
+		col.tds_type_token = 0xE7;	// NVARCHARTYPE, nvarchar(16) — non-PLP USHORT path
+		col.max_length = 32;
+		break;
+	case BcpCellSpec::Kind::Decimal18s6:
+		col.tds_type_token = 0x6A;	// DECIMALNTYPE
+		col.max_length = 9;
+		col.precision = 18;
+		col.scale = 6;
+		break;
+	}
+	f.cols.push_back(col);
+	return f;
+}
+
+// One chunk encode — production shape: EncodeRow per row into one buffer
+// (clear() keeps capacity, matching the reused per-batch packet buffer).
+size_t EncodeChunkCurrent(BcpFixture &f, duckdb::vector<uint8_t> &buf) {
+	buf.clear();
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		duckdb::tds::encoding::BCPRowEncoder::EncodeRow(buf, *f.chunk, row, f.cols, nullptr);
+	}
+	g_sink ^= buf.size();
+	return buf.size();
+}
+
+// Reference: the Value-based encoder over GetValue(row) (resolves dict /
+// constant indirection independently). Byte-identical output required.
+// DECIMAL is the one arm where the Value overload is documented as divergent
+// from the Vector overload (legacy parity: Value::GetValue<hugeint_t>()
+// rescales the mantissa — see codec::decimal::EncodeToBcp(Value...)), so the
+// reference encodes the raw mantissa directly for that kind.
+bool VerifyBcp(BcpFixture &f, const duckdb::vector<uint8_t> &got) {
+	using duckdb::tds::encoding::BCPRowEncoder;
+	duckdb::vector<uint8_t> ref;
+	for (idx_t row = 0; row < CHUNK_ROWS; ++row) {
+		duckdb::Value v = f.chunk->data[0].GetValue(row);
+		if (f.spec.kind == BcpCellSpec::Kind::Decimal18s6 && !v.IsNull()) {
+			BCPRowEncoder::EncodeDecimal(ref, duckdb::hugeint_t(v.GetValueUnsafe<int64_t>()), f.cols[0].precision,
+										 f.cols[0].scale);
+		} else {
+			BCPRowEncoder::EncodeValue(ref, v, f.cols[0]);
+		}
+	}
+	return ref.size() == got.size() && std::equal(ref.begin(), ref.end(), got.begin());
+}
+
+std::vector<BcpCellSpec> BuildBcpCells() {
+	using K = BcpCellSpec::Kind;
+	std::vector<BcpCellSpec> cells;
+	auto add = [&](K k, VecRep rep, size_t card, int nulls, const std::string &name) {
+		BcpCellSpec s;
+		s.kind = k;
+		s.rep = rep;
+		s.card = card;
+		s.null_pct = nulls;
+		s.name = name;
+		cells.push_back(s);
+	};
+
+	struct KindRow {
+		K kind;
+		const char *prefix;
+	};
+	for (const KindRow &kr : {KindRow {K::Bigint, "bigint"}, KindRow {K::Varchar16, "nvarchar16"}}) {
+		add(kr.kind, VecRep::FlatUnique, 2048, 0, std::string(kr.prefix) + "_flat_unique");
+		add(kr.kind, VecRep::FlatLowCard, 10, 0, std::string(kr.prefix) + "_flat_card10");
+		for (size_t card : {1, 10, 100}) {
+			add(kr.kind, VecRep::Dict, card, 0, std::string(kr.prefix) + "_dict" + std::to_string(card));
+		}
+		add(kr.kind, VecRep::Constant, 1, 0, std::string(kr.prefix) + "_const");
+		add(kr.kind, VecRep::FlatUnique, 2048, 50, std::string(kr.prefix) + "_flat_unique_null50");
+	}
+	add(K::Bigint, VecRep::Dict, 100, 50, "bigint_dict100_null50");
+	add(K::Bigint, VecRep::Constant, 1, 100, "bigint_const_null");
+	add(K::Decimal18s6, VecRep::FlatUnique, 2048, 0, "decimal18s6_flat_unique");
+	add(K::Decimal18s6, VecRep::Dict, 100, 0, "decimal18s6_dict100");
+	add(K::Decimal18s6, VecRep::Constant, 1, 0, "decimal18s6_const");
+	return cells;
+}
+
 }  // namespace
 
 int main() {
-	std::printf("[bench_materialize] spec 054 D1 — string decode group (current path)\n");
+	std::printf("[bench_materialize] spec 054 D1 — string-decode / fixed-decode / bcp-encode groups (current path)\n");
 	std::printf("group\tcell\tus_per_chunk_median\tus_p10\tus_p90\tns_per_value_median"
 				"\tutf16_in_bytes\tutf8_out_bytes\tcorrect\n");
 
@@ -570,6 +783,29 @@ int main() {
 					correct ? "PASS" : "FAIL");
 		} catch (std::exception &ex) {
 			std::fprintf(stderr, "cell %s threw: %s\n", fc.name.c_str(), ex.what());
+			failures++;
+		}
+	}
+
+	for (const auto &bspec : BuildBcpCells()) {
+		try {
+			BcpFixture f = BuildBcpFixture(bspec);
+			duckdb::vector<uint8_t> buf;
+			buf.reserve(1 << 20);
+
+			size_t out_bytes = EncodeChunkCurrent(f, buf);
+			bool correct = VerifyBcp(f, buf);
+			if (!correct) {
+				failures++;
+			}
+
+			auto r = TimeCell([&]() { EncodeChunkCurrent(f, buf); }, 400);
+
+			std::printf("bcp_encode_current\t%s\t%.1f\t%.1f\t%.1f\t%.1f\t-\t%zu\t%s\n", bspec.name.c_str(),
+						r.median_us_per_chunk, r.p10_us_per_chunk, r.p90_us_per_chunk, r.median_ns_per_value, out_bytes,
+						correct ? "PASS" : "FAIL");
+		} catch (std::exception &ex) {
+			std::fprintf(stderr, "cell %s threw: %s\n", bspec.name.c_str(), ex.what());
 			failures++;
 		}
 	}

--- a/test/cpp/codec/test_decimal_codec.cpp
+++ b/test/cpp/codec/test_decimal_codec.cpp
@@ -31,6 +31,7 @@
 #include "codec/literal_context.hpp"
 #include "codec/literal_format.hpp"
 #include "codec/type_family.hpp"
+#include "copy/target_resolver.hpp"
 #include "dml/ctas/mssql_ctas_config.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -230,6 +231,51 @@ void TestRenderMoneyAsString() {
 	CHECK_EQ(duckdb::mssql::codec::decimal::RenderMoneyAsString(money), std::string("1.5000"));
 }
 
+void TestEncodeToBcpMantissaRangeGuard() {
+	std::cout << "Test: EncodeToBcp mantissa exceeding target precision raises InvalidInputException (#177)\n";
+
+	// HUGEINT source feeding a decimal(38,0) target column (COPY CREATE_TABLE
+	// reads created-table metadata back, so this dispatches via Decimal family).
+	duckdb::mssql::BCPColumnMetadata col;
+	col.name = "total";
+	col.duckdb_type = LogicalType::HUGEINT;
+	col.precision = 38;
+	col.scale = 0;
+	col.max_length = 17;
+
+	// In range: 10^38 − 1 encodes fine.
+	const hugeint_t max38 = duckdb::Hugeint::POWERS_OF_TEN[38] - 1;
+	duckdb::vector<uint8_t> buf;
+	duckdb::mssql::codec::decimal::EncodeToBcp(Value::HUGEINT(max38), col, buf);
+	CHECK_EQ(buf.size(), static_cast<size_t>(18));	// [17][sign][16-byte mantissa]
+
+	// Out of range: 10^38 (39 digits) must fail client-side, naming the column.
+	bool threw = false;
+	try {
+		duckdb::vector<uint8_t> guard_buf;
+		duckdb::mssql::codec::decimal::EncodeToBcp(Value::HUGEINT(duckdb::Hugeint::POWERS_OF_TEN[38]), col, guard_buf);
+	} catch (const duckdb::InvalidInputException &ex) {
+		threw = true;
+		std::string msg(ex.what());
+		CHECK_TRUE(msg.find("out of range for DECIMAL(38,0)") != std::string::npos);
+		CHECK_TRUE(msg.find("total") != std::string::npos);
+	}
+	CHECK_TRUE(threw);
+
+	// Narrower target: mantissa 10^20 into decimal(20,0) is one digit too many.
+	col.precision = 20;
+	col.max_length = 9;
+	bool threw_narrow = false;
+	try {
+		duckdb::vector<uint8_t> narrow_buf;
+		duckdb::mssql::codec::decimal::EncodeToBcp(Value::HUGEINT(duckdb::Hugeint::POWERS_OF_TEN[20]), col, narrow_buf);
+	} catch (const duckdb::InvalidInputException &ex) {
+		threw_narrow = true;
+		CHECK_TRUE(std::string(ex.what()).find("out of range for DECIMAL(20,0)") != std::string::npos);
+	}
+	CHECK_TRUE(threw_narrow);
+}
+
 }  // namespace
 
 int main() {
@@ -242,6 +288,7 @@ int main() {
 	TestDispatcherRoutingDecimal();
 	TestRenderAsStringMatchesLiteral();
 	TestRenderMoneyAsString();
+	TestEncodeToBcpMantissaRangeGuard();
 
 	if (failures > 0) {
 		std::cerr << "\n" << failures << " assertion(s) failed.\n";

--- a/test/cpp/codec/test_integer_codec.cpp
+++ b/test/cpp/codec/test_integer_codec.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -332,6 +333,90 @@ void TestEncodeToBcpUhugeint() {
 	}
 }
 
+void TestEncodeToBcpHugeintMinEdge() {
+	std::cout << "Test: EncodeToBcp HUGEINT min (-2^127) is rejected, not silently sent (#177 edge)\n";
+
+	// HUGEINT min = -2^127 has 39 digits, so it must be rejected like any other
+	// out-of-range value. It is the one input the old abs-then-compare guard
+	// could mishandle: Hugeint::Negate(min) is not representable in int128.
+	const hugeint_t int128_min(std::numeric_limits<int64_t>::min(), 0);
+	auto col = MakeDecimal38Col(LogicalType::HUGEINT);
+
+	// Value overload.
+	{
+		duckdb::vector<uint8_t> buf;
+		bool threw = false;
+		try {
+			duckdb::mssql::codec::integer::EncodeToBcp(Value::HUGEINT(int128_min), col, buf);
+		} catch (const duckdb::InvalidInputException &ex) {
+			threw = true;
+			CHECK_TRUE(std::string(ex.what()).find("out of range for DECIMAL(38,0)") != std::string::npos);
+		}
+		CHECK_TRUE(threw);
+		CHECK_TRUE(buf.empty());
+	}
+
+	// Vector overload — same rejection.
+	{
+		duckdb::Vector vec(LogicalType::HUGEINT);
+		vec.SetValue(0, Value::HUGEINT(int128_min));
+		duckdb::vector<uint8_t> buf;
+		bool threw = false;
+		try {
+			duckdb::mssql::codec::integer::EncodeToBcp(vec, 0, col, buf);
+		} catch (const duckdb::InvalidInputException &) {
+			threw = true;
+		}
+		CHECK_TRUE(threw);
+	}
+}
+
+void TestEncodeToBcpDictionaryConstantVectors() {
+	std::cout << "Test: EncodeToBcp reads CONSTANT/DICTIONARY vectors through the format (W1, spec 054)\n";
+
+	auto col = MakeDecimal38Col(LogicalType::HUGEINT);
+	const hugeint_t vals[] = {hugeint_t(0, 7), hugeint_t(0, 42), hugeint_t(-1), duckdb::Hugeint::POWERS_OF_TEN[38] - 1};
+
+	// Reference: flat-vector encode of a single value at row 0.
+	auto encode_flat = [&](const hugeint_t &v) {
+		duckdb::Vector fv(LogicalType::HUGEINT);
+		fv.SetValue(0, Value::HUGEINT(v));
+		duckdb::vector<uint8_t> b;
+		duckdb::mssql::codec::integer::EncodeToBcp(fv, 0, col, b);
+		return b;
+	};
+
+	// CONSTANT vector: any row index must resolve to the single constant value.
+	// (A raw FlatVector::GetData[row] read would walk off the 1-element array.)
+	{
+		duckdb::Vector cv(Value::HUGEINT(vals[1]));	 // Value ctor → constant vector
+		duckdb::vector<uint8_t> b;
+		duckdb::mssql::codec::integer::EncodeToBcp(cv, 3, col, b);
+		CHECK_TRUE(b == encode_flat(vals[1]));
+	}
+
+	// DICTIONARY vector: a reversing selection over a 4-value child. Row i must
+	// resolve through fmt.sel to child[3 - i] (a FlatVector::GetData[i] read
+	// would return the wrong element).
+	{
+		duckdb::Vector child(LogicalType::HUGEINT, 4);
+		for (idx_t i = 0; i < 4; i++) {
+			child.SetValue(i, Value::HUGEINT(vals[i]));
+		}
+		duckdb::SelectionVector sel(4);
+		for (idx_t i = 0; i < 4; i++) {
+			sel.set_index(i, 3 - i);
+		}
+		duckdb::Vector dv(LogicalType::HUGEINT);
+		dv.Slice(child, sel, 4);
+		for (idx_t i = 0; i < 4; i++) {
+			duckdb::vector<uint8_t> b;
+			duckdb::mssql::codec::integer::EncodeToBcp(dv, i, col, b);
+			CHECK_TRUE(b == encode_flat(vals[3 - i]));
+		}
+	}
+}
+
 }  // namespace
 
 int main() {
@@ -344,7 +429,9 @@ int main() {
 	TestNullLiteral();
 	TestEncodeToBcpHugeintRoundTrip();
 	TestEncodeToBcpHugeintRangeGuard();
+	TestEncodeToBcpHugeintMinEdge();
 	TestEncodeToBcpUhugeint();
+	TestEncodeToBcpDictionaryConstantVectors();
 
 	if (failures > 0) {
 		std::cerr << "\n" << failures << " assertion(s) failed.\n";

--- a/test/cpp/codec/test_integer_codec.cpp
+++ b/test/cpp/codec/test_integer_codec.cpp
@@ -10,6 +10,10 @@
 //     DdlContext::CtasCreateTable (FR-025 / FR-028 — DDL unification).
 //   - EstimateLiteralSize sanity: returned upper bound is at least as large
 //     as a worst-case rendered literal.
+//   - EncodeToBcp HUGEINT/UHUGEINT as DECIMAL(38,0) — issue #177: round-trip
+//     through the wire layout ([17][sign][16-byte LE mantissa]) for 0, ±1,
+//     int64 edges, ±(10^38-1); InvalidInputException for 39-digit values
+//     (10^38 and above) in both the Vector and Value overloads.
 //
 // Build & run:
 //   GEN=ninja make debug
@@ -18,11 +22,15 @@
 #include "codec/integer_codec.hpp"
 #include "codec/literal_context.hpp"
 #include "codec/type_family.hpp"
+#include "copy/target_resolver.hpp"
 #include "dml/ctas/mssql_ctas_config.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 #include <cassert>
 #include <cstdint>
@@ -33,6 +41,7 @@
 using duckdb::hugeint_t;
 using duckdb::HugeIntValue;
 using duckdb::LogicalType;
+using duckdb::uhugeint_t;
 using duckdb::Value;
 using duckdb::mssql::codec::DdlContext;
 using duckdb::mssql::codec::LiteralContext;
@@ -182,6 +191,147 @@ void TestNullLiteral() {
 	CHECK_EQ(null_lit, std::string("NULL"));
 }
 
+//===----------------------------------------------------------------------===//
+// EncodeToBcp HUGEINT/UHUGEINT — issue #177
+//===----------------------------------------------------------------------===//
+
+#define CHECK_TRUE(expr)                                          \
+	do {                                                          \
+		if (!(expr)) {                                            \
+			++failures;                                           \
+			std::cerr << "FAIL [" << __LINE__ << "] " #expr "\n"; \
+		}                                                         \
+	} while (0)
+
+duckdb::mssql::BCPColumnMetadata MakeDecimal38Col(const LogicalType &type) {
+	duckdb::mssql::BCPColumnMetadata col;
+	col.name = "total";
+	col.duckdb_type = type;
+	col.precision = 38;
+	col.scale = 0;
+	col.max_length = 17;  // DECIMAL(38,0) storage — mirrors GenerateColumnMetadata
+	return col;
+}
+
+// Wire layout produced by BCPRowEncoder::EncodeDecimal for precision 38:
+// [byte_size=17][sign: 0x01 non-negative / 0x00 negative][16-byte LE mantissa].
+bool DecodeDecimal38Wire(const duckdb::vector<uint8_t> &buf, hugeint_t &out_abs, bool &out_negative) {
+	if (buf.size() != 18 || buf[0] != 17) {
+		return false;
+	}
+	out_negative = buf[1] == 0x00;
+	uint64_t lower = 0, upper = 0;
+	for (int i = 0; i < 8; ++i) {
+		lower |= static_cast<uint64_t>(buf[2 + i]) << (8 * i);
+		upper |= static_cast<uint64_t>(buf[10 + i]) << (8 * i);
+	}
+	out_abs = hugeint_t(static_cast<int64_t>(upper), lower);
+	return true;
+}
+
+void TestEncodeToBcpHugeintRoundTrip() {
+	std::cout << "Test: EncodeToBcp HUGEINT -> DECIMAL(38,0) wire round-trip (#177)\n";
+
+	const hugeint_t max38 = duckdb::Hugeint::POWERS_OF_TEN[38] - 1;
+	const hugeint_t samples[] = {
+		hugeint_t(0),
+		hugeint_t(1),
+		hugeint_t(-1),
+		hugeint_t(std::numeric_limits<int64_t>::max()),
+		hugeint_t(std::numeric_limits<int64_t>::min()),
+		max38,
+		duckdb::Hugeint::Negate(max38),
+	};
+	auto col = MakeDecimal38Col(LogicalType::HUGEINT);
+
+	for (const auto &v : samples) {
+		bool expect_negative = v.upper < 0;
+		hugeint_t expect_abs = expect_negative ? duckdb::Hugeint::Negate(v) : v;
+
+		// Value overload.
+		duckdb::vector<uint8_t> buf;
+		duckdb::mssql::codec::integer::EncodeToBcp(Value::HUGEINT(v), col, buf);
+		hugeint_t abs;
+		bool negative;
+		CHECK_TRUE(DecodeDecimal38Wire(buf, abs, negative));
+		CHECK_EQ(duckdb::Hugeint::ToString(abs), duckdb::Hugeint::ToString(expect_abs));
+		// Zero encodes with the non-negative sign byte.
+		CHECK_EQ(negative, expect_negative && !(v == hugeint_t(0)));
+
+		// Vector overload must produce identical bytes.
+		duckdb::Vector vec(LogicalType::HUGEINT);
+		vec.SetValue(0, Value::HUGEINT(v));
+		duckdb::vector<uint8_t> vec_buf;
+		duckdb::mssql::codec::integer::EncodeToBcp(vec, 0, col, vec_buf);
+		CHECK_TRUE(vec_buf == buf);
+	}
+}
+
+void TestEncodeToBcpHugeintRangeGuard() {
+	std::cout << "Test: EncodeToBcp HUGEINT 39-digit values raise InvalidInputException (#177)\n";
+
+	const hugeint_t pow38 = duckdb::Hugeint::POWERS_OF_TEN[38];	 // 10^38 — first 39-digit value
+	const hugeint_t int128_max(std::numeric_limits<int64_t>::max(), std::numeric_limits<uint64_t>::max());
+	const hugeint_t out_of_range[] = {pow38, duckdb::Hugeint::Negate(pow38), int128_max,
+									  duckdb::Hugeint::Negate(int128_max)};
+	auto col = MakeDecimal38Col(LogicalType::HUGEINT);
+
+	for (const auto &v : out_of_range) {
+		duckdb::vector<uint8_t> buf;
+		bool threw = false;
+		try {
+			duckdb::mssql::codec::integer::EncodeToBcp(Value::HUGEINT(v), col, buf);
+		} catch (const duckdb::InvalidInputException &ex) {
+			threw = true;
+			std::string msg(ex.what());
+			CHECK_TRUE(msg.find("out of range for DECIMAL(38,0)") != std::string::npos);
+			CHECK_TRUE(msg.find("total") != std::string::npos);	 // names the column
+		}
+		CHECK_TRUE(threw);
+		CHECK_TRUE(buf.empty());  // nothing written before the guard fired
+	}
+}
+
+void TestEncodeToBcpUhugeint() {
+	std::cout << "Test: EncodeToBcp UHUGEINT edges (#177)\n";
+
+	auto col = MakeDecimal38Col(LogicalType::UHUGEINT);
+	const uhugeint_t max38 = duckdb::Uhugeint::POWERS_OF_TEN[38] - 1;
+
+	// In-range: 0, 1, 10^38-1 round-trip with the non-negative sign byte.
+	const uhugeint_t ok[] = {uhugeint_t(0), uhugeint_t(1), max38};
+	for (const auto &v : ok) {
+		duckdb::vector<uint8_t> buf;
+		duckdb::mssql::codec::integer::EncodeToBcp(Value::UHUGEINT(v), col, buf);
+		hugeint_t abs;
+		bool negative;
+		CHECK_TRUE(DecodeDecimal38Wire(buf, abs, negative));
+		CHECK_EQ(duckdb::Hugeint::ToString(abs), duckdb::Uhugeint::ToString(v));
+		CHECK_TRUE(!negative);
+
+		duckdb::Vector vec(LogicalType::UHUGEINT);
+		vec.SetValue(0, Value::UHUGEINT(v));
+		duckdb::vector<uint8_t> vec_buf;
+		duckdb::mssql::codec::integer::EncodeToBcp(vec, 0, col, vec_buf);
+		CHECK_TRUE(vec_buf == buf);
+	}
+
+	// Out of range: 10^38 and uint128 max.
+	const uhugeint_t bad[] = {duckdb::Uhugeint::POWERS_OF_TEN[38],
+							  uhugeint_t(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max())};
+	for (const auto &v : bad) {
+		duckdb::vector<uint8_t> buf;
+		bool threw = false;
+		try {
+			duckdb::mssql::codec::integer::EncodeToBcp(Value::UHUGEINT(v), col, buf);
+		} catch (const duckdb::InvalidInputException &ex) {
+			threw = true;
+			CHECK_TRUE(std::string(ex.what()).find("out of range for DECIMAL(38,0)") != std::string::npos);
+		}
+		CHECK_TRUE(threw);
+	}
+}
+
 }  // namespace
 
 int main() {
@@ -192,6 +342,9 @@ int main() {
 	TestFormatDdlTypeNameExpectedShapes();
 	TestEstimateLiteralSizeUpperBound();
 	TestNullLiteral();
+	TestEncodeToBcpHugeintRoundTrip();
+	TestEncodeToBcpHugeintRangeGuard();
+	TestEncodeToBcpUhugeint();
 
 	if (failures > 0) {
 		std::cerr << "\n" << failures << " assertion(s) failed.\n";

--- a/test/cpp/codec/test_uuid_codec.cpp
+++ b/test/cpp/codec/test_uuid_codec.cpp
@@ -33,6 +33,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -326,6 +327,59 @@ void TestRenderAsString() {
 	CHECK_EQ(rendered_nil, std::string("00000000-0000-0000-0000-000000000000"));
 }
 
+// W1 latent fix (spec 054): uuid::EncodeToBcp used FlatVector::GetData[row],
+// which is wrong for CONSTANT/DICTIONARY inputs (table functions may legally
+// emit those). It now reads through a UnifiedVectorFormat. Prove both shapes
+// resolve to the same bytes as the equivalent flat encode.
+void TestEncodeConstantDictionaryVectors() {
+	std::cout << "Test: EncodeToBcp reads CONSTANT/DICTIONARY UUID vectors via format (W1 latent fix)\n";
+
+	BCPColumnMetadata col = MakeBCPColumn();
+	const char *uuids[] = {
+		"00000000-0000-0000-0000-000000000000",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		"01234567-89ab-cdef-0123-456789abcdef",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
+	};
+
+	auto encode_flat = [&](const char *canonical) {
+		duckdb::Vector fv(LogicalType::UUID, 1);
+		fv.SetValue(0, Value::UUID(canonical));
+		duckdb::vector<uint8_t> b;
+		duckdb::mssql::codec::uuid::EncodeToBcp(fv, 0, col, b);
+		return b;
+	};
+
+	// CONSTANT vector: any row index resolves to the single value (a raw
+	// FlatVector::GetData[row] read would walk off the 1-element backing array).
+	{
+		duckdb::Vector cv(Value::UUID(uuids[1]));
+		duckdb::vector<uint8_t> b;
+		duckdb::mssql::codec::uuid::EncodeToBcp(cv, 3, col, b);
+		CHECK_TRUE(b == encode_flat(uuids[1]));
+	}
+
+	// DICTIONARY vector: reversing selection over a 4-value child. Row i must
+	// resolve through fmt.sel to child[3 - i].
+	{
+		duckdb::Vector child(LogicalType::UUID, 4);
+		for (duckdb::idx_t i = 0; i < 4; i++) {
+			child.SetValue(i, Value::UUID(uuids[i]));
+		}
+		duckdb::SelectionVector sel(4);
+		for (duckdb::idx_t i = 0; i < 4; i++) {
+			sel.set_index(i, 3 - i);
+		}
+		duckdb::Vector dv(LogicalType::UUID);
+		dv.Slice(child, sel, 4);
+		for (duckdb::idx_t i = 0; i < 4; i++) {
+			duckdb::vector<uint8_t> b;
+			duckdb::mssql::codec::uuid::EncodeToBcp(dv, i, col, b);
+			CHECK_TRUE(b == encode_flat(uuids[3 - i]));
+		}
+	}
+}
+
 }  // namespace
 
 int main() {
@@ -338,6 +392,7 @@ int main() {
 	TestEncodeVectorRfc4122();
 	TestEncodeValueHighBit();
 	TestEncodeValueMixedPattern();
+	TestEncodeConstantDictionaryVectors();
 	TestEncodeDecodeRoundTrip();
 	TestFormatSqlLiteralByteIdentity();
 	TestFormatDdlTypeNameByteIdentity();

--- a/test/sql/catalog/filter_pushdown_hugeint.test
+++ b/test/sql/catalog/filter_pushdown_hugeint.test
@@ -17,9 +17,9 @@
 #   codec::integer::FormatSqlLiteral renders:  WHERE [col] = 12345
 #   matching the DECIMAL(38,0) column type natively.
 #
-# Note: the table is seeded via T-SQL (mssql_exec) because HUGEINT BCP encoding
-# is deferred to spec 045 Phase 6. The filter pushdown path under test is on
-# the SCAN side and is not affected.
+# Note: the table is seeded via T-SQL (mssql_exec) to keep this test focused on
+# the SCAN-side filter pushdown path (HUGEINT BCP encoding itself is covered by
+# copy_hugeint_bcp.test since issue #177).
 
 require mssql
 

--- a/test/sql/copy/copy_hugeint_bcp.test
+++ b/test/sql/copy/copy_hugeint_bcp.test
@@ -1,0 +1,83 @@
+# name: test/sql/copy/copy_hugeint_bcp.test
+# description: Issue #177 — HUGEINT (SUM() output) through COPY (FORMAT 'bcp') and default CTAS
+# group: [copy]
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+
+# SUM() over BIGINT returns HUGEINT — the exact repro from issue #177.
+statement ok
+CREATE TABLE hugeint_src AS SELECT range AS x FROM range(1000);
+
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_sum;
+
+statement ok
+COPY (SELECT SUM(x) AS total FROM hugeint_src) TO 'mssql://db/dbo/copy_hugeint_sum' (FORMAT 'bcp', CREATE_TABLE true);
+
+# Target column is DECIMAL(38,0); SUM(0..999) = 499500.
+query I
+SELECT total FROM db.dbo.copy_hugeint_sum;
+----
+499500
+
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_sum;
+
+# Default CTAS path (mssql_ctas_use_bcp=true) hits the same BCP encoder.
+statement ok
+CREATE TABLE db.dbo.copy_hugeint_ctas AS SELECT SUM(x) AS total FROM hugeint_src;
+
+query I
+SELECT total FROM db.dbo.copy_hugeint_ctas;
+----
+499500
+
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_ctas;
+
+# DECIMAL(38,0) edges round-trip: ±(10^38 − 1), zero, int64 boundaries.
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_edges;
+
+statement ok
+COPY (SELECT * FROM (VALUES
+    (99999999999999999999999999999999999999::HUGEINT),
+    (-99999999999999999999999999999999999999::HUGEINT),
+    (0::HUGEINT),
+    (9223372036854775807::HUGEINT),
+    (-9223372036854775808::HUGEINT)) t(v))
+TO 'mssql://db/dbo/copy_hugeint_edges' (FORMAT 'bcp', CREATE_TABLE true);
+
+query I
+SELECT v FROM db.dbo.copy_hugeint_edges ORDER BY v;
+----
+-99999999999999999999999999999999999999
+-9223372036854775808
+0
+9223372036854775807
+99999999999999999999999999999999999999
+
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_edges;
+
+# 39-digit values cannot fit DECIMAL(38,0): clean client-side error, not a
+# mid-batch server failure. int128 max = 170141183460469231731687303715884105727.
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_guard;
+
+statement error
+COPY (SELECT 170141183460469231731687303715884105727::HUGEINT AS v)
+TO 'mssql://db/dbo/copy_hugeint_guard' (FORMAT 'bcp', CREATE_TABLE true);
+----
+out of range for DECIMAL(38,0)
+
+statement ok
+DROP TABLE IF EXISTS db.dbo.copy_hugeint_guard;
+
+statement ok
+DROP TABLE hugeint_src;

--- a/test/sql/ctas/ctas_failure.test
+++ b/test/sql/ctas/ctas_failure.test
@@ -47,26 +47,24 @@ SELECT * FROM mssql_fail.dbo.ctas_fail_test;
 1	initial
 
 # =============================================================================
-# HUGEINT — DDL succeeds (DECIMAL(38,0)), BCP encoding deferred
+# HUGEINT — out-of-range value fails client-side (#177 range guard)
 # =============================================================================
 #
 # Spec 045 Phase 3 (FR-025 / FR-028): HUGEINT and UHUGEINT map to DECIMAL(38,0)
-# in BOTH CREATE-TABLE and CTAS DDL contexts. The DDL phase succeeds; BCP data
-# encoding for HUGEINT still throws (Phase 6 / T069). Net effect for CTAS: an
-# empty table is created and the row insert fails. The error text contains
-# "HUGEINT".
-#
-# Use a value within DECIMAL(38,0) range — earlier 2^127-1 exceeds the
-# SQL Server type capacity and would mask the BCP throw with a numeric overflow.
+# in BOTH CREATE-TABLE and CTAS DDL contexts. Since issue #177 the BCP data
+# phase encodes in-range HUGEINT values (see ctas_types.test); a 39-digit value
+# like 2^127−1 exceeds DECIMAL(38,0) and fails with a client-side range error
+# before any row is sent. Net effect for CTAS: an empty table is created and
+# the data phase fails.
 
 statement ok
 DROP TABLE IF EXISTS mssql_fail.dbo.ctas_fail_unsupported;
 
 statement error
 CREATE TABLE mssql_fail.dbo.ctas_fail_unsupported AS
-SELECT 99999999999999999999999999999999999999::HUGEINT AS huge_val;
+SELECT 170141183460469231731687303715884105727::HUGEINT AS huge_val;
 ----
-HUGEINT
+out of range for DECIMAL(38,0)
 
 # DDL did create the (now empty) table; drop before continuing.
 statement ok

--- a/test/sql/ctas/ctas_types.test
+++ b/test/sql/ctas/ctas_types.test
@@ -157,23 +157,38 @@ SELECT * FROM mssql_ctas_types.dbo.ctas_decimal_precision;
 12345678901234567890.12345
 
 # =============================================================================
-# Unsupported / Restricted Types
+# HUGEINT (issue #177) / Unsupported / Restricted Types
 # =============================================================================
 #
 # Per spec 045 Phase 3 (FR-025 / FR-028 DDL unification): HUGEINT and UHUGEINT
-# now map to DECIMAL(38,0) in BOTH the CREATE-TABLE and CTAS DDL contexts. The
-# DDL phase therefore succeeds; the BCP data-insert phase still throws until
-# the Decimal family migration lands (spec 045 Phase 6 / T069). The expected
-# error text matches the BCP NotImplementedException, which contains "HUGEINT".
+# map to DECIMAL(38,0) in BOTH the CREATE-TABLE and CTAS DDL contexts. Since
+# issue #177 the BCP data phase encodes HUGEINT as DECIMAL(38,0) too, so CTAS
+# over a HUGEINT projection succeeds end-to-end up to ±(10^38−1); 39-digit
+# values raise a client-side range error before any row is sent.
+
+statement ok
+DROP TABLE IF EXISTS mssql_ctas_types.dbo.ctas_hugeint;
+
+# 10^38−1 (38 digits) — DECIMAL(38,0) max — round-trips through default (BCP) CTAS.
+statement ok
+CREATE TABLE mssql_ctas_types.dbo.ctas_hugeint AS SELECT 99999999999999999999999999999999999999::HUGEINT AS val;
+
+query I
+SELECT val FROM mssql_ctas_types.dbo.ctas_hugeint;
+----
+99999999999999999999999999999999999999
+
+statement ok
+DROP TABLE IF EXISTS mssql_ctas_types.dbo.ctas_hugeint;
 
 statement ok
 DROP TABLE IF EXISTS mssql_ctas_types.dbo.ctas_fail;
 
-# HUGEINT — DDL maps to DECIMAL(38,0); BCP encoding pending (spec 045 Phase 6)
+# int128 max has 39 digits — cannot fit DECIMAL(38,0); clean client-side error (#177).
 statement error
-CREATE TABLE mssql_ctas_types.dbo.ctas_fail AS SELECT 99999999999999999999999999999999999999::HUGEINT AS val;
+CREATE TABLE mssql_ctas_types.dbo.ctas_fail AS SELECT 170141183460469231731687303715884105727::HUGEINT AS val;
 ----
-HUGEINT
+out of range for DECIMAL(38,0)
 
 # CTAS partially created the table at DDL phase; drop it before the next case.
 statement ok


### PR DESCRIPTION
## Summary

Phase 0 of the batch/SIMD materialization series (design: `docs/proposals/simd-chunk-materialization-design.md`, spec: `specs/054-simd-baseline-and-quick-wins/spec.md`). Baseline-first: all measurement infrastructure and recorded baselines land BEFORE the optimization commits, every conversion-touching change is gated by a byte-identity differential harness.

### Infrastructure
- `make bench-build` — release build with tpch injected via `EXTRA_EXTENSION_CONFIGS` (bench-only, never ships in `extension_config.cmake`)
- `make bench-materialize` — micro harness (`test/cpp/bench_materialize.cpp`): string-decode / fixed-decode / bcp-encode groups incl. dictionary/constant vector inputs
- `test/bench/bench_tpch_e2e.sh` — TPC-H e2e (write via BCP + scan back), release-comparison protocol via `MSSQL_BENCH_LOAD_SQL`/`MSSQL_BENCH_UNSIGNED`
- `test/bench/diff_check.sh` — 13-query byte-identity gate across two builds (every type family, NULL-heavy, PLP/MAX, embedded NUL, collations, 0/1/>2048 rows, BCP write-back)
- D4 debug counters at `MSSQL_DEBUG>=2`: per-stream / per-BCP-writer close summaries + thread-local UTF-16 fallback counter
- All baselines + deltas recorded append-only in `test/bench/bench_results_simd_baseline.md`

### Fixes
- **#177**: HUGEINT (e.g. `SUM()`) → BCP encodes as DECIMAL(38,0) with a client-side range guard, in BOTH the Integer and Decimal codec paths (COPY CREATE_TABLE reads target metadata back and dispatches via Decimal); COLMETADATA precision was 0/0
- CTAS mid-stream BCP failure no longer leaks a locked connection (#191 pattern)
- Pool teardown: cleanup thread now waits on a CV instead of a blind 1 s sleep — CLI round-trip 2.06 s → 0.03 s
- Latent: uuid/binary codecs read via `FlatVector::GetData` — wrong for dictionary/constant inputs; now format-based

### Quick wins (each gated by diff_check byte-identity + before/after micro)
- **W1+W2** (`EncodeChunk`): UnifiedVectorFormat + family encoder + NULL wire kind hoisted once per column per chunk (was 2× ToUnifiedFormat + 9-way switch per CELL). bigint 18.3→8.2 ns/value; dictionary penalty eliminated (2.8×)
- **W3+W4**: single-validation NVARCHAR encode, exact-size append, per-chunk accumulator reserve; unaligned destinations stay on simdutf (was: ~half of string values silently on the scalar legacy path)
- **R1**: string decode straight into the vector slot (`EmptyString` + valid-convert) — len32 2.6×, non-ASCII ~2×

### Gates
- Acceptance criterion 6 (no e2e step regresses >3%): **PASS** — every cross-session flag refuted by same-session interleaved A/B
- Pre-merge release comparison at SF 2 (lineitem 11,997,996 rows), 3 interleaved pairs vs the v0.2.2 release artifact: **every step improved** — copy_part −24.8%, copy_customer −32.7%, copy_lineitem −7.8%, Q1 −11.6% (short steps additionally reflect the pool fix: 2 s floor → instant)

Open item: Linux x86_64 micro baseline run (needs a real x86_64 host — QEMU-on-ARM timing is meaningless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)