### PR TITLE
fix(codec): widen the DATETIME day count before converting to epoch days

### DIFF
--- a/src/tds/encoding/datetime_encoding.cpp
+++ b/src/tds/encoding/datetime_encoding.cpp
@@ -64,8 +64,13 @@ timestamp_t DateTimeEncoding::ConvertDatetime(const uint8_t *data) {
 	std::memcpy(&days, data, 4);
 	std::memcpy(&ticks, data + 4, 4);
 
-	// Convert to days since 1970-01-01
-	int32_t unix_days = days - DAYS_FROM_1900_TO_EPOCH;
+	// Convert to days since 1970-01-01. Widened before the subtraction: `days` is
+	// a full signed 32-bit field, so INT32_MIN - 25567 overflows int32 — undefined
+	// behaviour on a value only a corrupt stream can produce. Caught by UBSan once
+	// test_row_stager started building sanitized (#217's script). For every legal
+	// day count the result is unchanged, and the unsigned assembly below already
+	// handles the meaningless-but-defined case the same way.
+	const int64_t unix_days = static_cast<int64_t>(days) - DAYS_FROM_1900_TO_EPOCH;
 
 	// Convert ticks to microseconds (1 tick = 1/300 second)
 	// microseconds = ticks * 1000000 / 300 = ticks * 10000 / 3


### PR DESCRIPTION
UBSan failure on `main` — both `Build (linux_amd64)` and `Build (osx_arm64)` in run 30607263680:

```
src/tds/encoding/datetime_encoding.cpp:68: runtime error:
signed integer overflow: -2147483648 - 25567 cannot be represented in type 'int'
```

`ConvertDatetime` reads a full signed 32-bit day field off the wire and rebases it on 1970-01-01. For day counts near `INT32_MIN` that subtraction overflows. The multiply immediately after it was already assembled through an unsigned type for exactly this reason — the subtraction ahead of it was missed.

Only a corrupt stream can produce such a value (DATETIME stops at 9999-12-31) and the result is a meaningless timestamp either way; the point is that it is now defined rather than UB. Every legal day count is unaffected.

**Why it surfaced now.** #217 put `test_row_stager` and `test_row_stager_framing` on one shared script, which builds sanitized. `test_row_stager` had run unsanitized since it landed, so its own "a DATETIME day count no conforming server can send" case had been stepping over this UB in silence. The unification found a real defect on its first run — which is the argument the framing test makes about drift, applied to sanitizer coverage.

Verified locally under UBSan: all 17 RowStager groups pass.