### PR TITLE
ci: allow manual dispatch of the Security Scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,6 +16,10 @@ on:
   pull_request:
   schedule:
     - cron: '17 5 * * 1'
+  # Manual runs: a failed scheduled run can only be re-run with the workflow
+  # definition from the commit it originally ran against, so a fix to this
+  # file never turns an old run green — dispatch a fresh one instead.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up to #252. Re-running the failed weekly scan ([31359694586](https://github.com/hugr-lab/mssql-extension/actions/runs/31359694586)) can never succeed: a re-run executes the workflow definition from the commit the run was created against (`37596c2`, before the lob exclusion). The next scheduled run is only next Monday.

This adds `workflow_dispatch:` so a fresh run can be triggered manually — I'll dispatch one right after merge to put a green Security Scan at the top of the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Az9Jy698ZsXztSNTSjMMq