### PR TITLE
ci: pin the POSIX vcpkg clone to the builtin-baseline commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,16 @@ jobs:
 
       - name: Setup vcpkg
         run: |
+          # Pinned to vcpkg.json's builtin-baseline: an unpinned master clone
+          # rides vcpkg's scripts ahead of the pinned ports, and the first
+          # cold-cache port build breaks when those scripts outgrow the
+          # runner's CMake (v0.2.3 release: z_vcpkg_spdx.cmake started using
+          # string(JSON ... STRING_ENCODE), CMake >= 4.1, and arm64-linux —
+          # the one platform without a warm openssl archive — failed).
           if [ ! -d "vcpkg" ]; then
             git clone https://github.com/microsoft/vcpkg.git
+            BASELINE=$(grep -o '"builtin-baseline": *"[a-f0-9]*"' vcpkg.json | grep -oE '[a-f0-9]{40}')
+            git -C vcpkg checkout "$BASELINE"
             ./vcpkg/bootstrap-vcpkg.sh
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,16 @@ jobs:
       - name: Setup vcpkg
         shell: bash
         run: |
+          # Pinned to vcpkg.json's builtin-baseline: an unpinned master clone
+          # rides vcpkg's scripts ahead of the pinned ports, and the first
+          # cold-cache port build breaks when those scripts outgrow the
+          # runner's CMake (v0.2.3 release: z_vcpkg_spdx.cmake started using
+          # string(JSON ... STRING_ENCODE), CMake >= 4.1, and arm64-linux —
+          # the one platform without a warm openssl archive — failed).
           if [ ! -d "vcpkg" ]; then
             git clone https://github.com/microsoft/vcpkg.git
+            BASELINE=$(grep -o '"builtin-baseline": *"[a-f0-9]*"' vcpkg.json | grep -oE '[a-f0-9]{40}')
+            git -C vcpkg checkout "$BASELINE"
             ./vcpkg/bootstrap-vcpkg.sh
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ vcpkg-setup:
 			rm -rf $(VCPKG_DIR); \
 			git clone https://github.com/microsoft/vcpkg.git $(VCPKG_DIR); \
 		fi; \
+		baseline=$$(grep -o '"builtin-baseline": *"[a-f0-9]*"' $(PROJ_DIR)vcpkg.json | grep -oE '[a-f0-9]{40}'); \
+		git -C $(VCPKG_DIR) checkout "$$baseline"; \
 		$(VCPKG_DIR)/bootstrap-vcpkg.sh; \
 	fi
 


### PR DESCRIPTION
The v0.2.3 release run failed on `linux_arm64` only: the unpinned `git clone` of vcpkg master picked up scripts using `string(JSON ... STRING_ENCODE)` (CMake ≥ 4.1), and arm64 was the one platform whose cold binary cache made vcpkg actually execute a portfile (openssl). Warm-cache platforms never run the broken script path — which is what makes an unpinned clone a time bomb rather than an immediate failure.

The clone now checks out `vcpkg.json`'s `builtin-baseline` (the commit the manifest already pins ports to, and the same one community-extensions pins via `vcpkg_commit`), in `release.yml`, `ci.yml` and `make vcpkg-setup`. Windows jobs already pin via `lukka/run-vcpkg` and are untouched.

After merge: re-tag `v0.2.3` on the fixed commit (the failed run published nothing) and let the release rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Az9Jy698ZsXztSNTSjMMq