### PR TITLE
ci: exclude the lob detector from the TruffleHog secret scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -44,4 +44,10 @@ jobs:
           # On PRs: scan from the base ref to HEAD (only new commits).
           # On push to main / schedule: scan the entire repo history. The
           # action handles the base/head args based on the event.
-          extra_args: --only-verified
+          #
+          # lob detector excluded: its pattern matches C++ test function
+          # names like test_serialize_string_unicode_characters (letters and
+          # underscores, not an API key shape) and its verifier confirms
+          # them, so the full-history scan fails on blobs we can't amend.
+          # We don't use Lob (lob.com print/mail API).
+          extra_args: --only-verified --exclude-detectors=lob


### PR DESCRIPTION
## What

The weekly full-history Security Scan on main failed ([run 31359694586](https://github.com/hugr-lab/mssql-extension/actions/runs/31359694586/job/93370804019)): TruffleHog reported 3 "verified" Lob API keys.

## Why it's a false positive

The "secret" is `test_serialize_string_unicode_characters` — a C++ test function name in `test/cpp/test_value_serializer.cpp` (letters and underscores, not an API key shape). The workflow pins `trufflehog@main` / `latest` image, and the Lob detector's pattern/verifier recently changed upstream: it now matches this identifier and its verification endpoint confirms it. Two hits are in historic blobs (Jan 2026 commits) plus one HTML-decoded duplicate — nothing recently merged is involved.

## Fix

Renaming the function would not help: the scheduled scan covers full git history, and old blobs can't be amended. Instead, exclude the `lob` detector via `--exclude-detectors=lob` — we don't use Lob (lob.com print/mail API), so this costs nothing.

Verified locally with the same image (`trufflehog:latest`, v3.96.0), full-history scan:
- without exclusion: `verified_secrets: 3` (the FP above)
- with exclusion: `verified_secrets: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Az9Jy698ZsXztSNTSjMMq