### PR TITLE
perf(codec): publish a uniform column-chunk as a CONSTANT vector (spec 056)

### DIFF
--- a/specs/056-chunk-analyzer-dictionary/spec.md
+++ b/specs/056-chunk-analyzer-dictionary/spec.md
@@ -207,3 +207,157 @@ detector exits at the second distinct value) and fixed-width dictionaries
 (0.4 ns detection). Both are small wins; neither justifies a phase of its own.
 **Recommendation: fold the CONSTANT/fixed-width part into whatever phase next
 touches the scan, and close this spec.**
+
+---
+
+# Reopened for CONSTANT only (2026-07-30)
+
+The verdict above stands for dictionaries but rested on one number that turns
+out to be a property of the prototype rather than of the problem: **13-21 ns per
+value to detect**. That prototype hashed values generically. When the value fits
+in a 64-bit word — INT, BIGINT, and any string of at most 8 bytes — the value
+*is* the key: no hashing of bytes, no `memcmp`, no pointer chasing, just open
+addressing on a power-of-two table.
+
+Re-measured on that shape, 2048-row chunks (ns per value):
+
+| detector | 1 distinct | 16 | 128 | 1024 | 2048 |
+| --- | --- | --- | --- | --- | --- |
+| CONSTANT check, int32 | 0.49 | ~0 | ~0 | ~0 | ~0 |
+| CONSTANT check, int64 | 0.28 | ~0 | ~0 | ~0 | ~0 |
+| dictionary build, int32 | 0.46 | 0.47 | 0.74 | 0.88 | 0.88 |
+| dictionary build, int64 | 0.46 | 0.47 | 0.78 | 0.93 | 0.89 |
+| dictionary build, 3-char strings | 1.81 | 1.86 | 1.83 | 1.90 | 1.86 |
+| dictionary build, 5-char strings | 2.55 | 2.24 | 2.40 | 2.40 | 2.44 |
+
+Against a decode of ~1.8 ns/value for integers and ~2.1 for short ASCII strings.
+
+**Dictionaries stay closed, for the corrected reason.** The scan-side economics
+are now fine for integers (0.5-0.9 ns), but the deciding half is downstream and
+unchanged: GROUP BY / DISTINCT / JOIN 2-3.5× faster, **`ORDER BY` 3× slower**,
+and the scan cannot know which it is feeding. Emitting one is a bet on the
+consumer. Revisit only with an end-to-end measurement on both shapes.
+
+**CONSTANT ships.** It is the one case that is not a bet:
+
+- a miss costs nothing — the detector exits at the second distinct value, and
+  the mixed-NULL case exits on a counter comparison before looking at any value;
+- a hit costs 0.3-0.5 ns per value;
+- unlike a dictionary, a constant vector has a fast path in essentially every
+  DuckDB operator, so there is no consumer for which it is a pessimisation;
+- and on a hit the batch decode collapses from N values to **one** — the scan
+  itself gets faster, so the win does not depend on downstream at all.
+
+## Implementation
+
+Hook: `RowStager::FinalizeChunk`, per column, ahead of the kernel switch. Three
+cases, ordered so the common one exits first:
+
+1. `st.null_count == row_count` → the column-chunk is entirely NULL.
+   `ConstantVector::SetNull(out, true)` and no kernel runs at all. Detected by
+   comparing two numbers already in hand.
+2. `st.null_count != 0` → mixed NULLs, cannot be constant. One comparison, then
+   the normal kernel.
+3. `st.null_count == 0` → scan for equality; on success decode row 0 alone.
+
+### The equality scan, per arm
+
+- **Direct** (`ops.direct_write`): the values are already in the output vector,
+  written there as they arrived. Compare `stride` bytes at row *i* against row 0
+  and, on success, only `out.SetVectorType(VectorType::CONSTANT_VECTOR)` — row
+  0's value is already at offset 0, so this copies **nothing**.
+- **Fixed**: same comparison against `st.buffer` at `stride`.
+- **Var**: `st.lengths[i] == st.lengths[0]` first, then `memcmp` — length alone
+  rejects most columns before a byte is read.
+
+### Decoding the single value
+
+On a hit the family's existing per-value entry point — `codec::<family>::
+DecodeFromTds(st.ValueAt(0), col, out, 0)` — writes slot 0, and the vector is
+then marked constant. That is one call per column per chunk, not a per-value
+path, and it avoids teaching every batch kernel a "just row 0" mode. The string
+kernel in particular sizes its work from `st.PayloadSize()`, i.e. the whole
+column, so calling it with `count = 1` would convert everything and save nothing.
+
+### Invariants this relies on
+
+`MSSQLResultStream::FillChunk` calls `chunk.Reset()` before filling
+(`mssql_result_stream.cpp:277`), and `DataChunk::Reset` → `ResetFromCache` sets
+`vector_type = FLAT_VECTOR` and resets validity. So a constant vector never
+survives into the next chunk, where `BeginChunk` re-takes `direct_dst` from
+`FlatVector::GetData` and would otherwise be handed a one-value buffer. A
+`D_ASSERT` on the vector type in `BeginChunk` pins that for any future caller at
+no release cost.
+
+**Columns feeding `pk_direct_to_rowid` must be excluded.** In that mode the
+stream writes PK values straight into the rowid vector rather than into a plain
+output column, so the constant path does not apply. The composite-PK paths are
+safe as they stand: they copy with `VectorOperations::Copy`, which is
+vector-type aware. Resolve the exclusion once, in `Configure`, as a per-column
+flag.
+
+### Tests
+
+- a constant chunk for each of Direct / Fixed / Var → CONSTANT emitted, value
+  correct;
+- an all-NULL chunk → CONSTANT and NULL, with no kernel run;
+- a mixed-NULL chunk → stays FLAT;
+- a chunk that differs **only in its last row** → stays FLAT (the detector must
+  not stop early);
+- two consecutive chunks, constant then not, then all-NULL — the reset hazard;
+- a scan with a rowid column over a constant PK.
+
+### Acceptance
+
+The wins to show: a constant column-chunk costs less than a flat one (the decode
+collapses to one value), and nothing else regresses — the miss path is measured
+against the current build on the same interleaved A/B discipline as spec 055.
+
+## As landed
+
+Two things changed against the plan above, both because a measurement said so.
+
+**Only columns that decode take the uniformity scan.** The plan scanned every
+arm, including direct-write ones, on the reasoning that a uniform Direct column
+costs a comparison and a single store. It does — and it saves nothing, because
+there is no decode to collapse: measured **+0.26 ns/value** on a uniform BIGINT
+column for a downstream constant alone. Restricted to the staged families, the
+scan is a pure win and the miss stays free:
+
+| column | uniform | distinct | delta |
+| --- | --- | --- | --- |
+| BIGINT (direct) | 2.26 | 2.27 | 0 |
+| DECIMAL(18,2) | 4.81 | 5.59 | **-14%** |
+| NVARCHAR(16) | 6.72 | 7.88 | **-15%** |
+
+The **all-NULL** case still applies to every column including Direct: it is two
+counters compared, never looks at a value, and skips publishing the validity
+mask.
+
+An earlier version of the detector used `memcmp` per value and measured +1.7
+ns/value on BIGINT — a call into libc where a word compare belongs. Typed loads
+brought that to +0.26 before the restriction removed it entirely.
+
+**The `pk_direct_to_rowid` exclusion turned out to be unnecessary.** That mode
+writes PK values into a plain output vector and `PopulateRowIdVector` returns
+without touching it; the composite paths copy through `VectorOperations::Copy`,
+which is vector-type aware. The real hazard was elsewhere: `CountChunkForDebug`
+reads every row through `FlatVector::GetData`, which on a constant vector counts
+whatever is left in the buffer. Debug-only, and fixed with the change.
+
+## What the tests caught
+
+- **NTEXT decoded as single-byte text.** The constant path publishes row 0
+  through the family's per-value entry, and `string::DecodeFromTds` listed
+  NCHAR / NVARCHAR / XML as UTF-16 but not NTEXT — which was invisible while
+  nothing called it for NTEXT, since the legacy path could not read the type at
+  all before #197. Fixed in `string_codec.cpp`.
+- **A test fixture that reset nothing.** The unit tests reused loose vectors
+  across chunks, a state production never sees because `FillChunk` calls
+  `DataChunk::Reset`. The `D_ASSERT` in `BeginChunk` fired on the first run; the
+  fixture now holds a real `DataChunk` and resets it, so the reuse path under
+  test is the one that ships.
+
+Gates: 17 unit blocks, the full local integration suite, and `diff_check.sh`
+byte-identical across 13 queries against a build without the constant path —
+including the NULL, empty-value, embedded-U+0000, PLP and BCP write-back cases.

--- a/src/codec/staging/row_stager.cpp
+++ b/src/codec/staging/row_stager.cpp
@@ -359,6 +359,11 @@ void RowStager::BeginChunk(const std::vector<Vector *> &targets) {
 		// data pointer has to be re-taken every chunk: DataChunk::Reset restores
 		// each vector from its cache and is free to hand back different memory.
 		// Columns that stage into their own buffer take no pointer at all.
+		// A chunk always starts FLAT: MSSQLResultStream::FillChunk calls
+		// DataChunk::Reset, whose ResetFromCache restores the type and validity.
+		// The constant path (spec 056) leaves vectors CONSTANT, and a CONSTANT one
+		// here would hand `direct_dst` a single-value view to write 2048 rows into.
+		D_ASSERT(targets_[i]->GetVectorType() == VectorType::FLAT_VECTOR);
 		uint8_t *direct_dst =
 			ops_[i].direct_write ? reinterpret_cast<uint8_t *>(FlatVector::GetData(*targets_[i])) : nullptr;
 		staging_[i]->BeginChunk(direct_dst);
@@ -581,6 +586,10 @@ void RowStager::FinalizeChunk(idx_t row_count) {
 		}
 		const ColumnStaging &st = *staging_[c];
 		const tds::ColumnMetadata &meta = (*metadata_)[c];
+		if (TryEmitConstant(c, st, meta, row_count)) {
+			chunk_nulls_[c] = st.null_count;
+			continue;
+		}
 		std::chrono::steady_clock::time_point started;
 		if (counters_enabled_) {
 			started = std::chrono::steady_clock::now();
@@ -641,6 +650,161 @@ void RowStager::FinalizeChunk(idx_t row_count) {
 		}
 	}
 	arena_.EndChunk();
+}
+
+//! Is every value the same? Callers reach these only for an all-valid column, so
+//! there are no NULL slots to step over.
+//!
+//! Each returns on the first difference, which is what makes the miss free: a
+//! column of distinct values costs one comparison, not a scan.
+namespace {
+
+//! One slot compared as a machine word rather than through memcmp, which is a
+//! call into libc per value — measured at ~1.7 ns/value against ~0.3 for this.
+//! memcpy for the load, not a cast: the staging buffer is byte-addressed.
+template <typename T>
+inline bool SlotsRepeat(const uint8_t *data, idx_t count) {
+	T first;
+	std::memcpy(&first, data, sizeof(T));
+	for (idx_t row = 1; row < count; row++) {
+		T value;
+		std::memcpy(&value, data + row * sizeof(T), sizeof(T));
+		if (value != first) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool BytesRepeat(const uint8_t *data, uint32_t stride, idx_t count) {
+	switch (stride) {
+	case 1:
+		return SlotsRepeat<uint8_t>(data, count);
+	case 2:
+		return SlotsRepeat<uint16_t>(data, count);
+	case 4:
+		return SlotsRepeat<uint32_t>(data, count);
+	case 8:
+		return SlotsRepeat<uint64_t>(data, count);
+	default:
+		// The odd widths — 3, 5-7, 9, 10, 13, 16, 17 — belong to the temporal,
+		// GUID and DECIMAL families, where the decode this saves dwarfs the
+		// comparison either way.
+		for (idx_t row = 1; row < count; row++) {
+			if (std::memcmp(data + row * stride, data, stride) != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+}
+
+bool StagedVarRepeats(const ColumnStaging &st, idx_t count) {
+	const uint32_t length = st.lengths[0];
+	const uint8_t *const first = st.buffer.data() + st.offsets[0];
+	for (idx_t row = 1; row < count; row++) {
+		// Length first: it rejects most columns before a byte is compared.
+		if (st.lengths[row] != length || std::memcmp(st.buffer.data() + st.offsets[row], first, length) != 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+}  // namespace
+
+bool RowStager::TryEmitConstant(idx_t c, const ColumnStaging &st, const tds::ColumnMetadata &meta, idx_t row_count) {
+	if (row_count < 2) {
+		// One row is trivially uniform, but a one-row chunk has nothing to save
+		// and the vector is already correct as a flat one.
+		return false;
+	}
+	Vector &out = *targets_[c];
+
+	// All NULL. Free to detect — two numbers already in hand — and it skips the
+	// kernel entirely, which is the whole win for a column a query does not
+	// populate. Common in wide tables.
+	if (st.null_count == row_count) {
+		out.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(out, true);
+		if (counters_enabled_) {
+			counters_.constant_null_columns++;
+		}
+		return true;
+	}
+	// A NULL among values cannot be uniform, and this rejects it before any value
+	// is looked at.
+	if (st.null_count != 0) {
+		return false;
+	}
+
+	// Only columns whose values still have to be DECODED are scanned for
+	// uniformity. A direct-write column has no decode to collapse — its values
+	// were stored into the output vector as they arrived — so the scan buys
+	// nothing here and only a downstream constant, which measured at +0.26
+	// ns/value on a uniform BIGINT column against a decode saving of zero. The
+	// families that do decode measured -14% (DECIMAL) and -16% (NVARCHAR).
+	//
+	// The all-NULL case above deliberately still applies to them: it is detected
+	// by comparing two counters, never looks at a value, and skips publishing the
+	// validity mask.
+	if (ops_[c].direct_write) {
+		return false;
+	}
+	if (ops_[c].kind == StagingKind::Var) {
+		if (!StagedVarRepeats(st, row_count)) {
+			return false;
+		}
+	} else if (!BytesRepeat(st.buffer.data(), st.stride, row_count)) {
+		return false;
+	}
+
+	// Decode row 0 alone. This is the family's per-VALUE entry point, called once
+	// per column per chunk — not a per-value path — and it is preferred to calling
+	// the batch kernel with count = 1 because the string kernel sizes its work
+	// from the whole staged payload and would convert all 2048 values to publish
+	// one.
+	DecodeFirstValue(c, st, meta, out);
+	out.SetVectorType(VectorType::CONSTANT_VECTOR);
+	if (counters_enabled_) {
+		counters_.constant_columns++;
+	}
+	return true;
+}
+
+//! Publish row 0 into slot 0, by family. Only the staged kernels come here;
+//! a direct-write column already has its value in place.
+void RowStager::DecodeFirstValue(idx_t c, const ColumnStaging &st, const tds::ColumnMetadata &meta, Vector &out) {
+	if (ops_[c].kernel == FinalizeKernel::Text) {
+		// The issue-#89 fallback is row-indexed already, so one row is one row.
+		FinalizeFallbackColumn(st, 1, meta, out);
+		return;
+	}
+	const uint8_t *const value = st.ValueAt(0);
+	const std::vector<uint8_t> bytes(value, value + st.LengthAt(0));
+	switch (ops_[c].kernel) {
+	case FinalizeKernel::String:
+		string::DecodeFromTds(bytes, meta, out, 0);
+		break;
+	case FinalizeKernel::Binary:
+		binary::DecodeFromTds(bytes, meta, out, 0);
+		break;
+	case FinalizeKernel::Uuid:
+		uuid::DecodeFromTds(bytes, meta, out, 0);
+		break;
+	case FinalizeKernel::Decimal:
+		decimal::DecodeFromTds(bytes, meta, out, 0);
+		break;
+	case FinalizeKernel::Money:
+		money::DecodeFromTds(bytes, meta, out, 0);
+		break;
+	case FinalizeKernel::Datetime:
+		datetime::DecodeFromTds(bytes, meta, out, 0);
+		break;
+	case FinalizeKernel::None:
+	case FinalizeKernel::Text:
+		break;
+	}
 }
 
 void RowStager::CountColumn(idx_t c, const ColumnStaging &st, idx_t row_count, uint64_t elapsed_ns) {

--- a/src/codec/string_codec.cpp
+++ b/src/codec/string_codec.cpp
@@ -472,8 +472,14 @@ void DecodeFromTds(const std::vector<uint8_t> &bytes, const tds::ColumnMetadata 
 	// as every pre-054 release did.
 	const bool trim_trailing_spaces = col.type_id == tds::TDS_TYPE_BIGCHAR || col.type_id == tds::TDS_TYPE_NCHAR;
 
+	// NTEXT belongs here too: its payload is UTF-16 exactly like NVARCHAR, only
+	// its ROW framing differs (a text pointer, spec 055 D9). It was missing while
+	// nothing called this entry point for it — the legacy path could not read
+	// NTEXT at all before #197 — and the omission surfaced the moment the spec-056
+	// constant path decoded one value through here and got the bytes read as
+	// single-byte characters.
 	if (col.type_id == tds::TDS_TYPE_NCHAR || col.type_id == tds::TDS_TYPE_NVARCHAR ||
-		col.type_id == tds::TDS_TYPE_XML) {
+		col.type_id == tds::TDS_TYPE_XML || col.type_id == tds::TDS_TYPE_NTEXT) {
 		size_t byte_len = bytes.size();
 		if (trim_trailing_spaces) {
 			while (byte_len >= 2 && bytes[byte_len - 2] == 0x20 && bytes[byte_len - 1] == 0x00) {

--- a/src/include/codec/staging/row_stager.hpp
+++ b/src/include/codec/staging/row_stager.hpp
@@ -69,6 +69,11 @@ struct StagingCounters {
 	uint64_t boundary[BOUNDARY_STRATEGY_COUNT] = {};
 	//! Code units replaced with U+FFFD (invalid UTF-16, legal in UCS-2).
 	uint64_t replaced_units = 0;
+	//! Column-chunks published as a CONSTANT vector (spec 056): every value the
+	//! same, or every value NULL. The second is counted apart because it costs
+	//! nothing to detect and skips the kernel outright.
+	uint64_t constant_columns = 0;
+	uint64_t constant_null_columns = 0;
 	//! Columns by how their payload was sized, counted once per result set.
 	//! `capped` is the interesting one: a bound existed but was too large to
 	//! preallocate, so the column finds its size by growing.
@@ -169,6 +174,16 @@ private:
 	//! Fold one finished column into the counters. Out of line and called only
 	//! when they are on.
 	void CountColumn(idx_t c, const ColumnStaging &st, idx_t row_count, uint64_t elapsed_ns);
+
+	//! Publish the column as a CONSTANT vector when every row holds the same
+	//! value, or every row is NULL (spec 056). Returns true when it did, in which
+	//! case no kernel runs and no flat validity is published.
+	//!
+	//! Cheap to fail: a mixed-NULL column exits on a counter comparison, and a
+	//! column of distinct values exits at row 1.
+	bool TryEmitConstant(idx_t c, const ColumnStaging &st, const tds::ColumnMetadata &meta, idx_t row_count);
+	//! Decode row 0 into slot 0 for a staged family, one call per column-chunk.
+	void DecodeFirstValue(idx_t c, const ColumnStaging &st, const tds::ColumnMetadata &meta, Vector &out);
 
 	StagingArena arena_;
 	std::vector<ColumnOps> ops_;

--- a/src/query/mssql_result_stream.cpp
+++ b/src/query/mssql_result_stream.cpp
@@ -668,6 +668,10 @@ void MSSQLResultStream::PrintStagingCounters() {
 			(unsigned long long)sc.direct_values, (unsigned long long)sc.nbc_rows,
 			(unsigned long long)arena.GrowEvents(), (unsigned long long)arena.ShrinkEvents(),
 			(unsigned long long)arena.PeakPayloadBytes());
+	if (sc.constant_columns > 0 || sc.constant_null_columns > 0) {
+		fprintf(stderr, "[MSSQL COUNTERS]   constant column-chunks: uniform=%llu all_null=%llu\n",
+				(unsigned long long)sc.constant_columns, (unsigned long long)sc.constant_null_columns);
+	}
 	fprintf(stderr, "[MSSQL COUNTERS]   columns: prealloc_bounded=%llu prealloc_capped=%llu unbounded=%llu\n",
 			(unsigned long long)sc.prealloc_bounded_columns, (unsigned long long)sc.prealloc_capped_columns,
 			(unsigned long long)sc.unbounded_columns);

--- a/test/cpp/codec/test_row_stager.cpp
+++ b/test/cpp/codec/test_row_stager.cpp
@@ -37,6 +37,7 @@
 #include "codec/staging/row_stager.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "tds/encoding/type_converter.hpp"
@@ -359,22 +360,26 @@ public:
 		// a test reads — and a test that owns its stager can simply turn it on.
 		// Enabling them also puts the counter-folding code itself under test.
 		stager_.EnableCounters();
+		// A real DataChunk, not loose vectors: the stream fills one of these and
+		// calls Reset() on it between chunks, which is what restores FLAT vectors
+		// and clean validity after the constant path (spec 056) leaves one
+		// CONSTANT. A fixture that reset nothing would test a state production
+		// never sees — and it did, until the BeginChunk assertion said so.
+		duckdb::vector<LogicalType> types;
 		for (size_t i = 0; i < metadata_.size(); i++) {
-			if (skipped_[i]) {
-				owned_.push_back(nullptr);
-				targets_.push_back(nullptr);
-				continue;
-			}
-			const LogicalType type = targets_types_[i].id() == LogicalTypeId::INVALID
-										 ? TypeConverter::GetDuckDBType(metadata_[i])
-										 : targets_types_[i];
-			owned_.push_back(std::unique_ptr<Vector>(new Vector(type)));
-			targets_.push_back(owned_.back().get());
+			types.push_back(targets_types_[i].id() == LogicalTypeId::INVALID
+								? TypeConverter::GetDuckDBType(metadata_[i])
+								: targets_types_[i]);
+		}
+		chunk_.Initialize(duckdb::Allocator::DefaultAllocator(), types);
+		for (size_t i = 0; i < metadata_.size(); i++) {
+			targets_.push_back(skipped_[i] ? nullptr : &chunk_.data[i]);
 		}
 		stager_.Configure(metadata_, targets_);
 	}
 
 	void BeginChunk() {
+		chunk_.Reset();
 		stager_.BeginChunk(targets_);
 	}
 	size_t StageRow(const Wire &row, idx_t row_idx) {
@@ -390,12 +395,17 @@ public:
 	//! What column `c` holds at `row`, rendered — "NULL" for a NULL, so a wrong
 	//! NULL and a wrong value read the same way in the failure output.
 	std::string ValueAt(size_t c, idx_t row) {
-		const duckdb::Value v = owned_[c]->GetValue(row);
+		const duckdb::Value v = chunk_.data[c].GetValue(row);
 		return v.IsNull() ? std::string("NULL") : v.ToString();
 	}
 
+	//! CONSTANT or FLAT — the spec-056 emission is asserted, not assumed.
+	bool IsConstant(size_t c) {
+		return chunk_.data[c].GetVectorType() == duckdb::VectorType::CONSTANT_VECTOR;
+	}
+
 	bool IsNull(size_t c, idx_t row) {
-		return owned_[c]->GetValue(row).IsNull();
+		return chunk_.data[c].GetValue(row).IsNull();
 	}
 
 	RowStager &stager() {
@@ -413,7 +423,7 @@ private:
 	std::vector<bool> skipped_;
 	//! INVALID means "whatever the wire type implies" — the ordinary case.
 	std::vector<LogicalType> targets_types_;
-	std::vector<std::unique_ptr<Vector>> owned_;
+	duckdb::DataChunk chunk_;
 	std::vector<Vector *> targets_;
 	RowStager stager_;
 };
@@ -967,15 +977,22 @@ void TestStringBoundaryStrategies() {
 		// and would not read these P2 rows at all.
 		f.Add(Meta(duckdb::tds::TDS_TYPE_NVARCHAR, 400));
 		std::vector<Wire> values;
+		// Distinct on purpose: two identical values are a CONSTANT column-chunk
+		// (spec 056) and never reach a boundary walk at all.
 		values.push_back(RepeatUnit(0x4E00, 120));
-		values.push_back(RepeatUnit(0x4E00, 120));
+		values.push_back(Cat(RepeatUnit(0x4E00, 119), Units({0x4E8C})));
 		DecodeStrings(f, values);
 		std::string expected;
 		for (int i = 0; i < 120; i++) {
 			expected += "\xE4\xB8\x80";
 		}
+		std::string expected2;
+		for (int i = 0; i < 119; i++) {
+			expected2 += "\xE4\xB8\x80";
+		}
+		expected2 += "\xE4\xBA\x8C";
 		CHECK_EQ(f.ValueAt(0, 0), expected, "CJK value 0 at three bytes per unit");
-		CHECK_EQ(f.ValueAt(0, 1), expected, "CJK value 1");
+		CHECK_EQ(f.ValueAt(0, 1), expected2, "CJK value 1");
 		CHECK_EQ(BoundaryCount(f, Boundary::Memchr), static_cast<uint64_t>(1), "long runs take memchr");
 	}
 }
@@ -1207,6 +1224,116 @@ void TestTemporalScaleIsBounded() {
 	}
 }
 
+void TestConstantEmission() {
+	std::cout << "[16] constant column-chunks (spec 056)..." << std::endl;
+
+	// A uniform column-chunk is published as a CONSTANT vector: the decode
+	// collapses from N values to one, so the win is on the scan itself and not
+	// only downstream. Every arm is covered — Direct (already in the vector,
+	// nothing decoded at all), Fixed and Var.
+	const std::vector<ArmCase> cases = AllArms();
+	for (size_t i = 0; i < cases.size(); i++) {
+		// Direct columns are deliberately left flat: they have no decode to
+		// collapse, so scanning them for uniformity buys only a downstream
+		// constant and measured at +0.26 ns/value to do it.
+		const bool collapses =
+			!duckdb::mssql::codec::staging::ResolveColumnOps(cases[i].meta, TypeConverter::GetDuckDBType(cases[i].meta))
+				 .direct_write;
+		Fixture f;
+		f.Add(cases[i].meta);
+		f.Configure();
+		f.BeginChunk();
+		for (idx_t row = 0; row < 8; row++) {
+			f.StageRow(cases[i].value, row);
+		}
+		f.FinalizeChunk(8);
+		CHECK_EQ(f.IsConstant(0), collapses, cases[i].label);
+		// Correctness is the point, not the vector type: every row must still read
+		// back as the value, through the same accessor a consumer would use.
+		for (idx_t row = 0; row < 8; row++) {
+			CHECK_EQ(f.ValueAt(0, row), std::string(cases[i].expected), cases[i].label);
+		}
+	}
+
+	// One differing row — and the LAST one, so a detector that stops early is
+	// caught — must keep the column flat and decode every value.
+	for (size_t i = 0; i < cases.size(); i++) {
+		if (cases[i].null_wire.empty()) {
+			continue;  // no NULL form to differ with in a plain ROW
+		}
+		Fixture f;
+		f.Add(cases[i].meta);
+		f.Configure();
+		f.BeginChunk();
+		for (idx_t row = 0; row < 7; row++) {
+			f.StageRow(cases[i].value, row);
+		}
+		f.StageRow(cases[i].null_wire, 7);
+		f.FinalizeChunk(8);
+		CHECK_TRUE(!f.IsConstant(0), cases[i].label);
+		CHECK_EQ(f.ValueAt(0, 0), std::string(cases[i].expected), cases[i].label);
+		CHECK_EQ(f.ValueAt(0, 6), std::string(cases[i].expected), cases[i].label);
+		CHECK_TRUE(f.IsNull(0, 7), cases[i].label);
+	}
+}
+
+void TestConstantAllNullAndReuse() {
+	std::cout << "[17] all-NULL chunks, and a vector reused across chunks..." << std::endl;
+
+	// All NULL: detected by comparing two counters, no kernel runs, and the
+	// vector is CONSTANT-NULL.
+	Fixture f;
+	f.Add(Meta(duckdb::tds::TDS_TYPE_NVARCHAR, 40));
+	f.Add(Meta(duckdb::tds::TDS_TYPE_INTN, 4));
+	f.Configure();
+	f.BeginChunk();
+	for (idx_t row = 0; row < 5; row++) {
+		f.StageRow(Cat(P2Null(), P1Null()), row);
+	}
+	f.FinalizeChunk(5);
+	CHECK_TRUE(f.IsConstant(0), "all-NULL string column is constant");
+	CHECK_TRUE(f.IsConstant(1), "all-NULL integer column is constant");
+	for (idx_t row = 0; row < 5; row++) {
+		CHECK_TRUE(f.IsNull(0, row), "every row NULL");
+		CHECK_TRUE(f.IsNull(1, row), "every row NULL");
+	}
+
+	// The same vectors, chunk after chunk: constant, then mixed, then all-NULL.
+	// This is the reuse hazard — a CONSTANT vector carried into the next chunk
+	// would hand the Direct arm a one-value view to write into, and stale NULL
+	// bits would republish rows as NULL. DataChunk::Reset is what prevents both,
+	// and the fixture goes through it exactly as the stream does.
+	f.BeginChunk();
+	for (idx_t row = 0; row < 4; row++) {
+		f.StageRow(Cat(P2(Utf16("same")), P1(Bare({7, 0, 0, 0}))), row);
+	}
+	f.FinalizeChunk(4);
+	CHECK_TRUE(f.IsConstant(0), "second chunk: uniform again");
+	CHECK_TRUE(!f.IsConstant(1), "a uniform INTN is left flat — no decode to collapse");
+	CHECK_EQ(f.ValueAt(0, 3), std::string("same"), "second chunk value");
+	CHECK_EQ(f.ValueAt(1, 3), std::string("7"), "second chunk integer");
+
+	f.BeginChunk();
+	f.StageRow(Cat(P2(Utf16("a")), P1(Bare({1, 0, 0, 0}))), 0);
+	f.StageRow(Cat(P2(Utf16("b")), P1(Bare({2, 0, 0, 0}))), 1);
+	f.StageRow(Cat(P2Null(), P1Null()), 2);
+	f.FinalizeChunk(3);
+	CHECK_TRUE(!f.IsConstant(0), "third chunk: mixed values stay flat");
+	CHECK_EQ(f.ValueAt(0, 0), std::string("a"), "flat after constant: row 0");
+	CHECK_EQ(f.ValueAt(0, 1), std::string("b"), "flat after constant: row 1");
+	CHECK_TRUE(f.IsNull(0, 2), "flat after constant: row 2 NULL");
+	CHECK_EQ(f.ValueAt(1, 0), std::string("1"), "integer row 0");
+	CHECK_EQ(f.ValueAt(1, 1), std::string("2"), "integer row 1");
+	CHECK_TRUE(f.IsNull(1, 2), "integer row 2 NULL");
+
+	// A single-row chunk stays flat: there is nothing to collapse.
+	f.BeginChunk();
+	f.StageRow(Cat(P2(Utf16("solo")), P1(Bare({9, 0, 0, 0}))), 0);
+	f.FinalizeChunk(1);
+	CHECK_TRUE(!f.IsConstant(0), "a one-row chunk is not worth collapsing");
+	CHECK_EQ(f.ValueAt(0, 0), std::string("solo"), "one-row value");
+}
+
 }  // namespace
 
 int main() {
@@ -1227,6 +1354,8 @@ int main() {
 	TestDatetimeDayRange();
 	TestImpossibleDeclaredWidth();
 	TestTemporalScaleIsBounded();
+	TestConstantEmission();
+	TestConstantAllNullAndReuse();
 
 	if (failures == 0) {
 		std::cout << "\nAll RowStager tests passed." << std::endl;


### PR DESCRIPTION
> Stacked on #214 — base retargets to `main` when that merges. The diff here is the single commit `08be67b`.

A column-chunk whose values are all the same is published as a **CONSTANT** vector: the batch decode collapses from N values to one. A column-chunk that is entirely NULL runs no kernel at all.

## Measured

Medians of three interleaved runs, ns/value, 2048-row chunks:

| column | uniform | distinct | delta |
| --- | --- | --- | --- |
| DECIMAL(18,2) | 4.81 | 5.59 | **−14%** |
| NVARCHAR(16) | 6.72 | 7.88 | **−15%** |
| BIGINT | 2.26 | 2.27 | 0 |

**The miss is free.** A mixed-NULL column exits on a counter comparison without looking at a value; a column of distinct values exits at row 1.

## Only columns that decode are scanned

The first version scanned every arm. A direct-write column has no decode to collapse — its values were stored into the output vector as they arrived — so scanning it buys a downstream constant and nothing else: **+0.26 ns/value** on a uniform BIGINT for zero scan-side saving. Restricted to the staged families, the change is a pure win where it applies and costs nothing where it does not.

The all-NULL case still covers every column, direct ones included: two counters compared, no value read, and the validity mask never published.

(An earlier detector used `memcmp` per value — a call into libc where a word compare belongs, +1.7 ns/value on BIGINT. Typed loads brought that to +0.26 before the restriction removed it.)

## Why constants and not dictionaries

Spec 056 was closed on the finding that detection costs 13–21 ns/value. That number is a property of the prototype's generic hashing, not of the problem: when the value fits a 64-bit word — INT, BIGINT, any string ≤ 8 bytes — the value *is* the key, and detection measures 0.5–0.9 ns.

Dictionaries still do not ship, for the corrected reason: the deciding half is downstream, where GROUP BY / DISTINCT / JOIN are 2–3.5× faster but **`ORDER BY` is 3× slower**, and the scan cannot know which it is feeding. Emitting one is a bet on the consumer. A constant vector has no such asymmetry — there is no operator for which it is a pessimisation — which is why this half ships and that half waits for an end-to-end measurement.

## Two defects it surfaced

- **`string::DecodeFromTds` treated NTEXT as single-byte text.** It lists NCHAR, NVARCHAR and XML as UTF-16 and never got NTEXT — invisible while nothing called it for that type, since the legacy path could not read NTEXT at all before #197. The constant path publishes row 0 through that entry point and produced `O\0k\0` for `Ok`.
- **The unit-test fixture reused vectors across chunks without a reset**, a state production never reaches because `FillChunk` calls `DataChunk::Reset`. The new `D_ASSERT` in `BeginChunk` caught it on the first run. The fixture now holds a real `DataChunk`, so the reuse path under test is the one that ships.

## Also checked, and not needed

`pk_direct_to_rowid` looked like it would have to be excluded. It does not: that mode writes into a plain output vector and `PopulateRowIdVector` returns without touching it, and the composite paths copy through `VectorOperations::Copy`, which is vector-type aware. The real hazard was `CountChunkForDebug`, which reads every row through `FlatVector::GetData` and would count whatever is left in the buffer of a constant vector — debug-only, fixed here.

## Gates

17 unit blocks; the full local integration suite (132 cases, 3879 assertions); and `diff_check.sh` **byte-identical across 13 queries** against a build without the constant path — NULLs, empty values, embedded `U+0000`, PLP and BCP write-back included.
