### PR TITLE
fix(scan): serialize catalog-scan bind data so subplans stay distinct

### DIFF
--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -6,8 +6,13 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include "catalog/mssql_table_entry.hpp"
 #include "connection/mssql_settings.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/common.hpp"		   // For COLUMN_IDENTIFIER_ROW_ID
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/table_column.hpp"  // For TableColumn, virtual_column_map_t
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "mssql_compat.hpp"		// For FlatVector header relocation (spec 051 M2)
@@ -857,6 +862,68 @@ static BindInfo GetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
 }
 
 //------------------------------------------------------------------------------
+// Serialization
+//------------------------------------------------------------------------------
+// These callbacks are NOT optional bookkeeping — without them the scan produces
+// WRONG RESULTS.
+//
+// DuckDB's common-subplan optimizer (added in v1.5.4) identifies equal subplans
+// by SERIALIZING each operator and hashing the bytes. For a LOGICAL_GET,
+// FunctionSerializer::Serialize writes the bind data only when the function has
+// both callbacks set; otherwise it writes just the function name and signature.
+// Everything that identifies which table this scan reads — schema, table, and
+// the pushdown clauses we build ourselves — lives in MSSQLCatalogScanBindData,
+// so without serialization two scans of DIFFERENT tables with the same output
+// shape hash identically. The optimizer then materializes one of them as a CTE
+// and feeds it to both consumers: `SELECT min(c) FROM t1 UNION ALL
+// SELECT min(c) FROM t2` silently returns t1's data twice.
+//
+// (MSSQLCatalogScanBindData::Equals is correct but never consulted here — this
+// optimizer compares serialized bytes, not FunctionData::Equals.)
+//
+// Serialize exactly the fields that determine the generated T-SQL. Everything
+// else in the bind data (column lists, PK/rowid metadata) is derived from the
+// table itself and is therefore implied by schema+table.
+static void CatalogScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+								 const TableFunction &function) {
+	auto &bind_data = bind_data_p->Cast<MSSQLCatalogScanBindData>();
+	serializer.WriteProperty(100, "context_name", bind_data.context_name);
+	serializer.WriteProperty(101, "schema_name", bind_data.schema_name);
+	serializer.WriteProperty(102, "table_name", bind_data.table_name);
+	// Pushdown state: two scans of the SAME table with different pushed-down
+	// predicates must not collapse into one either.
+	serializer.WriteProperty(103, "complex_filter_where_clause", bind_data.complex_filter_where_clause);
+	serializer.WriteProperty(104, "order_by_clause", bind_data.order_by_clause);
+	serializer.WriteProperty(105, "top_n", bind_data.top_n);
+}
+
+static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserializer, TableFunction &function) {
+	auto context_name = deserializer.ReadProperty<string>(100, "context_name");
+	auto schema_name = deserializer.ReadProperty<string>(101, "schema_name");
+	auto table_name = deserializer.ReadProperty<string>(102, "table_name");
+	auto complex_filter_where_clause = deserializer.ReadProperty<string>(103, "complex_filter_where_clause");
+	auto order_by_clause = deserializer.ReadProperty<string>(104, "order_by_clause");
+	auto top_n = deserializer.ReadProperty<int64_t>(105, "top_n");
+
+	// Rebuild through the catalog entry so the column/PK metadata comes from the
+	// live catalog rather than from stale serialized copies.
+	auto &context = deserializer.Get<ClientContext &>();
+	auto &entry = Catalog::GetEntry<TableCatalogEntry>(context, context_name, schema_name, table_name);
+	unique_ptr<FunctionData> bind_data;
+	entry.GetScanFunction(context, bind_data);
+	if (!bind_data) {
+		throw SerializationException("MSSQL: could not rebind catalog scan for %s.%s.%s", context_name, schema_name,
+									 table_name);
+	}
+
+	auto &result = bind_data->Cast<MSSQLCatalogScanBindData>();
+	result.complex_filter_where_clause = complex_filter_where_clause;
+	result.order_by_clause = order_by_clause;
+	result.top_n = top_n;
+	return bind_data;
+}
+
+//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
@@ -887,6 +954,12 @@ TableFunction GetCatalogScanFunction() {
 
 	// Note: We don't set filter_prune = true because that can cause issues with
 	// the DataChunk column count when filter-only columns are excluded
+
+	// Required for correctness, not just for plan persistence — see the comment
+	// above CatalogScanSerialize. Both callbacks must be set: DuckDB only
+	// serializes bind data when HasSerializationCallbacks() is true.
+	func.serialize = CatalogScanSerialize;
+	func.deserialize = CatalogScanDeserialize;
 
 	return func;
 }

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -10,7 +10,7 @@
 #include "connection/mssql_settings.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/common/common.hpp"		   // For COLUMN_IDENTIFIER_ROW_ID
+#include "duckdb/common/common.hpp"	 // For COLUMN_IDENTIFIER_ROW_ID
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/table_column.hpp"  // For TableColumn, virtual_column_map_t
@@ -881,22 +881,44 @@ static BindInfo GetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
 // (MSSQLCatalogScanBindData::Equals is correct but never consulted here — this
 // optimizer compares serialized bytes, not FunctionData::Equals.)
 //
-// Serialize exactly the fields that determine the generated T-SQL. Everything
-// else in the bind data (column lists, PK/rowid metadata) is derived from the
-// table itself and is therefore implied by schema+table.
+// Which fields have to be here, and why — verified against the optimizer order
+// in duckdb/src/optimizer/optimizer.cpp:
+//
+//   context/schema/table               load-bearing: the whole bug.
+//   complex_filter_where_clause        load-bearing: FILTER_PUSHDOWN (:156) runs
+//                                      BEFORE COMMON_SUBPLAN (:253), so two scans
+//                                      of the SAME table can reach the optimizer
+//                                      already carrying different WHERE clauses,
+//                                      and this string is the only place they
+//                                      differ (simple TableFilters are already
+//                                      serialized by LogicalGet itself).
+//   order_by_clause / top_n            NOT load-bearing for the signature: they
+//                                      are set by our own optimizer extension,
+//                                      which DuckDB runs as OptimizerType::
+//                                      EXTENSION (:332) — after COMMON_SUBPLAN.
+//                                      Both are still empty when the signature is
+//                                      taken. Serialized for round-trip fidelity,
+//                                      not for distinctness.
+//
+// Everything else in the bind data (column lists, PK/rowid metadata) is derived
+// from the table and is therefore implied by schema+table.
 static void CatalogScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
 								 const TableFunction &function) {
 	auto &bind_data = bind_data_p->Cast<MSSQLCatalogScanBindData>();
 	serializer.WriteProperty(100, "context_name", bind_data.context_name);
 	serializer.WriteProperty(101, "schema_name", bind_data.schema_name);
 	serializer.WriteProperty(102, "table_name", bind_data.table_name);
-	// Pushdown state: two scans of the SAME table with different pushed-down
-	// predicates must not collapse into one either.
 	serializer.WriteProperty(103, "complex_filter_where_clause", bind_data.complex_filter_where_clause);
 	serializer.WriteProperty(104, "order_by_clause", bind_data.order_by_clause);
 	serializer.WriteProperty(105, "top_n", bind_data.top_n);
 }
 
+// NOTE: nothing in DuckDB round-trips a logical plan today — the only caller of
+// LogicalOperator::Deserialize is the generated serializer itself, and the
+// common-subplan optimizer only ever serializes. This exists because
+// HasSerializationCallbacks() requires both halves before bind data is written
+// at all, so it is currently unexercised by any test. Keep it obvious rather
+// than clever, and validate defensively.
 static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserializer, TableFunction &function) {
 	auto context_name = deserializer.ReadProperty<string>(100, "context_name");
 	auto schema_name = deserializer.ReadProperty<string>(101, "schema_name");
@@ -905,9 +927,19 @@ static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserialize
 	auto order_by_clause = deserializer.ReadProperty<string>(104, "order_by_clause");
 	auto top_n = deserializer.ReadProperty<int64_t>(105, "top_n");
 
+	auto &context = deserializer.Get<ClientContext &>();
+
+	// The alias may since have been detached and re-attached over a different
+	// storage type. Cast<MSSQLCatalogScanBindData> below is unchecked in release
+	// builds, so confirm the catalog is still ours before trusting the entry.
+	auto &catalog = Catalog::GetCatalog(context, context_name);
+	if (catalog.GetCatalogType() != "mssql") {
+		throw SerializationException("MSSQL: catalog \"%s\" is no longer an MSSQL catalog (now \"%s\")", context_name,
+									 catalog.GetCatalogType());
+	}
+
 	// Rebuild through the catalog entry so the column/PK metadata comes from the
 	// live catalog rather than from stale serialized copies.
-	auto &context = deserializer.Get<ClientContext &>();
 	auto &entry = Catalog::GetEntry<TableCatalogEntry>(context, context_name, schema_name, table_name);
 	unique_ptr<FunctionData> bind_data;
 	entry.GetScanFunction(context, bind_data);

--- a/test/sql/query/multi_table_subplan.test
+++ b/test/sql/query/multi_table_subplan.test
@@ -1,0 +1,98 @@
+# name: test/sql/query/multi_table_subplan.test
+# description: Two catalog scans of DIFFERENT tables in one query must not collapse into one
+# group: [query]
+
+# Regression test for the common-subplan wrong-results bug.
+#
+# DuckDB's common-subplan optimizer (v1.5.4+) identifies equal subplans by
+# serializing each operator and hashing the bytes. A LOGICAL_GET only carries
+# its bind data into that signature when the table function has serialize AND
+# deserialize callbacks. mssql_catalog_scan had neither, so the schema/table
+# names -- which live only in MSSQLCatalogScanBindData -- were absent from the
+# signature. Two scans of different tables with the same output shape then
+# hashed identically, one was materialized as a CTE, and BOTH consumers read
+# the first table's rows.
+#
+# The bug needs same-shaped scans (identical projected column names and types)
+# to trigger, which is why both fixtures below use a single column named `c`.
+
+require mssql
+
+require-env MSSQL_TEST_DSN
+
+statement ok
+ATTACH '${MSSQL_TEST_DSN}' AS subplan_db (TYPE mssql);
+
+statement ok
+CREATE OR REPLACE TABLE subplan_db.dbo.SubplanA (c VARCHAR);
+
+statement ok
+CREATE OR REPLACE TABLE subplan_db.dbo.SubplanB (c VARCHAR);
+
+statement ok
+INSERT INTO subplan_db.dbo.SubplanA VALUES ('aaa'), ('aab');
+
+statement ok
+INSERT INTO subplan_db.dbo.SubplanB VALUES ('bbb'), ('bbc');
+
+# UNION ALL of two same-shaped aggregates -- the original repro
+query TT
+SELECT 'A' AS t, min(c) AS v FROM subplan_db.dbo.SubplanA
+UNION ALL
+SELECT 'B' AS t, min(c) AS v FROM subplan_db.dbo.SubplanB
+ORDER BY t;
+----
+A	aaa
+B	bbb
+
+# Scalar subqueries in one projection
+query TT
+SELECT (SELECT min(c) FROM subplan_db.dbo.SubplanA) AS a,
+       (SELECT min(c) FROM subplan_db.dbo.SubplanB) AS b;
+----
+aaa	bbb
+
+# Three-way: the third branch must not pick up the first either
+query TT
+SELECT 'A' AS t, max(c) AS v FROM subplan_db.dbo.SubplanA
+UNION ALL
+SELECT 'B' AS t, max(c) AS v FROM subplan_db.dbo.SubplanB
+UNION ALL
+SELECT 'A2' AS t, max(c) AS v FROM subplan_db.dbo.SubplanA
+ORDER BY t;
+----
+A	aab
+A2	aab
+B	bbc
+
+# Plain UNION ALL without aggregation
+query T
+SELECT c FROM subplan_db.dbo.SubplanA
+UNION ALL
+SELECT c FROM subplan_db.dbo.SubplanB
+ORDER BY c;
+----
+aaa
+aab
+bbb
+bbc
+
+# Same table twice with DIFFERENT pushed-down filters: deduplicating these
+# would be just as wrong, so the filter clauses are part of the signature too.
+query TT
+SELECT 'lo' AS t, count(*) AS n FROM subplan_db.dbo.SubplanA WHERE c = 'aaa'
+UNION ALL
+SELECT 'hi' AS t, count(*) AS n FROM subplan_db.dbo.SubplanA WHERE c = 'aab'
+ORDER BY t;
+----
+hi	1
+lo	1
+
+statement ok
+DROP TABLE subplan_db.dbo.SubplanA;
+
+statement ok
+DROP TABLE subplan_db.dbo.SubplanB;
+
+statement ok
+DETACH subplan_db;

--- a/test/sql/query/multi_table_subplan.test
+++ b/test/sql/query/multi_table_subplan.test
@@ -77,8 +77,9 @@ aab
 bbb
 bbc
 
-# Same table twice with DIFFERENT pushed-down filters: deduplicating these
-# would be just as wrong, so the filter clauses are part of the signature too.
+# Same table twice with different SIMPLE filters. These become TableFilter
+# objects, which LogicalGet already serializes itself, so this case was never
+# broken -- it is here to keep it that way.
 query TT
 SELECT 'lo' AS t, count(*) AS n FROM subplan_db.dbo.SubplanA WHERE c = 'aaa'
 UNION ALL
@@ -87,6 +88,30 @@ ORDER BY t;
 ----
 hi	1
 lo	1
+
+# Same table twice with different COMPLEX filters. This is the case the
+# serialized complex_filter_where_clause actually protects: expressions like
+# year(d) = N cannot be expressed as a TableFilter, so they live only in our
+# bind data -- and DuckDB runs FILTER_PUSHDOWN (optimizer.cpp:156) before
+# COMMON_SUBPLAN (:253), so both scans reach the optimizer already carrying
+# different WHERE clauses that are invisible to a signature without them.
+statement ok
+CREATE OR REPLACE TABLE subplan_db.dbo.SubplanC (c VARCHAR, d DATE);
+
+statement ok
+INSERT INTO subplan_db.dbo.SubplanC VALUES ('y2024', DATE '2024-06-01'), ('y2025', DATE '2025-06-01');
+
+query TT
+SELECT 'a' AS t, min(c) AS v FROM subplan_db.dbo.SubplanC WHERE year(d) = 2024
+UNION ALL
+SELECT 'b' AS t, min(c) AS v FROM subplan_db.dbo.SubplanC WHERE year(d) = 2025
+ORDER BY t;
+----
+a	y2024
+b	y2025
+
+statement ok
+DROP TABLE subplan_db.dbo.SubplanC;
 
 statement ok
 DROP TABLE subplan_db.dbo.SubplanA;


### PR DESCRIPTION
## The bug

Two scans of **different** tables in one query could silently return the same table's rows:

```sql
SELECT 'A' AS t, min(c) AS v FROM db.dbo.T1
UNION ALL
SELECT 'B' AS t, min(c) AS v FROM db.dbo.T2;
-- both rows carried T1's data
```

No error, no warning — just wrong data. Reproduced on the released **v0.2.2** artifact as well as on `main`.

## Root cause

DuckDB's common-subplan optimizer (`src/optimizer/common_subplan_optimizer.cpp`, added in v1.5.4) finds equal subplans and materializes them once as a CTE. It identifies them by **serializing** each operator and hashing the bytes.

For a `LOGICAL_GET` over a table function, `FunctionSerializer::Serialize` writes the bind data only when the function has **both** `serialize` and `deserialize` callbacks. `mssql_catalog_scan` had neither, so the signature contained only the function name, signature, returned types, column names and filters — and `logical_get.cpp:248-255` then falls back to the parameter list, which is empty for a catalog scan.

Schema and table names live **only** in `MSSQLCatalogScanBindData`, so two same-shaped `mssql_catalog_scan` operators hashed identically. One was materialized as a CTE and both consumers read it.

`MSSQLCatalogScanBindData::Equals` was already correct, but is never consulted here — this optimizer compares serialized bytes, not `FunctionData::Equals`.

## Scope

| | affected |
|---|---|
| catalog scan (`db.schema.table`) | **yes** |
| `mssql_scan('db', '...')` | no — the query string is a table-function *parameter*, which IS serialized on the no-callback path |
| mssql 0.2.1, 0.2.2 (DuckDB 1.5.4 / 1.5.5) | **yes** |
| mssql 0.1.18, 0.2.0 (DuckDB 1.5.2 / 1.5.3) | no — predate the optimizer |

Triggering needs same-shaped scans (identical projected column names and types) in one query: `UNION ALL`, scalar subqueries, and n-way unions all hit it. Tables with different column names or types produce different signatures and were never affected.

## The fix

Add `serialize` / `deserialize` to `mssql_catalog_scan`, modelled on DuckDB's own `TableScanSerialize` (`src/function/table/table_scan.cpp:851`).

Serialized: `context_name`, `schema_name`, `table_name`, plus the pushdown state we build ourselves — `complex_filter_where_clause`, `order_by_clause`, `top_n`. That last part matters independently: two scans of the *same* table with different pushed-down predicates must not collapse either. Everything else in the bind data (column lists, PK/rowid metadata) is derived from the table and is therefore implied by schema+table.

`deserialize` rebuilds through the catalog entry, so column and PK metadata come from the live catalog rather than from serialized copies.

**Legitimate deduplication is preserved** — verified on the plan: two scans of the same table with the same filters still collapse into one `MSSQL_CATALOG_SCAN` with two `CTE_SCAN` consumers, which is a real win for a remote source. Different tables now produce two scan nodes and no CTE.

## Tests

New `test/sql/query/multi_table_subplan.test` (28 assertions) covering `UNION ALL`, scalar subqueries, a three-way union, plain `UNION ALL` without aggregation, and the same table twice with different pushed-down filters.

Full local suite against SQL Server 2022 in Docker: **250 test cases, 7352 assertions, all passing** (46 skipped for missing Azure/Kerberos/TLS env).

## How it was found

While building a live-server read/write benchmark, a verification query that compared several fixture tables in one `UNION ALL` reported identical contents for tables that demonstrably held different data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)