### PR TITLE
fix(compat): the version matrix could pass without comparing, and break its own --json

### DIFF
--- a/test/compat/mssql_version_matrix.sh
+++ b/test/compat/mssql_version_matrix.sh
@@ -322,18 +322,41 @@ roundtrip() {
 	# -csv -noheader: the default box renderer draws with U+2502, not ASCII '|',
 	# so anything grepping for a pipe silently matches nothing and every result
 	# reads as "n/a" — which looks like a skip rather than a broken parser.
+	# TWO numbers, not one: the mismatch count alone cannot tell "every row
+	# agreed" from "there were no rows to compare". The `IS NOT NULL` guard means
+	# a column with zero non-NULL rows counts 0 mismatches and would report pass
+	# while comparing nothing — the same vacuous-pass shape as the self-compare
+	# tautology this function was already fixed for once.
 	out=$("$DUCKDB_BIN" -csv -noheader -c "
 $pre
 ATTACH '$(dsn)' AS m (TYPE mssql);
-SELECT count(*) FROM m.dbo.Charsets
-WHERE $col IS NOT NULL AND $col IS DISTINCT FROM ($expected);" 2>"$err" | tr -d '\r' | grep -E '^[0-9]+$' | head -1)
+SELECT count(*) FILTER (WHERE $col IS DISTINCT FROM ($expected)) || ':' || count(*)
+FROM m.dbo.Charsets WHERE $col IS NOT NULL;" 2>"$err" | tr -d '\r' | grep -E '^[0-9]+:[0-9]+$' | head -1)
 	rc=$?
 	if [ -n "$out" ]; then
 		rm -f "$err"
-		[ "$out" = "0" ] && echo "pass" || echo "FAIL:${out}_mismatch"
+		# ':' not ',' as the separator: -csv QUOTES any value containing a comma,
+		# so `0,2` arrives as `"0,2"` and no bare-numeric regex matches it. Third
+		# time an output-format detail has silently defeated this parser (see the
+		# U+2502 note above), hence the deliberately unquotable separator.
+		local bad="${out%%:*}" compared="${out##*:}"
+		if [ "$compared" = "0" ]; then
+			# Nothing to compare. Reported distinctly so it can never be read as
+			# evidence the column round-trips.
+			echo "empty"
+		elif [ "$bad" = "0" ]; then
+			echo "pass:${compared}"
+		else
+			echo "FAIL:${bad}_of_${compared}"
+		fi
 		return
 	fi
-	local detail; detail=$(tr -d '\r' < "$err" | grep -iE "error" | head -1 | cut -c1-70)
+	# Strip the characters that break the two consumers downstream: `"` makes
+	# --json emit invalid JSON (DuckDB says `Referenced column "v_u8" not found`),
+	# and `|` shifts every later field of the `IFS='|' read` that builds the
+	# summary row. Both were reachable from any real error.
+	local detail
+	detail=$(tr -d '\r' < "$err" | grep -iE "error" | head -1 | tr -d '"\\|' | tr -s ' ' | cut -c1-70)
 	rm -f "$err"
 	if echo "$detail" | grep -qiE "not found in FROM clause|Referenced column|does not have a column"; then
 		echo "n/a"   # column genuinely absent on this version
@@ -503,10 +526,10 @@ fi
 echo "==============================================================="
 echo "  SUMMARY"
 echo "==============================================================="
-printf "%-6s %-14s %-10s %-6s %-9s %-9s %-9s %-9s\n" ver product status u8col nvarchar dbcs cp1252 utf8col
+printf "%-6s %-14s %-10s %-6s %-12s %-12s %-12s %-12s\n" ver product status u8col nvarchar dbcs cp1252 utf8col
 for r in "${RESULTS[@]}"; do
 	IFS='|' read -r ver prod st u8 nv jp l1 u8c _wire <<< "$r"
-	printf "%-6s %-14s %-10s %-6s %-9s %-9s %-9s %-9s\n" "$ver" "$prod" "$st" "$u8" "$nv" "$jp" "$l1" "$u8c"
+	printf "%-6s %-14s %-10s %-6s %-12s %-12s %-12s %-12s\n" "$ver" "$prod" "$st" "$u8" "$nv" "$jp" "$l1" "$u8c"
 done
 echo
 for r in "${RESULTS[@]}"; do
@@ -536,7 +559,7 @@ fi
 # it is the status that used to be reported as "n/a" and slip through.
 for r in "${RESULTS[@]}"; do
 	case "$r" in
-	*"|FAILED|"*|*"|LOGIN_FAIL|"*|*"|SEED_FAIL|"*|*"|NO_SQLCMD|"*|*"|UNKNOWN_VERSION|"*|*FAIL:*|*ERR:*)
+	*"|FAILED|"*|*"|LOGIN_FAIL|"*|*"|SEED_FAIL|"*|*"|NO_SQLCMD|"*|*"|UNKNOWN_VERSION|"*|*FAIL:*|*ERR:*|*"|empty"*|*"|empty|"*)
 		exit 1 ;;
 	esac
 done


### PR DESCRIPTION
Two defects I introduced in #232 and shipped in **v0.2.3**. Both were caught by the post-commit reviews of the rebased commits (roborev 640/641) — which I never read at the time, so they went out unaddressed.

One file, no production code.

## `--json` emitted invalid JSON on any error

`detail` was raw DuckDB stderr spliced into a `|`-delimited `RESULTS` record and then into `printf '"%s"'`. DuckDB messages routinely carry double quotes:

```
{"version":"2019","wire_bytes_per_row":"ERR:Binder Error: Referenced column "v_u8" not found …
parses: NO — Expecting ',' delimiter
```

So the flag whose entire purpose is mechanical diffing across runs broke on **precisely the runs worth diffing**. A `|` in the same 70 characters would also shift every later field of the `IFS='|' read` that builds the summary row.

Worth noting how it got in: before `ERR:` existed, every field value came from a closed set (`pass` / `FAIL:N_mismatch` / `n/a`) and was safe by construction. Adding free text broke that invariant and nothing noticed. Now stripped at the point of construction.

## `roundtrip` could still pass without comparing anything

The self-comparison tautology was already fixed once. The `IS NOT NULL` guard left the *other* way in: a column with zero non-NULL rows counts zero mismatches and reported `pass`.

A mismatch count alone cannot distinguish "every row agreed" from "there were no rows to compare", so it now returns both numbers:

| result | meaning |
| --- | --- |
| `pass:5` | 5 rows compared, all agreed |
| `FAIL:2_of_5` | 2 of 5 disagreed |
| `empty` | nothing compared — **fails the run**, since the fixture always seeds non-NULL values, so an empty column means it did not |

This paid for itself on the first run:

```
round-trip: nvarchar=pass:5  dbcs(jp)=pass:2  cp1252=pass:2  utf8col=pass:5
```

`dbcs(jp)` and `cp1252` were only ever comparing **two rows**. True before this change, invisible before it.

## A note on the separator

`':'` not `','`, because `-csv` **quotes** any value containing a comma — `0,2` arrives as `"0,2"` and no bare-numeric regex matches. That is the third time an output-format detail has silently defeated this file's parsing (after grepping ASCII `|` where DuckDB's box renderer draws U+2502), so the reason is written down next to the separator rather than left to be rediscovered.

## Verified

Against SQL Server 2022 on a live container: all four round-trips pass with their counts, `--json` parses, and both the `empty` and `FAIL` branches exit non-zero. The sanitiser was checked against a real quoted-and-piped DuckDB message.