### PR TITLE
spec 068: login routing on every auth path (implements #257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,46 @@ jobs:
             test/cpp/test_index_kind.cpp -o /tmp/test_index_kind
           /tmp/test_index_kind
 
+      # Spec 068: login-time routing (ENVCHANGE 20) is followed on every auth
+      # path. Drives a real TdsConnection against a loopback fake TDS server on
+      # 127.0.0.1 -- no SQL Server, no Azure, no AD. It lives in THIS job rather
+      # than the build job's "Run C++ unit tests" step on purpose: that job is
+      # dispatch/schedule-gated, and a routing regression must fail the PR that
+      # causes it. tds_connection.cpp reaches nothing outside the TDS layer, so
+      # the only externals are simdutf (via encoding/utf16.cpp) and OpenSSL
+      # (via tds_socket.hpp -> the TLS TUs; the test itself runs unencrypted).
+      - name: Install simdutf (spec 068 routing test)
+        run: |
+          if [ "${{ matrix.os.id }}" = "macos" ]; then
+            brew install simdutf
+          else
+            sudo apt-get update
+            sudo apt-get install -y libsimdutf-dev libssl-dev
+          fi
+
+      - name: Build + run login routing hop-driver test (spec 068)
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.os.id }}" = "macos" ]; then
+            SIMDUTF_PREFIX="$(brew --prefix simdutf)"
+            OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+            EXTRA_INC="-I $SIMDUTF_PREFIX/include -I $OPENSSL_PREFIX/include"
+            EXTRA_LIB="-L $SIMDUTF_PREFIX/lib -L $OPENSSL_PREFIX/lib"
+          else
+            EXTRA_INC=""
+            EXTRA_LIB=""
+          fi
+          c++ -std=c++17 -pthread -Wno-deprecated-declarations \
+            -I src/include $EXTRA_INC \
+            test/cpp/test_login_routing_hops.cpp \
+            src/tds/tds_connection.cpp src/tds/tds_socket.cpp \
+            src/tds/tls/tds_tls_context.cpp src/tds/tls/tds_tls_impl.cpp \
+            src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp \
+            src/tds/encoding/utf16.cpp \
+            $EXTRA_LIB -lsimdutf -lssl -lcrypto \
+            -o /tmp/test_login_routing_hops
+          /tmp/test_login_routing_hops
+
       # Spec 063 D1: who supplies a bulk-load writer's connection and how many
       # writers there may be. Every case it decides fails SILENTLY when wrong —
       # a writer given the pinned connection interleaves ROW tokens into someone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,21 +171,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SIMDUTF_VER=$(python3 -c "import json;print([o['version'] for o in json.load(open('vcpkg.json'))['overrides'] if o['name']=='simdutf'][0])")
-          # Update this hash when the vcpkg.json override moves; the mismatch
-          # message below is the reminder.
-          EXPECTED_VER=6.1.1
-          EXPECTED_SHA=28f4b565330d25801f160c97970ef06f6b861202286e9a3fef35b0d7320bbf3f
+          # shellcheck source=scripts/ci/simdutf_pin.env
+          . scripts/ci/simdutf_pin.env
+          # `next(..., '')` rather than `[0]`: vcpkg.json's own comments
+          # contemplate dropping the override once the baseline catches up, and
+          # an IndexError traceback is not the guidance a maintainer needs.
+          SIMDUTF_VER=$(python3 -c "import json;print(next((o['version'] for o in json.load(open('vcpkg.json'))['overrides'] if o['name']=='simdutf'), ''))")
+          if [ -z "$SIMDUTF_VER" ]; then
+            echo "::error::vcpkg.json no longer overrides simdutf, so the routing test cannot tell which version the extension links. Either restore the override or pin the version directly in scripts/ci/simdutf_pin.env and drop this check."
+            exit 1
+          fi
+          if [ "$SIMDUTF_VER" != "$SIMDUTF_EXPECTED_VER" ]; then
+            echo "::error::vcpkg.json now pins simdutf $SIMDUTF_VER but scripts/ci/simdutf_pin.env records $SIMDUTF_EXPECTED_VER. Download the new asset, record its SHA-256, and update that file."
+            exit 1
+          fi
           echo "vcpkg.json pins simdutf $SIMDUTF_VER"
           mkdir -p /tmp/simdutf
           curl -sSL --fail --retry 3 -o /tmp/simdutf/singleheader.zip \
             "https://github.com/simdutf/simdutf/releases/download/v${SIMDUTF_VER}/singleheader.zip"
-          if [ "$SIMDUTF_VER" = "$EXPECTED_VER" ]; then
-            echo "$EXPECTED_SHA  /tmp/simdutf/singleheader.zip" | shasum -a 256 -c -
-          else
-            echo "::error::vcpkg.json now pins simdutf $SIMDUTF_VER, but the checksum recorded in ci.yml is for $EXPECTED_VER. Record the new asset's SHA-256 and update EXPECTED_VER/EXPECTED_SHA."
-            exit 1
-          fi
+          echo "$SIMDUTF_EXPECTED_SHA  /tmp/simdutf/singleheader.zip" | shasum -a 256 -c -
           unzip -o -q /tmp/simdutf/singleheader.zip -d /tmp/simdutf
           test -f /tmp/simdutf/simdutf.cpp && test -f /tmp/simdutf/simdutf.h
 
@@ -908,12 +912,30 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          # Same pin file the Linux/macOS leg reads, so the two cannot drift.
+          $pin = Get-Content scripts/ci/simdutf_pin.env `
+                 | Where-Object { $_ -notmatch '^\s*#' -and $_ -match '=' } `
+                 | ConvertFrom-StringData
+          $expectedVer = $pin.SIMDUTF_EXPECTED_VER
+          $expectedSha = $pin.SIMDUTF_EXPECTED_SHA
           $ver = (Get-Content vcpkg.json | ConvertFrom-Json).overrides `
                  | Where-Object { $_.name -eq "simdutf" } | Select-Object -ExpandProperty version
+          if (-not $ver) {
+            throw "vcpkg.json no longer overrides simdutf; see scripts/ci/simdutf_pin.env"
+          }
+          if ($ver -ne $expectedVer) {
+            throw "vcpkg.json pins simdutf $ver but scripts/ci/simdutf_pin.env records $expectedVer. Record the new asset's SHA-256 in that file."
+          }
           Write-Host "vcpkg.json pins simdutf $ver"
           New-Item -ItemType Directory -Force -Path simdutf_sh | Out-Null
           Invoke-WebRequest -Uri "https://github.com/simdutf/simdutf/releases/download/v$ver/singleheader.zip" `
             -OutFile simdutf_sh/singleheader.zip
+          # ~100k lines of C++ get compiled into the test binary below; verify
+          # the bytes before trusting them, exactly as the POSIX leg does.
+          $actualSha = (Get-FileHash simdutf_sh/singleheader.zip -Algorithm SHA256).Hash
+          if ($actualSha -ne $expectedSha.ToUpper()) {
+            throw "simdutf singleheader.zip SHA-256 mismatch: got $actualSha, expected $($expectedSha.ToUpper())"
+          }
           Expand-Archive -Force -Path simdutf_sh/singleheader.zip -DestinationPath simdutf_sh
           $prefix = "build/release/vcpkg_installed/x64-windows-static-release"
           cl /std:c++17 /EHsc /nologo /MT /D_WINSOCK_DEPRECATED_NO_WARNINGS `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -913,9 +913,12 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           # Same pin file the Linux/macOS leg reads, so the two cannot drift.
-          $pin = Get-Content scripts/ci/simdutf_pin.env `
-                 | Where-Object { $_ -notmatch '^\s*#' -and $_ -match '=' } `
-                 | ConvertFrom-StringData
+          # -Raw matters: without it Get-Content emits one string PER LINE and
+          # ConvertFrom-StringData runs per input, returning an array of
+          # single-entry hashtables that only behaves like one hashtable through
+          # member-access enumeration. ConvertFrom-StringData already skips '#'
+          # comment lines, so no pre-filter is needed.
+          $pin = Get-Content -Raw scripts/ci/simdutf_pin.env | ConvertFrom-StringData
           $expectedVer = $pin.SIMDUTF_EXPECTED_VER
           $expectedSha = $pin.SIMDUTF_EXPECTED_SHA
           $ver = (Get-Content vcpkg.json | ConvertFrom-Json).overrides `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Kerberos dev headers (Linux)
+      # libssl-dev is for the spec 068 routing test below, which links
+      # -lssl -lcrypto (tds_socket.hpp pulls in the TLS context). It rides along
+      # with this step because this one already runs apt-get update, and
+      # depending on the runner image happening to carry OpenSSL headers is the
+      # kind of assumption that breaks quietly on an image bump.
+      - name: Install Kerberos + OpenSSL dev headers (Linux)
         if: matrix.os.id == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libkrb5-dev binutils pkg-config
+          sudo apt-get install -y libkrb5-dev binutils pkg-config libssl-dev
 
       - name: Build + run gssapi_runtime loader unit test (spec 053)
         run: |
@@ -155,16 +160,32 @@ jobs:
       # the only externals are simdutf (via encoding/utf16.cpp) and OpenSSL
       # (via tds_socket.hpp -> the TLS TUs; the test itself runs unencrypted).
       # simdutf comes from the upstream single-file amalgamation rather than a
-      # distro package: Ubuntu 24.04 (noble) has no libsimdutf-dev, and pinning
-      # the tag to vcpkg.json's `simdutf` override means this test decodes
-      # UTF-16 with the same version the shipped extension links. No package
-      # manager, no vcpkg, no version drift.
+      # distro package: Ubuntu 24.04 (noble) has no libsimdutf-dev (the repo's
+      # own test/kerberos/test-client/Dockerfile says so and builds from source
+      # for the same reason), and brew/apt would ship 8.x while the extension
+      # links what vcpkg.json pins. The version is READ FROM vcpkg.json rather
+      # than hardcoded, so bumping the override cannot silently leave this test
+      # on the old codec; the checksum is pinned alongside it, so such a bump
+      # fails here loudly and visibly instead of pulling unreviewed bytes.
       - name: Fetch simdutf amalgamation (spec 068 routing test)
+        shell: bash
         run: |
           set -euo pipefail
+          SIMDUTF_VER=$(python3 -c "import json;print([o['version'] for o in json.load(open('vcpkg.json'))['overrides'] if o['name']=='simdutf'][0])")
+          # Update this hash when the vcpkg.json override moves; the mismatch
+          # message below is the reminder.
+          EXPECTED_VER=6.1.1
+          EXPECTED_SHA=28f4b565330d25801f160c97970ef06f6b861202286e9a3fef35b0d7320bbf3f
+          echo "vcpkg.json pins simdutf $SIMDUTF_VER"
           mkdir -p /tmp/simdutf
-          curl -sSL --retry 3 -o /tmp/simdutf/singleheader.zip \
-            https://github.com/simdutf/simdutf/releases/download/v6.1.1/singleheader.zip
+          curl -sSL --fail --retry 3 -o /tmp/simdutf/singleheader.zip \
+            "https://github.com/simdutf/simdutf/releases/download/v${SIMDUTF_VER}/singleheader.zip"
+          if [ "$SIMDUTF_VER" = "$EXPECTED_VER" ]; then
+            echo "$EXPECTED_SHA  /tmp/simdutf/singleheader.zip" | shasum -a 256 -c -
+          else
+            echo "::error::vcpkg.json now pins simdutf $SIMDUTF_VER, but the checksum recorded in ci.yml is for $EXPECTED_VER. Record the new asset's SHA-256 and update EXPECTED_VER/EXPECTED_SHA."
+            exit 1
+          fi
           unzip -o -q /tmp/simdutf/singleheader.zip -d /tmp/simdutf
           test -f /tmp/simdutf/simdutf.cpp && test -f /tmp/simdutf/simdutf.h
 
@@ -873,6 +894,40 @@ jobs:
             ../../duckdb
           cmake --build . --config Release
           Pop-Location
+
+      # Spec 068: the routing hop-driver test is a standalone compile (it is not
+      # part of the CMake target set), and its fake TDS server is the only
+      # Winsock code in the tree outside TdsSocket -- listen/accept/select/recv
+      # behind #ifdef _WIN32, which nothing else would ever compile. It rides on
+      # THIS job rather than the ungated cpp-unit-tests one because that job has
+      # no vcpkg, and OpenSSL on a Windows runner would mean guessing at a
+      # package location; here the prefix is already built above.
+      # Consequence: Windows coverage of this test is dispatch-gated, unlike
+      # Linux/macOS which run it on every PR.
+      - name: Build + run login routing hop-driver test (spec 068)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $ver = (Get-Content vcpkg.json | ConvertFrom-Json).overrides `
+                 | Where-Object { $_.name -eq "simdutf" } | Select-Object -ExpandProperty version
+          Write-Host "vcpkg.json pins simdutf $ver"
+          New-Item -ItemType Directory -Force -Path simdutf_sh | Out-Null
+          Invoke-WebRequest -Uri "https://github.com/simdutf/simdutf/releases/download/v$ver/singleheader.zip" `
+            -OutFile simdutf_sh/singleheader.zip
+          Expand-Archive -Force -Path simdutf_sh/singleheader.zip -DestinationPath simdutf_sh
+          $prefix = "build/release/vcpkg_installed/x64-windows-static-release"
+          cl /std:c++17 /EHsc /nologo /MT /D_WINSOCK_DEPRECATED_NO_WARNINGS `
+            /I src/include /I simdutf_sh /I "$prefix/include" `
+            test/cpp/test_login_routing_hops.cpp `
+            src/tds/tds_connection.cpp src/tds/tds_socket.cpp `
+            src/tds/tls/tds_tls_context.cpp src/tds/tls/tds_tls_impl.cpp `
+            src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp `
+            src/tds/encoding/utf16.cpp simdutf_sh/simdutf.cpp `
+            /Fe:test_login_routing_hops.exe `
+            /link /LIBPATH:"$prefix/lib" libssl.lib libcrypto.lib ws2_32.lib crypt32.lib user32.lib advapi32.lib
+          if ($LASTEXITCODE -ne 0) { throw "compile failed" }
+          ./test_login_routing_hops.exe
+          if ($LASTEXITCODE -ne 0) { throw "test failed" }
 
       # See the linux/macos build job for why the binary cache needs pruning.
       - name: Prune stale vcpkg binary archives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,35 +154,39 @@ jobs:
       # causes it. tds_connection.cpp reaches nothing outside the TDS layer, so
       # the only externals are simdutf (via encoding/utf16.cpp) and OpenSSL
       # (via tds_socket.hpp -> the TLS TUs; the test itself runs unencrypted).
-      - name: Install simdutf (spec 068 routing test)
+      # simdutf comes from the upstream single-file amalgamation rather than a
+      # distro package: Ubuntu 24.04 (noble) has no libsimdutf-dev, and pinning
+      # the tag to vcpkg.json's `simdutf` override means this test decodes
+      # UTF-16 with the same version the shipped extension links. No package
+      # manager, no vcpkg, no version drift.
+      - name: Fetch simdutf amalgamation (spec 068 routing test)
         run: |
-          if [ "${{ matrix.os.id }}" = "macos" ]; then
-            brew install simdutf
-          else
-            sudo apt-get update
-            sudo apt-get install -y libsimdutf-dev libssl-dev
-          fi
+          set -euo pipefail
+          mkdir -p /tmp/simdutf
+          curl -sSL --retry 3 -o /tmp/simdutf/singleheader.zip \
+            https://github.com/simdutf/simdutf/releases/download/v6.1.1/singleheader.zip
+          unzip -o -q /tmp/simdutf/singleheader.zip -d /tmp/simdutf
+          test -f /tmp/simdutf/simdutf.cpp && test -f /tmp/simdutf/simdutf.h
 
       - name: Build + run login routing hop-driver test (spec 068)
         run: |
           set -euo pipefail
           if [ "${{ matrix.os.id }}" = "macos" ]; then
-            SIMDUTF_PREFIX="$(brew --prefix simdutf)"
             OPENSSL_PREFIX="$(brew --prefix openssl@3)"
-            EXTRA_INC="-I $SIMDUTF_PREFIX/include -I $OPENSSL_PREFIX/include"
-            EXTRA_LIB="-L $SIMDUTF_PREFIX/lib -L $OPENSSL_PREFIX/lib"
+            EXTRA_INC="-I $OPENSSL_PREFIX/include"
+            EXTRA_LIB="-L $OPENSSL_PREFIX/lib"
           else
             EXTRA_INC=""
             EXTRA_LIB=""
           fi
           c++ -std=c++17 -pthread -Wno-deprecated-declarations \
-            -I src/include $EXTRA_INC \
+            -I src/include -I /tmp/simdutf $EXTRA_INC \
             test/cpp/test_login_routing_hops.cpp \
             src/tds/tds_connection.cpp src/tds/tds_socket.cpp \
             src/tds/tls/tds_tls_context.cpp src/tds/tls/tds_tls_impl.cpp \
             src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp \
-            src/tds/encoding/utf16.cpp \
-            $EXTRA_LIB -lsimdutf -lssl -lcrypto \
+            src/tds/encoding/utf16.cpp /tmp/simdutf/simdutf.cpp \
+            $EXTRA_LIB -lssl -lcrypto \
             -o /tmp/test_login_routing_hops
           /tmp/test_login_routing_hops
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/053-lazy-gssapi-linking"
+  "feature_directory": "specs/068-login-routing-unification"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Login-time routing is now followed on every authentication path**
+  (spec 068). A server can answer LOGIN7 with a ROUTING ENVCHANGE (type 20)
+  meaning "log in over there instead" — Azure SQL Managed Instance, Azure SQL
+  under the **Redirect** connection policy (the default for clients connecting
+  from inside Azure), Fabric/Synapse gateways, and on-prem AlwaysOn read-only
+  routing all do it. Only the Azure AD path honoured it; SQL authentication and
+  integrated (Kerberos/SSPI) authentication did not.
+  - **SQL auth**: a routed login used to fail as `Authentication failed` when
+    the redirect arrived without a LOGINACK, and — worse, because it was silent
+    — appear to *succeed* when a LOGINACK came with it, leaving the session
+    bound to a gateway that had just told the client to leave. Both now follow
+    the hop.
+  - **Azure AD**: a redirect with no LOGINACK (legal per [MS-TDS]) died as
+    `Azure AD authentication failed` because the success check ran before the
+    routing fields were read. Behaviour against gateways that send LOGINACK is
+    unchanged.
+  - **Integrated auth**: hops now acquire a service ticket for the **routed**
+    host's SPN instead of replaying the gateway's, which could not validate. An
+    explicit `service_principal_name=` is still used verbatim on every hop. See
+    `Kerberos.md`.
+  - The hop budget (5) and the routed-target parsing (`host\instance:port`,
+    no SQL Browser lookup on a hop) are unchanged; exceeding the budget now
+    names the last routed target in the error.
+
+  **Behaviour change**: SQL authentication against an endpoint that answers with
+  ROUTING *and* a LOGINACK now redirects instead of transacting against the
+  gateway. That is the correct behaviour per [MS-TDS] — a routed session is not
+  usable — but it is a visible change for anyone who was unknowingly relying on
+  the old one.
+
+  **Internal API change**: `TdsConnection::AuthenticateIntegrated` takes an
+  `AuthenticatorFactory` (`(host, port) -> IAuthenticator`) instead of a
+  pre-built authenticator. Affects embedders calling the TDS layer directly.
+
 - **dbt segfault with `threads >= 2`** (spec 052, closes
   [#126](https://github.com/hugr-lab/mssql-extension/issues/126)).
   Catalog entries (`MSSQLTableEntry`, `MSSQLSchemaEntry`) switched from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ target_compile_features(${EXTENSION_NAME} PRIVATE cxx_std_17)
 
 
 <!-- SPECKIT START -->
-Active spec: 053-lazy-gssapi-linking. See implementation plan at
-`specs/053-lazy-gssapi-linking/plan.md` for technical context,
+Active spec: 068-login-routing-unification. See implementation plan at
+`specs/068-login-routing-unification/plan.md` for technical context,
 research findings, data model, contracts, and quickstart.
 <!-- SPECKIT END -->

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -118,6 +118,45 @@ classDiagram
 - Auth strategies cover SQL auth, FEDAUTH (Azure AD), Kerberos (POSIX), and Windows SSPI. `IAuthenticator` is the SPNEGO continuation interface for integrated auth (spec 042).
 - All destructors in this layer are `noexcept` (spec 047 T046k) — the teardown chain has no place to swallow errors except via `MSSQL_POOL_DEBUG_LOG`.
 
+### Login is a loop, not a step (spec 068)
+
+A login is not one handshake against one host. Any of these endpoints may answer
+LOGIN7 with a ROUTING ENVCHANGE (type 20) meaning "not here, log in over there":
+Azure SQL Managed Instance, Azure SQL under the Redirect connection policy
+(the default from inside Azure), Fabric/Synapse gateways, on-prem AlwaysOn
+read-only routing. So the connection's login step is:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Authenticating: Connect()
+    Authenticating --> Attempt: PRELOGIN + LOGIN7
+    Attempt --> Idle: Success (LOGINACK, no ROUTING)
+    Attempt --> Authenticating: Route (close, retarget, reconnect) — max 5
+    Attempt --> Disconnected: Failure (neither)
+    Attempt --> Disconnected: hop limit / reconnect failed
+```
+
+Invariants that make this safe, all owned by `TdsConnection::RunWithRoutingHops`
+and none by the callbacks:
+
+- **ROUTING outranks LOGINACK.** A routed response is a hop even when a LOGINACK
+  came with it — [MS-TDS] says a routed session is unusable. The per-attempt
+  callback therefore returns `LoginAttemptOutcome::{Success, Route, Failure}`; a
+  bool cannot express the routed-without-LOGINACK case, and mis-expressing it is
+  the bug spec 068 fixed.
+- **The state machine stays in `Authenticating` across a hop.** The loop calls
+  `socket_->Connect()`, not `TdsConnection::Connect()`, and no callback touches
+  `state_` or closes the socket.
+- **Per-hop reset**: packet id → 1, TLS off, FEDAUTH echo off, routing fields
+  cleared (also *before* the first attempt, so a reused connection cannot
+  inherit a stale route). `tds_server_name_` is deliberately kept — it is the
+  hop's output, and carries the `hostname\instance` form into LOGIN7.
+- **Bounded**: 5 hops, then an error naming the count and the last routed target.
+- **Credential per target**: `AuthenticateIntegrated` takes an
+  `AuthenticatorFactory` rather than an authenticator, because a Kerberos/SSPI
+  ticket is bound to the target's SPN; each hop builds a new one for the routed
+  host and frees the previous context first.
+
 ---
 
 ## Layer 2 — Connection pool (spec 047)

--- a/Kerberos.md
+++ b/Kerberos.md
@@ -293,6 +293,42 @@ ATTACH 'Server=sql-internal.local,1433;Database=db;Trusted_Connection=yes;servic
 Accepts either the canonical Kerberos principal form (`MSSQLSvc/host:port`) or
 the hostbased-service form (`MSSQLSvc@host`).
 
+### SPNs when the server redirects you (login routing)
+
+Some endpoints answer a login by telling the client to log in somewhere else
+(TDS ENVCHANGE type 20 — Azure SQL Managed Instance, Azure SQL under the
+Redirect connection policy, on-prem AlwaysOn read-only routing). A Kerberos or
+SSPI ticket is bound to the **target's** SPN, so the gateway's ticket cannot be
+replayed on the routed server.
+
+The extension therefore acquires a **fresh ticket per hop**:
+
+- **No override set** — the SPN is re-derived for the routed host as
+  `MSSQLSvc/<routed-host>:<routed-port>`. This is normally what you want, and it
+  requires that the routed host's SPN is registered in AD. On Azure SQL MI the
+  routed name is inside the `*.database.windows.net` zone.
+- **`service_principal_name=` set** — your value is used **verbatim on every
+  hop**, gateway and routed server alike. You pinned it; the extension does not
+  second-guess it. If the routed server needs a different SPN than the gateway,
+  do not pin one.
+
+If a hop cannot obtain a ticket, the error names the routed host and the SPN
+that would have been requested, e.g.:
+
+```
+MSSQL Kerberos auth failed: could not build an authenticator for routed server
+sql-node-3.corp.example.com:1433 (expected SPN MSSQLSvc/sql-node-3.corp.example.com:1433
+unless service_principal_name= overrides it)
+```
+
+That is the first thing to check with `setspn -L` (or the `kvno` recipe above)
+when integrated auth works against a gateway but fails right after a redirect.
+
+> This path is exercised in unit tests against a loopback fake server, but no
+> environment with **both** Active Directory and a routing front-end exists in
+> the project's test surface. Field reports are welcome — the error above is
+> designed to make one diagnosable in a single round.
+
 ## Using MSSQL Secrets
 
 Use a secret when you want to:

--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,34 @@ test-login-error-state: debug
 	@echo "Running LOGIN7 response-parser unit test..."
 	build/test/test_login_error_state
 
+# Spec 068: login-time routing (ENVCHANGE 20) hop driver. Drives a REAL
+# TdsConnection against a loopback fake TDS server -- no SQL Server, no Azure,
+# and no libduckdb: tds_connection.cpp reaches nothing outside the TDS layer,
+# so the link set is the LOGIN7 one plus the socket + TLS TUs and OpenSSL.
+# (The TLS TUs come in via tds_socket.hpp; the test itself runs use_encrypt=false.)
+ROUTING_TEST_SOURCES := \
+    src/tds/tds_connection.cpp \
+    src/tds/tds_socket.cpp \
+    src/tds/tls/tds_tls_context.cpp \
+    src/tds/tls/tds_tls_impl.cpp \
+    $(LOGIN7_TEST_SOURCES)
+
+test-login-routing-hops: debug
+	@echo "Building login routing hop-driver unit test (spec 068)..."
+	@mkdir -p build/test
+	@if [ -z "$(LOGIN7_TEST_VCPKG_TRIPLET)" ]; then \
+		echo "ERROR: $(LOGIN7_TEST_VCPKG_INSTALLED) has no triplet subdir; run 'make debug' first." >&2; \
+		exit 1; \
+	fi
+	$(CXX) $(LOGIN7_TEST_FLAGS) $(LOGIN7_TEST_INCLUDES) \
+	    test/cpp/test_login_routing_hops.cpp \
+	    $(ROUTING_TEST_SOURCES) \
+	    $(LOGIN7_TEST_LIBS) -lssl -lcrypto \
+	    -o build/test/test_login_routing_hops
+	@echo ""
+	@echo "Running login routing hop-driver unit test..."
+	build/test/test_login_routing_hops
+
 # Spec 058 D1-alt: the fast skip walk must consume exactly what the legacy
 # per-value walk consumes, for every TDS type. Two switches in one file with
 # nothing holding them together — a width edited in ResolveSkipForm but not in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,6 +458,26 @@ Standard library types (`std::vector`, `std::runtime_error`) only.
 | `Krb5Authenticator` | `krb5_authenticator.cpp` | POSIX (Linux + macOS), via system GSSAPI | Phase 3 shipped |
 | `WinSspiAuthenticator` | `winsspi_authenticator.cpp` | Windows, via `secur32.dll` Negotiate package | Phase 4 pending |
 
+### Login-time routing (spec 068)
+
+Routing is a property of the **connection**, not of an authentication method.
+`TdsConnection::RunWithRoutingHops` owns the hop loop and every state transition
+in it; the three `Authenticate*` entry points are thin wrappers that supply a
+per-attempt callback (their PRELOGIN flavour + their LOGIN7 flavour). A callback
+reports `LoginAttemptOutcome::{Success, Route, Failure}` — three states rather
+than a bool, because a routed answer *without* a LOGINACK is neither a success
+nor a failure, and expressing it as "false plus a side flag" is what produced
+the original bug.
+
+| Path | Wrapper | Notes |
+|---|---|---|
+| SQL auth | `Authenticate` | — |
+| Azure AD | `AuthenticateWithFedAuth` | the loop originally lived here |
+| Kerberos / SSPI | `AuthenticateIntegrated` | takes an `AuthenticatorFactory`, so each hop gets a ticket for the routed host's SPN |
+
+Protocol details, the hop budget and the normalization rules are in
+[tds-protocol.md](tds-protocol.md#routing-envchange-type-20).
+
 ### Configuration Structs
 
 **PreloginOptions**:

--- a/docs/tds-protocol.md
+++ b/docs/tds-protocol.md
@@ -219,9 +219,11 @@ Packet 1: type=0x08, status=0x00, len=4096, payload=4088 bytes
 Packet 2: type=0x08, status=0x01, len=110,  payload=102 bytes (remaining)
 ```
 
-### Routing (Azure SQL Gateway)
+### Routing (ENVCHANGE type 20)
 
-Azure SQL Database may redirect connections via ENVCHANGE type 20 (0x14):
+Login-time routing is **not Azure-specific**, and since spec 068 it is not
+FEDAUTH-specific either. A server redirects the client with ENVCHANGE type 20
+(0x14) in the LOGIN7 response:
 
 ```
 ENVCHANGE Type 20 (Routing):
@@ -232,11 +234,47 @@ ENVCHANGE Type 20 (Routing):
   N bytes: server name (UTF-16LE)
 ```
 
-When routing occurs:
-1. Close current connection
-2. Connect to new server:port
-3. Repeat PRELOGIN/TLS/LOGIN7/FEDAUTH flow
-4. Up to 5 routing hops allowed
+Who sends it: Azure SQL Database under the **Redirect** connection policy (the
+default for clients connecting from inside Azure), Azure SQL Managed Instance,
+Microsoft Fabric / Synapse gateways, and on-prem AlwaysOn **read-only routing**
+for read-intent sessions.
+
+**The contract — routing outranks success.** If the response carries ROUTING,
+the outcome on that socket is *hop*, whether or not a LOGINACK came with it.
+[MS-TDS] is explicit that a routed session is not usable, so treating
+route-with-LOGINACK as success (keep talking to the gateway) and
+route-without-LOGINACK as failure are both wrong. Before spec 068 the extension
+did one of each, depending on the auth path.
+
+Which paths follow it:
+
+| Auth path | Follows ROUTING |
+|---|---|
+| SQL authentication (`Authenticate`) | yes |
+| Azure AD / FEDAUTH (`AuthenticateWithFedAuth`) | yes |
+| Integrated Kerberos / SSPI (`AuthenticateIntegrated`) | yes |
+
+All three go through one driver, `TdsConnection::RunWithRoutingHops`
+(`src/tds/tds_connection.cpp`), which per hop:
+
+1. closes the current socket;
+2. normalizes the routed target — a trailing `:port` beats the ENVCHANGE port,
+   `hostname\instance` (port stripped) becomes the LOGIN7 ServerName, and the
+   instance suffix is stripped for DNS/TCP. **The SQL Browser is not consulted
+   on a hop**: every observed gateway supplies the port, and adding UDP traffic
+   mid-login is how timeouts happen;
+3. resets the per-hop state — packet id back to 1, TLS off, FEDAUTH echo off,
+   routing fields cleared;
+4. reconnects (TLS SNI follows the *routed* hostname, not the original gateway)
+   and repeats the full PRELOGIN + LOGIN7 handshake.
+
+Up to `MAX_ROUTING_HOPS` = 5 hops. Exceeding it aborts with an error naming both
+the hop count and the last routed target.
+
+Integrated auth additionally rebuilds its authenticator per hop, via the
+`AuthenticatorFactory` callable its caller supplies — a Kerberos/SSPI ticket is
+bound to the target's SPN, so the gateway's ticket will not validate on the
+routed host. See `Kerberos.md`.
 
 ### Endpoint Type Detection
 

--- a/scripts/ci/simdutf_pin.env
+++ b/scripts/ci/simdutf_pin.env
@@ -1,0 +1,16 @@
+# Pinned simdutf single-file amalgamation for the spec 068 routing test.
+#
+# The routing test (test/cpp/test_login_routing_hops.cpp) is a standalone
+# compile with no vcpkg, so it fetches simdutf from the upstream release
+# instead. Three CI legs consume this file -- Linux, macOS and the
+# dispatch-gated Windows one -- and they read it rather than each carrying
+# their own copy, because two hardcoded hashes are two things that can drift.
+#
+# SIMDUTF_EXPECTED_VER must match the `simdutf` override in vcpkg.json, so the
+# test decodes UTF-16 with the version the shipped extension links. When that
+# override moves, update BOTH lines here: fetch the new
+# https://github.com/simdutf/simdutf/releases/download/v<VER>/singleheader.zip
+# and record its SHA-256. CI fails loudly if the two disagree rather than
+# quietly testing the old codec or pulling unverified bytes.
+SIMDUTF_EXPECTED_VER=6.1.1
+SIMDUTF_EXPECTED_SHA=28f4b565330d25801f160c97970ef06f6b861202286e9a3fef35b0d7320bbf3f

--- a/specs/068-login-routing-unification/contracts/tds_connection_routing.md
+++ b/specs/068-login-routing-unification/contracts/tds_connection_routing.md
@@ -1,0 +1,150 @@
+# Contract — `TdsConnection` login/routing interface
+
+The extension's external surface (SQL functions, settings, ATTACH options) does
+**not** change in spec 068. The contract that changes is the internal C++ one
+between `TdsConnection` and its callers, and it is a breaking one for a single
+method. It is specified here at the same level of detail an external API would
+get, because the two affected callers are in a different layer
+(`src/catalog/`, `src/`) than the definition (`src/tds/`).
+
+---
+
+## C1 — Unchanged signatures, changed behaviour
+
+```cpp
+bool Authenticate(const std::string &username, const std::string &password,
+                  const std::string &database, bool use_encrypt = false,
+                  const std::string &app_name = "");
+
+bool AuthenticateWithFedAuth(const std::string &database,
+                             const std::vector<uint8_t> &fedauth_token,
+                             bool use_encrypt = true,
+                             const std::string &app_name = "");
+```
+
+| Aspect | Before | After |
+|---|---|---|
+| `Authenticate` on a ROUTING response with LOGINACK | returns `true`, session bound to the gateway | follows the hop; returns `true` bound to the routed server |
+| `Authenticate` on ROUTING without LOGINACK | returns `false`, `"Authentication failed …"` | follows the hop |
+| `AuthenticateWithFedAuth` on ROUTING with LOGINACK | follows the hop | unchanged, byte-identical |
+| `AuthenticateWithFedAuth` on ROUTING without LOGINACK | returns `false`, `"Azure AD authentication failed"` | follows the hop |
+| Either, no routing | unchanged | unchanged — same packets, same ServerName, same hop count (0) |
+| Post-condition on `true` | `GetState() == Idle`, `GetHost()`/`GetPort()` = the connect target | same, except the target may now be a routed one |
+
+**Caller impact**: none. `mssql_catalog.cpp:222`, `mssql_storage.cpp:1111`/`1179`
+and `mssql_diagnostic.cpp:144` compile and behave as before on non-routing
+servers; the diagnostic path gains routing support for free.
+
+---
+
+## C2 — Breaking signature change
+
+```cpp
+// BEFORE
+bool AuthenticateIntegrated(const std::string &database,
+                            std::shared_ptr<tds::IAuthenticator> authenticator,
+                            bool use_encrypt = true,
+                            const std::string &app_name = "",
+                            size_t login7_max_packet = 0);
+
+// AFTER
+bool AuthenticateIntegrated(const std::string &database,
+                            AuthenticatorFactory authenticator_factory,
+                            bool use_encrypt = true,
+                            const std::string &app_name = "",
+                            size_t login7_max_packet = 0);
+```
+
+**Deliberately not overloaded.** A `shared_ptr` overload kept for compatibility
+would silently reuse the gateway's service ticket on a hop — the exact bug D3
+exists to prevent. Two call sites is a cheap price for making the wrong thing
+unwritable.
+
+**Caller obligations**:
+
+1. Build the authenticator **inside** the callable, from a
+   `MSSQLConnectionInfo` copy whose `host`/`port` are overwritten with the
+   callable's arguments.
+2. Return `nullptr` rather than throwing; exceptions thrown by
+   `AuthStrategyFactory::Create` must be caught in the callable and reported the
+   way each site already reports them (stderr line in the pool factory,
+   `InvalidInputException` in the ATTACH validator — note the validator must
+   surface the message *after* `AuthenticateIntegrated` returns, since the
+   callable itself cannot throw across the TDS layer).
+3. Capture by value only. No `ClientContext`, no reference to the catalog
+   (issue #178/#179: the pool factory runs on worker threads).
+
+Reference shape for `src/catalog/mssql_catalog.cpp:194`:
+
+```cpp
+factory = [info_copy, app_name]() -> std::shared_ptr<tds::TdsConnection> {
+    auto conn = std::make_shared<tds::TdsConnection>();
+    /* ... SetRequestedPacketSize / SetRequestUtf8Support / Connect as today ... */
+    auto auth_factory = [info_copy](const std::string &host, uint16_t port)
+        -> std::shared_ptr<tds::IAuthenticator> {
+        MSSQLConnectionInfo hop_info = info_copy;   // per-hop copy
+        hop_info.host = host;                       // SPN follows the routed host
+        hop_info.port = port;                       // explicit service_principal_name
+        try {                                       //   is honoured verbatim by DeriveSpn
+            auto strategy = tds::AuthStrategyFactory::Create(hop_info);
+            return strategy ? strategy->GetAuthenticator() : nullptr;
+        } catch (const std::exception &e) {
+            fprintf(stderr, "[MSSQL POOL] integrated-auth: %s\n", e.what());
+            return nullptr;
+        }
+    };
+    if (!conn->AuthenticateIntegrated(info_copy.database, auth_factory,
+                                      info_copy.use_encrypt, app_name,
+                                      info_copy.login7_max_packet)) { /* ... */ }
+    return conn;
+};
+```
+
+---
+
+## C3 — Private driver contract
+
+```cpp
+enum class LoginAttemptOutcome : uint8_t { Success, Route, Failure };
+
+// Runs `attempt` against the current target and follows ROUTING up to
+// MAX_ROUTING_HOPS (5) times, with a full reconnect + handshake per hop.
+// Pre:  state_ == Authenticating, socket_ connected, host_/port_ set.
+// Post: true  -> state_ == Idle, socket_ connected to the final target;
+//       false -> state_ == Disconnected, socket_ closed, last_error_ set.
+bool RunWithRoutingHops(const std::function<LoginAttemptOutcome()> &attempt);
+```
+
+Guarantees to the callback:
+
+- `host_`, `port_`, `tds_server_name_` are already retargeted for this attempt.
+- Per-hop state is already reset (see data-model.md §4).
+- The socket is connected and un-TLS'd; the callback performs its own PRELOGIN.
+
+Obligations on the callback:
+
+- Set `last_error_` when returning `Failure`.
+- Never touch `state_` and never call `socket_->Close()`.
+- Return `Route` whenever `has_routing_` was set, without consulting `success`.
+
+Driver-side error strings (stable, since field reports quote them):
+
+| Condition | Message |
+|---|---|
+| hop limit exceeded | `"Too many routing hops (N) - aborting; last routed target was <server>:<port>"` |
+| reconnect failed | `"Failed to connect to routed server <host>:<port>: <socket error>"` |
+
+The first extends today's `"Too many routing hops (N) - aborting"`
+(`tds_connection.cpp:294`) with the target, per the spec's acceptance criteria.
+
+---
+
+## C4 — What is explicitly **not** in the contract
+
+- No SQL Browser (UDP 1434) resolution on a hop, regardless of
+  `mssql_named_instance_resolution`. A routed `host\instance` with no port
+  fails with the routed string quoted.
+- No new setting, no new SQL function, no change to `mssql_pool_stats` output.
+- No change to `ParseLoginResponse` or to `LoginResponse`'s fields —
+  `src/tds/tds_protocol.cpp` is untouched by this feature.
+- Hop limit stays 5 and stays a `constexpr`, not a setting.

--- a/specs/068-login-routing-unification/data-model.md
+++ b/specs/068-login-routing-unification/data-model.md
@@ -1,0 +1,125 @@
+# Phase 1 Data Model — spec 068
+
+No persisted data and no DuckDB-visible types. The "entities" here are the
+in-memory types and the connection-object state that the hop driver reads and
+writes. They are listed with the same rigour a storage model would get because
+the bugs this spec fixes are all state-lifetime bugs.
+
+---
+
+## 1. `LoginAttemptOutcome` (new enum)
+
+`src/include/tds/tds_connection.hpp`, namespace `duckdb::tds`.
+
+| Value | Meaning | Driver action |
+|---|---|---|
+| `Success` | LOGINACK received, no ROUTING | stop the loop, transition to `Idle` |
+| `Route` | ROUTING received (**with or without** LOGINACK) | close socket, normalize target, reset per-hop state, reconnect, run the attempt again |
+| `Failure` | neither LOGINACK nor ROUTING | stop the loop, transition to `Disconnected`, close socket, `last_error_` already set by the callback |
+
+**Invariant (D1)**: a login helper that observes `LoginResponse::has_routing ==
+true` returns `Route`. It never returns `Success` and never returns `Failure`,
+whatever `LoginResponse::success` says. This is the entire contract of the
+feature; every other rule below serves it.
+
+Backed by `uint8_t`. C++11-compatible (`enum class` with fixed underlying type
+is C++11).
+
+---
+
+## 2. `AuthenticatorFactory` (new type alias)
+
+`src/include/tds/tds_connection.hpp`, namespace `duckdb::tds`.
+
+```cpp
+using AuthenticatorFactory =
+    std::function<std::shared_ptr<IAuthenticator>(const std::string &host, uint16_t port)>;
+```
+
+| Field | Rule |
+|---|---|
+| `host` argument | the **TCP/DNS** host of the current hop — instance-stripped, no port suffix. Never `tds_server_name_` (research.md R9) |
+| `port` argument | the current hop's TCP port |
+| return value | a fresh authenticator, or `nullptr` |
+| `nullptr` on the **first** call | maps to the existing "compiled without Kerberos / SSPI support" error, wording preserved |
+| `nullptr` on a **hop** | `Failure` with an error naming the routed host and the SPN that would have been requested (the field-diagnosability mitigation from the spec's risk section) |
+
+**Lifetime**: the factory is called once per login attempt. The authenticator
+from attempt *N* is `Free()`d before attempt *N+1* is built. The factory itself
+must outlive the `AuthenticateIntegrated` call — both call sites pass a lambda
+capturing `MSSQLConnectionInfo` **by value**, so this holds without further
+work.
+
+**Validation rule**: the factory must not capture the connection object or any
+`ClientContext` — it runs on pool-refill worker threads (issue #178/#179
+contract).
+
+---
+
+## 3. `RoutedTarget` (transient, not a stored member)
+
+Produced by `NormalizeRoutedTarget` from `LoginResponse::routed_server` +
+`routed_port`.
+
+| Field | Source | Rule |
+|---|---|---|
+| `tcp_host` | routed_server, `:port` suffix stripped, everything from `\` stripped | used for `socket_->Connect()` and for TLS SNI |
+| `tcp_port` | trailing `:digits` if present and in 1..65535, else `LoginResponse::routed_port` | the suffix wins — Fabric sends both and they can differ |
+| `tds_server_name` | routed_server with `:port` stripped but `\instance` **kept** | written to the member `tds_server_name_`; goes in the LOGIN7 ServerName field |
+
+Malformed input (empty routed_server, port 0, unparseable suffix) does not
+throw: the suffix parse falls back to the ENVCHANGE port, and an empty host
+fails at `socket_->Connect()` with an error naming the routed string verbatim.
+
+---
+
+## 4. `TdsConnection` state touched by the driver
+
+State transitions (`ConnectionState`), driver-owned:
+
+```
+Authenticating ──attempt→Success──→ Idle
+       │
+       ├──attempt→Route──→ (socket close, reconnect) ──→ Authenticating   [≤ 5 times]
+       │
+       ├──attempt→Failure──→ Disconnected
+       └──hop limit exceeded / reconnect failed──→ Disconnected
+```
+
+`Authenticating` is never left during a hop — the loop uses `socket_->Connect()`
+directly, not `TdsConnection::Connect()` (research.md R2).
+
+Per-attempt member state:
+
+| Member | Reset before **every** attempt | Notes |
+|---|---|---|
+| `has_routing_`, `routed_server_`, `routed_port_` | yes | includes before the *first* attempt, so a reused connection cannot inherit a stale route (R8) |
+| `next_packet_id_` | yes → 1 | pinned by fake-server scenario 4 |
+| `tls_enabled_` | yes → false | new socket, new handshake |
+| `fedauth_echo_` | yes → false | fedauth-only meaning; harmless on the other paths |
+| `tds_server_name_` | **no** — written by the hop | initialized to `host_` before the first attempt, on all three paths |
+| `spid_`, `negotiated_packet_size_`, `utf8_support_acked_`, `database_` | no | each is assigned (not accumulated) by a successful login; verified in R8 |
+
+---
+
+## 5. Ordering invariant inside the login helpers (D1)
+
+For each of `DoLogin7`, `DoLogin7WithFedAuth`, and the integrated response
+handler, the required statement order after `ParseLoginResponse` is:
+
+1. `NoteFeatureAcks(login_response)`
+2. copy `has_routing` / `routed_server` / `routed_port` into the members
+3. if `has_routing_` → return `Route` *(before any `success` check)*
+4. if `!success` → set `last_error_`, return `Failure`
+5. `spid_` / `negotiated_packet_size_` / `ApplyNegotiatedFraming()`, return `Success`
+
+Step 3 preceding step 4 **is** the Gap-1 fix. Today `DoLogin7WithFedAuth` runs
+them as 4→5→2 (`tds_connection.cpp:618`, `:633`) and `DoLogin7` omits 2–3
+entirely.
+
+A subtlety for the integrated path: the SPNEGO continuation loop reads a
+response per round, and a ROUTING answer can arrive at any round. The check
+therefore lives inside the round loop, ahead of both the `success` branch
+(`:761`) and the `has_sspi_token` rejection branch (`:774`) — otherwise a
+routing response with no SSPI token would be misreported as "auth rejected by
+server (no SSPI token, no LOGINACK)".

--- a/specs/068-login-routing-unification/plan.md
+++ b/specs/068-login-routing-unification/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Login routing for every auth path
+
+**Branch**: `task/spec-068-4f420d` (spec text arrives via `spec/068-login-routing`, PR #257) | **Date**: 2026-08-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/068-login-routing-unification/spec.md`
+
+## Summary
+
+TDS login-time routing (ENVCHANGE type 20) is parsed correctly but consumed on
+exactly one of three authentication paths. This plan extracts the hop loop that
+already works on the FEDAUTH path into a single private driver on
+`TdsConnection`, makes all three paths go through it, and fixes the ordering bug
+that makes a route-without-LOGINACK response look like an authentication
+failure.
+
+Technical approach, in one line each:
+
+- A private `RunWithRoutingHops(attempt)` owns the loop, the routed-target
+  normalization, the per-hop state resets, and the state-machine transitions.
+- The per-attempt callback returns a **tri-state** outcome
+  (`Success` / `Route` / `Failure`) rather than the `bool` the spec sketches —
+  route-without-LOGINACK is exactly the case a `bool` cannot express, and it is
+  the bug D1 exists to fix. See [research.md](./research.md) R1.
+- `AuthenticateIntegrated` takes a `(host, port) → IAuthenticator` factory so a
+  hop gets a service ticket for the routed host's SPN.
+- Tests are three layers: parser pins (no server), a loopback fake-TDS-server
+  hop test (no server, no DuckDB link), live smoke on Azure + the Kerberos
+  stack.
+
+## Technical Context
+
+**Language/Version**: C++17 in the TDS layer, but **C++11-compatible ABI**
+constraints apply repo-wide (no structured bindings; ODR hazard on Linux — see
+CLAUDE.md "Build Troubleshooting"). `std::function` and lambdas are already used
+throughout `mssql_catalog.cpp`, so the driver signature adds no new requirement.
+
+**Primary Dependencies**: none new. Existing: OpenSSL (vcpkg, TLS), simdutf
+(UTF-16 decode). The `src/tds/` layer has **zero DuckDB dependencies** and this
+must stay true — `RunWithRoutingHops` and the authenticator-factory typedef live
+behind `tds/tds_connection.hpp` and `tds/auth/iauthenticator.hpp`, neither of
+which may include a DuckDB header.
+
+**Storage**: N/A (connection-establishment path only; no persisted state).
+
+**Testing**:
+- Parser pins extend `test/cpp/test_login_error_state.cpp` (TDS-only link:
+  `tds_packet.cpp tds_protocol.cpp tds_types.cpp encoding/utf16.cpp` +
+  `-lsimdutf`), run by `make test-login-error-state` and by the CI heavy job.
+- New `test/cpp/test_login_routing_hops.cpp` — loopback fake TDS server. Links
+  the same TDS-only set **plus** `tds_connection.cpp tds_socket.cpp
+  tls/tds_tls_context.cpp tls/tds_tls_impl.cpp` and `-lssl -lcrypto`. Verified
+  self-contained: `tds_connection.cpp` includes only its own headers plus libc
+  (see research.md R3), so this does **not** require a DuckDB build and belongs
+  in the light CI job next to the other TDS-only groups.
+- Live: Azure Test workflow dispatch (fedauth regression) + `test/kerberos/`
+  docker stack (integrated-path refactor).
+
+**Target Platform**: Linux (GCC), macOS (Clang), Windows (MSVC + MinGW). The
+fake-server test uses BSD sockets; Windows needs the existing
+`tds_platform.hpp` shims plus `WSAStartup`, which `TdsSocket` already performs
+(research.md R4 records the gate decision if that proves awkward).
+
+**Project Type**: DuckDB extension (single C++ tree, `src/` + `test/`).
+
+**Performance Goals**: no measurable change on the non-routing path. The driver
+adds one `std::function` indirection per **login**, not per query or per row;
+`AuthenticateWithFedAuth`'s hop count and packet sequence must be byte-identical
+to today against the Azure/Fabric gateways.
+
+**Constraints**: `MAX_ROUTING_HOPS = 5` preserved exactly, including the current
+off-by-design shape (`while (routing_hop <= MAX_ROUTING_HOPS)` → up to 5 hops /
+6 login attempts). No SQL Browser UDP traffic on a hop. No credential material
+(FEDAUTH token bytes, SSPI blobs) in any new log line — the existing redaction
+comments at `tds_connection.cpp:573` are the standard.
+
+**Scale/Scope**: three public entry points, two internal login helpers, two
+callers of the integrated path, one deprecated diagnostic caller. Estimated
+±350 LOC in `src/tds/tds_connection.cpp`, ~40 in its header, ~25 across the two
+callers, ~400 in new tests.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-evaluated after Phase 1 design. Result:
+**PASS** both times, no violations, Complexity Tracking left empty.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Native and Open** | Pure TDS protocol work in our own client. No ODBC/FreeTDS/MS libraries introduced. PASS |
+| **II. Streaming First** | Login path only; no result buffering touched. Not applicable, no violation. PASS |
+| **III. Correctness over Convenience** | This is the principle the feature serves. Today a routed login on SQL auth either fails with a wrong message (route-without-LOGINACK) or **silently keeps talking to a gateway that told us to leave** (route-with-LOGINACK) — the second is exactly the "silent, ambiguous behaviour" the principle forbids. Post-change, an unfollowable route aborts with an error naming the hop count and the last routed target verbatim. PASS |
+| **IV. Explicit State Machines** | Strengthened. Today the `Authenticating → Idle/Disconnected` transitions are duplicated across three methods and, in `AuthenticateIntegrated`, are interleaved with I/O error handling. The driver becomes the single owner of those transitions and of the per-hop reset set; the attempt callbacks perform no transitions at all (research.md R2). All transitions covered by the fake-server test. PASS |
+| **V. DuckDB-Native UX** | No catalog/type surface change. A user ATTACHing an Azure MI or read-intent AlwaysOn endpoint simply stops seeing a bogus login failure. PASS |
+| **VI. Incremental Delivery** | Delivered as one coherent connection-level behaviour with no half-state: after this, "which auth paths follow routing" has one answer (all) instead of three. Each layer of D4's test plan is independently runnable. PASS |
+
+Two constitution-adjacent notes carried into the design rather than waived:
+
+1. **Version Baseline** says SQL text goes as UTF-16LE — the routed server name
+   arrives UTF-16LE and is already decoded through `ReadUTF16LE`
+   (`tds_protocol.cpp:895`). Normalization operates on the decoded UTF-8 string;
+   the `:port` / `\instance` scan is byte-wise ASCII and safe on UTF-8
+   (research.md R5).
+2. **Explicit State Machines** requires cancellation-safety; routing happens
+   strictly before the connection is `Idle`, so no ATTENTION interaction exists.
+   No change needed, recorded so the next reader does not re-derive it.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/068-login-routing-unification/
+├── spec.md              # Input (PR #257)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── tds_connection_routing.md   # Phase 1 output — internal C++ contract
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── include/
+│   └── tds/
+│       ├── tds_connection.hpp          # +LoginAttemptOutcome, +AuthenticatorFactory,
+│       │                               #  +RunWithRoutingHops / NormalizeRoutedTarget decls,
+│       │                               #  AuthenticateIntegrated signature change
+│       └── auth/iauthenticator.hpp     # unchanged (DuckDB-free boundary preserved)
+├── tds/
+│   ├── tds_connection.cpp              # the whole change: driver + 3 wrappers +
+│   │                                   #  D1 ordering in DoLogin7 / DoLogin7WithFedAuth /
+│   │                                   #  integrated response handling
+│   └── tds_protocol.cpp                # unchanged (parser is already correct)
+├── catalog/mssql_catalog.cpp           # :194 integrated factory closure
+├── mssql_storage.cpp                   # :1338 ValidateIntegratedAuthConnection
+└── connection/mssql_diagnostic.cpp     # :144 — no edit; inherits routing via Authenticate()
+
+test/
+└── cpp/
+    ├── test_login_error_state.cpp      # +4 parser pins (D4 layer 1)
+    └── test_login_routing_hops.cpp     # NEW — loopback fake TDS server (D4 layer 2)
+
+docs/
+├── architecture.md                     # routing as a connection-level behaviour
+└── tds-protocol.md                     # ENVCHANGE 20 handling + path table
+Kerberos.md                             # SPN-over-hop rules
+DATAMODEL.md                            # connection layer: login is now a hop loop
+Makefile / .github/workflows/ci.yml     # wire test_login_routing_hops
+```
+
+**Structure Decision**: no new directories or modules. The feature is a
+refactor plus a bug fix inside one existing translation unit
+(`src/tds/tds_connection.cpp`), with a signature change that ripples to exactly
+two call sites. Adding a `src/tds/routing/` module was considered and rejected
+in research.md R6 — the routed-target normalization is ~40 lines with one
+caller, and moving it out of the TU would buy a header for no reuse.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Table intentionally empty.

--- a/specs/068-login-routing-unification/quickstart.md
+++ b/specs/068-login-routing-unification/quickstart.md
@@ -1,0 +1,123 @@
+# Quickstart — spec 068
+
+How to build, run, and observe the routing work. Everything below runs without
+an Azure subscription or an Active Directory; the two live checks are listed
+last and are optional for development.
+
+## 0. Branch state
+
+The spec text arrives from PR #257 (`spec/068-login-routing`); implementation
+happens on this worktree's branch. The base must include PR #254/#255 — the
+DONE-token size fix — because D4's "ROUTING behind a DONEINPROC run" pin only
+means anything on top of it.
+
+```bash
+git log --oneline -1            # expect 571e465 or later
+```
+
+## 1. Parser pins — no server, no DuckDB, ~10 s
+
+The fastest loop while working on the D1 ordering. Extends the existing file.
+
+```bash
+make test-login-error-state
+```
+
+Or the manual compile (what CI does, mirrored in the file's header comment):
+
+```bash
+c++ -std=c++17 -pthread -I src/include -I duckdb/src/include \
+    -I /opt/homebrew/opt/simdutf/include \
+    test/cpp/test_login_error_state.cpp \
+    src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp \
+    src/tds/encoding/utf16.cpp \
+    -L /opt/homebrew/opt/simdutf/lib -lsimdutf \
+    -o build/test/test_login_error_state && ./build/test/test_login_error_state
+```
+
+New cases to expect green: route-with-LOGINACK, route-without-LOGINACK, routed
+target field extraction, ROUTING behind a DONEINPROC run.
+
+## 2. Hop-driver pins — loopback fake TDS server, no DuckDB, ~15 s
+
+```bash
+make test-login-routing-hops
+```
+
+The target compiles the TDS layer only (see research.md R3): connection +
+socket + TLS TUs + protocol + simdutf + OpenSSL. Two listeners bind
+`127.0.0.1:0`; the test reads the assigned ports back, so nothing collides with
+a developer's SQL Server or another CI job.
+
+Debugging a failure:
+
+```bash
+MSSQL_DEBUG=2 ./build/test/test_login_routing_hops
+```
+
+Level 1 prints the `ROUTING: parsed server=…` line from the parser and the
+driver's per-hop line; level 2 adds the response hex dump. Note the fake server
+speaks `use_encrypt=false`, so there is no TLS to unwrap in the dump.
+
+## 3. Full unit suite + build
+
+```bash
+make            # release build (vcpkg TLS)
+make test       # unit tests, no SQL Server
+```
+
+On macOS run `make vcpkg-setup` first if this is a fresh tree, or the simdutf /
+C++17 conflict bites at `utf16.cpp`.
+
+## 4. Regression against a real (non-routing) server
+
+The docker SQL Server does not route, which is the point: it proves the
+zero-hop path is unchanged.
+
+```bash
+make docker-up
+make integration-test          # .test files actually run only via this target
+make docker-down
+```
+
+Watch for: same login latency, `mssql_pool_stats` unchanged, no new lines at
+`MSSQL_DEBUG=1` during connect.
+
+## 5. Integrated-auth refactor — self-contained KDC, no AD needed
+
+```bash
+cd test/kerberos
+docker compose up -d --build
+docker compose exec test-client /run-tests.sh
+docker compose down -v
+```
+
+This exercises the D3 signature change end to end (fresh authenticator per
+connection, SPN `MSSQLSvc/sql.example.com:1433`). It does **not** exercise a
+hop — no routing front-end exists in the stack. That gap is the spec's
+acknowledged risk; the mitigation is that the hop failure path names the SPN it
+tried.
+
+## 6. Live smoke (optional, maintainer-only)
+
+- **Azure**: dispatch the Azure Test workflow on the branch. Whether the gateway
+  routes depends on the subscription's connection policy; either way it
+  regression-checks the fedauth path that the refactor moved.
+- **Manual routing check** on any Azure SQL DB, from inside Azure (Redirect
+  policy) or with the policy set to Redirect:
+
+  ```sql
+  ATTACH 'Server=<name>.database.windows.net;Database=<db>;User Id=<u>;Password=<p>;Encrypt=yes'
+      AS azdb (TYPE mssql);
+  ```
+
+  With `MSSQL_DEBUG=1` a routed login prints `ROUTING: parsed server=…` followed
+  by the driver's hop line. Before this spec, SQL auth against a routing
+  endpoint printed an authentication failure instead.
+
+## 7. Docs to update in the same PR
+
+`docs/tds-protocol.md`, `docs/architecture.md`, `Kerberos.md`, `DATAMODEL.md`
+(the connection layer's login flow becomes a hop loop — CLAUDE.md makes this
+mandatory when an end-to-end flow changes), plus a changelog line for the
+SQL-auth behaviour change on route-with-LOGINACK.

--- a/specs/068-login-routing-unification/research.md
+++ b/specs/068-login-routing-unification/research.md
@@ -1,0 +1,293 @@
+# Phase 0 Research — spec 068
+
+All findings are against `571e465` (main after PR #254/#255), which is the base
+this branch is built on. Line numbers below are from that commit.
+
+The spec's decisions D1–D4 are taken as settled. This document resolves the
+implementation unknowns those decisions leave open, and records three code
+findings the spec did not have.
+
+---
+
+## R1 — The attempt callback's return type
+
+**Question**: the spec sketches `bool RunWithRoutingHops(const std::function<bool()> &attempt)`.
+Can a `bool` carry the outcome?
+
+**Decision**: no — the callback returns a tri-state enum.
+
+```cpp
+enum class LoginAttemptOutcome : uint8_t { Success, Route, Failure };
+```
+
+**Rationale**: D1's whole point is that route-without-LOGINACK is neither
+success nor failure. With a `bool` the driver would have to read `has_routing_`
+as a side channel on the `false` return — which is precisely the
+"success-flag-plus-hidden-flag" arrangement that produced Gap 1 in the first
+place. The enum makes the contract unrepresentable-if-wrong: a login helper
+that sees ROUTING **must** say `Route`, and there is no `false` for the driver
+to misinterpret. It also removes the `bool` overload ambiguity when the
+callback is a lambda returning an implicitly-convertible expression.
+
+**Alternatives considered**:
+- `bool` + `has_routing_` side channel (spec's sketch) — rejected as above.
+- `std::optional<RoutedTarget>` return — expresses Route/Success but collapses
+  Failure into "empty", the same defect mirrored.
+- Exceptions for failure — rejected: the TDS layer reports login failure via
+  `last_error_` + `false` everywhere, and `TdsConnection` is constructed on
+  pool-refill worker threads where the existing contract is no-throw.
+
+---
+
+## R2 — Who owns the state-machine transitions
+
+**Question**: the three auth paths currently transition
+`ConnectionState` in different places. Where do transitions live after the
+extraction?
+
+**Finding (new — not in the spec)**: the paths are inconsistent today.
+
+- `AuthenticateWithFedAuth` (`tds_connection.cpp:243`): the **wrapper** stores
+  `Disconnected` on each failure and `Idle` on success; the helpers
+  (`DoPreloginWithFedAuth`, `DoLogin7WithFedAuth`) only set `last_error_`.
+- `AuthenticateIntegrated` (`:662`): the **method body itself** stores
+  `Disconnected` and calls `socket_->Close()` at nine separate failure points,
+  interleaved with the SPNEGO loop.
+- `Authenticate` (`:149`): wrapper-owned, like fedauth.
+
+**Decision**: the driver owns every transition. The attempt callback sets
+`last_error_` and returns an outcome; it must not touch `state_` or close the
+socket. The nine in-body transitions in `AuthenticateIntegrated` move out to the
+driver as part of the extraction.
+
+**Rationale**: constitution IV. A hop needs the socket closed *and reopened*
+with the state still `Authenticating` — if a callback stores `Disconnected`
+mid-loop, the next `socket_->Connect()` succeeds while the state machine says
+the connection is dead, and the eventual `Idle` store papers over it. Keeping
+the transition set in one function is also what makes the fake-server test able
+to assert on it.
+
+**Note**: the hop loop calls `socket_->Connect()` directly, **not**
+`TdsConnection::Connect()` — the latter requires the `Disconnected` state and
+would re-enter the state machine. This is what today's fedauth loop does
+(`:372`) and it is preserved deliberately.
+
+---
+
+## R3 — Can the fake-server hop test link without DuckDB?
+
+**Question**: D4 layer 2 needs a real `TdsConnection` driving a real socket.
+The existing standalone TDS tests link four files and `-lsimdutf`. Does pulling
+in `TdsConnection` drag in DuckDB (and therefore a full `make` before the test
+can build, i.e. the heavy CI job)?
+
+**Decision**: no DuckDB needed. Link set is:
+
+```
+test/cpp/test_login_routing_hops.cpp
+src/tds/tds_connection.cpp src/tds/tds_socket.cpp
+src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp
+src/tds/encoding/utf16.cpp
+src/tds/tls/tds_tls_context.cpp src/tds/tls/tds_tls_impl.cpp
+-lssl -lcrypto -lsimdutf
+```
+
+**Evidence**: `src/tds/tds_connection.cpp` includes only
+`tds/tds_connection.hpp`, `<cstdio/cstdlib/cstring>` and a platform header
+(`windows.h` / `unistd.h`). Its header pulls `tds/auth/iauthenticator.hpp`
+(pure-virtual, DuckDB-free by the standing rule recorded in CLAUDE.md),
+`tds_platform.hpp`, `tds_protocol.hpp`, `tds_socket.hpp`, `tds_types.hpp`.
+`tds_socket.hpp` pulls `tls/tds_tls_context.hpp`, hence the two TLS TUs and
+OpenSSL. Nothing reaches into `duckdb/`.
+
+**Consequence**: the test goes in the **light** CI job alongside
+`test_login7_encoding` / `test_login_error_state` / `test_skip_form_equivalence`
+(`.github/workflows/ci.yml` ~365–395), not behind the dispatch-gated heavy
+build. That matters: per the repo's own history, tests that only run in the
+dispatch-gated job effectively do not run (see the integration-suite
+false-green history, issue #212).
+
+**Alternative considered**: add it to `STANDALONE_TEST_SOURCES` (`Makefile:396`),
+which links the built extension archive + `libduckdb_static.a`. Rejected —
+it requires `make` (release) first and would land the test in the gated job for
+no benefit.
+
+---
+
+## R4 — Fake-server test design and flake budget
+
+**Decision**: one test binary, two `SOCK_STREAM` listeners bound to
+`127.0.0.1:0` (kernel-assigned ports, read back with `getsockname`), each
+served by a `std::thread` running a hand-rolled TDS responder that speaks
+exactly three things: a PRELOGIN response with `ENCRYPT_NOT_SUP`, a LOGIN7
+response, and nothing else. `use_encrypt=false` throughout, so no TLS keys and
+no OpenSSL handshake in the test path.
+
+Scenarios pinned (all four are D4's list):
+
+1. Single hop, SQL auth: listener A answers LOGIN7 with ROUTING → B; B answers
+   LOGINACK + DONE. Assert `Authenticate()` returns true, `GetState()==Idle`,
+   and the connection's host/port are B's.
+2. Route-without-LOGINACK (the Gap-1 shape) still follows the hop.
+3. Hop-limit abort: a listener that routes **to itself** must fail after
+   exactly 5 hops with an error naming the count and the last routed target.
+4. Per-hop packet-id reset: listener B asserts the first packet it receives has
+   `packet_id == 1`.
+
+**Flake mitigations**, decided up front rather than after the first red CI:
+- bind port 0, never a fixed port;
+- `SO_REUSEADDR`; accept with a poll timeout, so a hung accept fails the test
+  in seconds instead of hanging the job;
+- the responder threads are joined and the listeners closed in a scope guard,
+  including on assertion failure (the existing `CHECK` macro calls
+  `std::exit(1)`, so cleanup is process teardown — acceptable, and noted so
+  nobody adds an fd-leak assertion later);
+- overall test wall-clock budget: a few hundred ms. `DEFAULT_CONNECTION_TIMEOUT`
+  is only reached on a genuine bug.
+
+**If it flakes anyway**: gate behind an env var (`MSSQL_TEST_FAKE_SERVER=1`)
+rather than delete — the spec's own instruction.
+
+**Windows**: `TdsSocket` already calls `WSAStartup` and `tds_platform.hpp`
+provides the `ssize_t` shim. The test's own listener code needs the same
+`#ifdef _WIN32` split. Windows CI is manual-dispatch and currently red for
+unrelated MSVC reasons (#165), so the Windows leg of this test is
+"compiles, run manually", stated here so `/speckit-tasks` does not schedule
+verification that cannot happen.
+
+---
+
+## R5 — Routed-target normalization details
+
+**Decision**: lift `AuthenticateWithFedAuth`'s inline block (`:309–369`) into a
+private helper, unchanged in behaviour:
+
+```cpp
+// Returns {tcp_host, port}; sets tds_server_name_ as a side effect.
+void NormalizeRoutedTarget(const std::string &routed_server, uint16_t routed_port,
+                           std::string &out_host, uint16_t &out_port);
+```
+
+Behaviour preserved verbatim: trailing `:digits` wins over the ENVCHANGE port;
+`hostname\instance` (port stripped) becomes `tds_server_name_` for the LOGIN7
+ServerName field; everything from `\` onward is stripped for DNS/TCP; no SQL
+Browser lookup.
+
+**UTF-8 safety**: the routed server arrives as UTF-16LE and is decoded to UTF-8
+at `tds_protocol.cpp:895`. Scanning for `':'` (0x3A) and `'\\'` (0x5C) over
+UTF-8 is safe — continuation bytes are all ≥ 0x80, so no multi-byte sequence can
+contain either. `std::isdigit` is called with the `unsigned char` cast already
+present at `:323`. No change needed; recorded because an IDN routed hostname is
+plausible on Azure and someone will ask.
+
+**Out of scope, reaffirmed**: a routed `host\instance` with **no** port does not
+trigger a Browser lookup. The error message names the routed string verbatim.
+
+---
+
+## R6 — Module placement
+
+**Decision**: everything stays in `src/tds/tds_connection.cpp` +
+`tds_connection.hpp`. No `src/tds/routing/` module.
+
+**Rationale**: the driver plus the normalizer is ~120 lines with exactly one
+caller (`TdsConnection` itself), and both touch private members (`host_`,
+`port_`, `tds_server_name_`, `next_packet_id_`, `tls_enabled_`,
+`fedauth_echo_`, `socket_`). Extracting them would mean either a friend class or
+widening the member surface — cost with no reuse on the other side.
+
+---
+
+## R7 — SQL-auth LOGIN7 sends the wrong ServerName after a hop (new finding)
+
+**Not in the spec.** `DoLogin7` builds LOGIN7 with `host_` as the ServerName
+(`tds_connection.cpp:847`):
+
+```cpp
+TdsPacket login = TdsProtocol::BuildLogin7(host_, username, password, ...);
+```
+
+The integrated path already does the right thing
+(`tds_server_name_.empty() ? host_ : tds_server_name_`, `:725`), and the fedauth
+builder is passed the same. Once SQL auth can hop, `host_` is the
+**instance-stripped DNS name** while the server expects `hostname\instance` in
+ServerName — exactly the Fabric shape D2 calls out.
+
+**Decision**: `DoLogin7` adopts the same `tds_server_name_.empty() ? host_ : …`
+expression. On a first attempt `tds_server_name_` is set to `host_` by the
+driver (as `AuthenticateWithFedAuth:255` does today), so **non-routing SQL auth
+is byte-identical** to current behaviour.
+
+---
+
+## R8 — Per-hop state resets: what the current loop resets, and what it misses
+
+Audited every member that a second login attempt on a fresh socket could carry
+over. The fedauth loop resets `has_routing_`, `routed_server_`, `routed_port_`,
+`next_packet_id_`, `tls_enabled_`, `fedauth_echo_` (`:359–364`).
+
+| Member | Carried over? | Verdict |
+|---|---|---|
+| `next_packet_id_` | reset to 1 | correct; pinned by fake-server scenario 4 |
+| `tls_enabled_` | reset | correct — new socket, new handshake |
+| `fedauth_echo_` | reset | correct; harmless to reset on the other two paths |
+| `has_routing_` / `routed_server_` / `routed_port_` | reset | correct — and the driver must **also** clear them *before the first* attempt, so a reused `TdsConnection` cannot inherit a stale route |
+| `spid_`, `negotiated_packet_size_` | overwritten by the next successful login | fine |
+| `utf8_support_acked_` | **assigned**, not OR'd, by `NoteFeatureAcks` (`tds_connection.hpp:224`) | fine — a gateway's UTF8 ack cannot survive onto a routed server that does not ack. Checked explicitly because it would have been a silent wrong-decode bug |
+| `tds_server_name_` | deliberately **kept** — it is the hop's output | correct |
+| `original_sni_hostname_` | untouched by the loop | unused on this path; leave alone |
+| `database_` | set only on success | fine |
+
+**Decision**: the driver's reset block is the fedauth six, plus clearing the
+routing triple before the first attempt. No other member needs it.
+
+---
+
+## R9 — Integrated auth: what the factory closes over
+
+**Question**: D3 changes the parameter to a `(host, port) → IAuthenticator`
+callable. Does the SPN actually follow?
+
+**Verified**: `AuthStrategyFactory::Create` derives the SPN from
+`info.host` / `info.port` (`auth_strategy_factory.cpp`, `DeriveSpn`:
+`"MSSQLSvc/" + info.host + ":" + std::to_string(info.port)`), and returns
+`info.service_principal_name` **verbatim** when the user set one. So a factory
+that copies `MSSQLConnectionInfo` and overwrites `host`/`port` per hop gets the
+routed SPN for free, and an explicit override survives hops with no extra code —
+D3's requirement falls out of the existing derivation rather than needing new
+logic.
+
+**Decision on the factory's host argument**: pass the **TCP/DNS host**
+(instance-stripped), not `tds_server_name_`. AD registers
+`MSSQLSvc/<fqdn>:<port>`; a `host\instance` string is not a valid SPN component.
+
+**Both call sites already hold the info by value** — `mssql_catalog.cpp:168`
+(`MSSQLConnectionInfo info_copy = *connection_info_;`) and
+`mssql_storage.cpp:1303` (`MSSQLConnectionInfo &info` parameter). The change is
+local, as the spec states. The `nullptr`-authenticator branch
+(`tds_connection.cpp:676`, the "compiled without Kerberos support" message)
+moves to "factory returned null on the first call" and keeps its wording.
+
+**Free()**: `authenticator->Free()` is called once on success (`:770`). Per hop,
+the previous hop's authenticator must be `Free()`d before the next is built —
+the driver does this on the `Route` outcome. Missing it leaks a GSSAPI context
+per hop.
+
+---
+
+## R10 — Documentation surface
+
+**Decision**: four files, each with a specific claim to change.
+
+- `docs/tds-protocol.md` — ENVCHANGE 20 section: the D1 contract, the hop limit,
+  the no-Browser-on-hop rule.
+- `docs/architecture.md` — routing is a *connection-level* behaviour, not an
+  Azure-only one; the per-path table becomes a single row.
+- `Kerberos.md` — SPN on a hop: derived for the routed host; explicit
+  `service_principal_name=` survives verbatim.
+- `DATAMODEL.md` — the connection layer's login step is a hop loop; per CLAUDE.md
+  this is exactly the "alters an end-to-end flow" trigger that requires updating
+  it in the same PR.
+
+The user-visible behaviour change (SQL auth stops "succeeding" against a routing
+gateway) goes in the changelog, per the spec's risk section.

--- a/specs/068-login-routing-unification/spec.md
+++ b/specs/068-login-routing-unification/spec.md
@@ -1,0 +1,180 @@
+# Spec 068 — Login routing for every auth path, not just FEDAUTH
+
+**Status**: DRAFT
+**Branch**: `spec/068-login-routing`
+**Follows**: PR #254 (the TDS 7.2+ DONE-token size fix, merged e2d2822). That PR
+fixed the parse desync that #88/#164 actually hit; this spec closes the gap it
+exposed on the way: TDS login-time routing (ENVCHANGE type 20) is honoured on
+exactly one of our three authentication paths.
+
+## 1. Reconnaissance — what exists and where it stops
+
+`ParseLoginResponse` parses the ROUTING ENVCHANGE completely and correctly
+(`tds_protocol.cpp` ~832): `has_routing`, `routed_server`, `routed_port` land on
+`LoginResponse`, with a level-1 debug line. The parser is not the problem.
+
+**The one working consumer** is `AuthenticateWithFedAuth`
+(`tds_connection.cpp:243–391`). It owns a hop loop with everything a hop needs,
+built and battle-tested for the Azure SQL / Fabric gateways:
+
+- `MAX_ROUTING_HOPS = 5`, full PRELOGIN + TLS + LOGIN7 per hop;
+- routed-target normalization: Fabric sends
+  `hostname.pbidedicated.windows.net\INSTANCE:port`, so it extracts a trailing
+  `:port` (digits only), keeps `hostname\instance` (no port) as
+  `tds_server_name_` for the LOGIN7 ServerName field, and strips `\instance`
+  for DNS/TCP — the SQL Browser is deliberately not consulted on a hop;
+- per-hop state resets: `next_packet_id_ = 1`, `tls_enabled_ = false`,
+  `fedauth_echo_ = false`, routing fields cleared;
+- TLS SNI follows the routed hostname, not the original gateway (go-mssqldb
+  behaviour).
+
+**Gap 1 — ordering inside the working path.** `DoLogin7WithFedAuth` returns on
+`!login_response.success` (~line 618) *before* it copies
+`login_response.has_routing` into the connection (~line 633). A gateway that
+answers the token with ROUTING + DONE and **no LOGINACK** — legal per MS-TDS,
+the session on this socket is not usable either way — parses as
+`success=false, has_routing=true` and dies as "authentication failed" without
+the loop ever seeing the redirect. Route-*with*-LOGINACK (what the Azure
+gateways we've met actually send) is the only shape that works today.
+
+**Gap 2 — SQL auth.** `Authenticate` (149) → `DoPrelogin` + `DoLogin7` is a
+straight line: `DoLogin7` (835) reads only `success`, never `has_routing`. A
+routing answer — Azure SQL with the **Redirect** connection policy (the default
+for traffic originating inside Azure), Azure SQL Managed Instance, on-prem
+AlwaysOn read-only routing for read-intent sessions — is reported as a failed
+login. With LOGINACK present the failure is silent and worse: we'd keep talking
+to a gateway that told us to leave.
+
+**Gap 3 — integrated auth.** `AuthenticateIntegrated` (662) has the same
+blindness, plus a problem the other two paths don't have: its credential is
+**bound to the target's SPN**. The authenticator arrives pre-built for
+`MSSQLSvc/<original-host>:<port>` (the pool factory in `mssql_catalog.cpp:169`
+constructs it per connection, from `MSSQLConnectionInfo`); a service ticket for
+the gateway's SPN will not validate on the routed host. A hop therefore needs a
+**fresh authenticator for the new host:port**, not a retry with the old blob.
+
+**Callers.** All three entry points are called from exactly two places each:
+the pool connection factory (`mssql_catalog.cpp` 156/194/222) and the
+ATTACH-time eager validation (`mssql_storage.cpp` 1111/1179/1338, plus the
+deprecated `mssql_diagnostic.cpp:144`). Routing support added inside
+`TdsConnection` reaches all of them; only the integrated path needs its caller
+signature touched (D3).
+
+**Why now.** Nobody with a routing trace is currently stuck — DantasB's Synapse
+case was the DONE desync, not routing. But Viroxken's Azure SQL case (#164) is
+still unconfirmed: if his retest on #254 artifacts still fails and the new
+`DoLogin7` byte dump shows ENVCHANGE 20, this spec is his fix. And any Azure MI
+user connecting from inside Azure hits Gap 2 on their first ATTACH.
+
+## 2. Decisions
+
+### D1 — the routing contract: `has_routing` outranks `success`
+
+One rule, applied uniformly: **if the login response carries ROUTING, the
+attempt's outcome on this socket is "hop", regardless of whether a LOGINACK was
+also present.** MS-TDS is explicit that a routed session is not usable, so
+treating route-with-LOGINACK as success (keep talking to the gateway) and
+route-without-LOGINACK as failure (give up) are both wrong — and we currently
+do one of each depending on the path.
+
+Concretely: `DoLogin7`, `DoLogin7WithFedAuth`, and the integrated response
+handling copy `has_routing` / `routed_server` / `routed_port` into the
+connection **before** any early return on `!success`. The failure return
+happens only when there is neither success nor routing.
+
+### D2 — one hop driver, three thin wrappers
+
+Extract the loop body of `AuthenticateWithFedAuth` into a private driver:
+
+```cpp
+// Runs attempt() against the current target, follows ROUTING up to
+// MAX_ROUTING_HOPS times (reconnect + full handshake per hop), returns the
+// final attempt's verdict. attempt() sees host_/port_/tds_server_name_
+// already retargeted.
+bool TdsConnection::RunWithRoutingHops(const std::function<bool()> &attempt);
+```
+
+The routed-target normalization (port suffix, instance strip,
+`tds_server_name_`) moves to a named helper so the hop driver stays readable.
+`Authenticate`, `AuthenticateWithFedAuth`, and `AuthenticateIntegrated` become
+wrappers passing their per-attempt lambda (PRELOGIN flavour + LOGIN7 flavour).
+Per-hop state resets stay in the driver — they are the part that's easy to
+forget and impossible to test path-by-path.
+
+Not in scope: re-resolving a routed `host\instance` **without** a port via the
+SQL Browser (`mssql_named_instance_resolution` runs at ATTACH only). The
+fedauth loop never needed it — every observed gateway supplies the port — and
+inventing UDP traffic mid-login on a hunch is how timeouts happen. If a real
+target ever omits the port, the error message names the routed string verbatim.
+
+### D3 — integrated auth takes an authenticator factory
+
+`AuthenticateIntegrated`'s `shared_ptr<IAuthenticator>` parameter becomes
+
+```cpp
+std::function<std::shared_ptr<tds::IAuthenticator>(const std::string &host, uint16_t port)>
+```
+
+The pool factory and the validation path already hold `MSSQLConnectionInfo` by
+value at the call site; they build the strategy inside the callable with
+`info.host/info.port` overridden to the driver's current target. First attempt
+therefore behaves exactly as today (fresh authenticator per connection, spec
+042 semantics preserved); a hop gets a ticket for the routed host's SPN.
+
+An explicit `service_principal_name=` override is passed through **unchanged**
+on every hop — the user pinned it, we don't second-guess it. Documented in
+`Kerberos.md` alongside the existing SPN-derivation rules.
+
+### D4 — testing without a routing server
+
+No environment we control emits ROUTING (the docker SQL Server doesn't route;
+the Kerberos KDC stack doesn't; the Azure test target's policy is whatever the
+subscription says). Three layers instead:
+
+1. **Parser pins** (extend `test_login_error_state.cpp`): route-with-LOGINACK
+   (`has_routing` + `success` both true), route-without-LOGINACK (`has_routing`
+   true, `success` false — the Gap-1 shape), routed-target field extraction,
+   and ROUTING sitting *behind* a DONEINPROC run (composition with the #254
+   fix — the shape a routing Synapse would send).
+2. **Hop-driver pins**: a loopback fake TDS server (plain C++ test, two
+   listener sockets, `use_encrypt=false` so no TLS keys needed) that answers
+   PRELOGIN and replies to LOGIN7 with ROUTING → second listener completes the
+   login. Pins: single hop end-to-end for SQL auth, hop-limit abort at
+   `MAX_ROUTING_HOPS`, route-without-LOGINACK following the hop, per-hop packet
+   id reset. First fake-server test in the repo; if it turns out flaky on CI it
+   gets a `require-env` gate rather than deletion.
+3. **Live smoke**: dispatch the Azure Test job on the branch (it runs against
+   real Azure SQL; whether it routes depends on the gateway, but the fedauth
+   path regression-checks either way), plus the Kerberos e2e stack for the
+   integrated-path refactor.
+
+## 3. Acceptance criteria
+
+- ROUTING is followed on all three auth paths; route-without-LOGINACK follows
+  the hop instead of failing (D1), on every path.
+- `AuthenticateWithFedAuth` behaviour against today's Azure SQL / Fabric
+  gateways is unchanged (same hop count, same SNI/ServerName handling) — the
+  refactor is observable only in code structure.
+- Integrated-auth hops present a ticket for the routed host's SPN; the
+  explicit-SPN override survives hops verbatim.
+- Hop limit stays 5 and aborts with an error naming the count and the last
+  routed target.
+- All parser + hop-driver pins green; Kerberos e2e green; full CI green.
+- `docs/` (architecture/tds-protocol) and `Kerberos.md` updated: routing is a
+  connection-level behaviour, table of which paths follow it (all, after this
+  spec).
+
+## 4. Risks
+
+- **The SPN-over-hop guess.** No AD environment with a routing front-end exists
+  in our test surface; the "fresh authenticator per hop" design mirrors
+  go-mssqldb but ships unverified against real AD + MI. Mitigation: the error
+  path names the SPN it tried, so a field report is diagnosable in one round.
+- **Fake-server test flakiness** on CI runners (port allocation, accept
+  timing). Mitigation: bind port 0, pass the bound port through; gate behind
+  `require-env` only if it actually flakes.
+- **Behavioural change on route-with-LOGINACK for SQL auth**: today it
+  "succeeds" against the gateway; after D1 it hops. That is the correct
+  behaviour per spec, but any user who somehow depended on talking to the
+  gateway (none known, and the gateway kills routed sessions) would see a
+  change. Called out in the changelog.

--- a/specs/068-login-routing-unification/tasks.md
+++ b/specs/068-login-routing-unification/tasks.md
@@ -1,0 +1,259 @@
+---
+
+description: "Task list for spec 068 — login routing for every auth path"
+---
+
+# Tasks: Login routing for every auth path
+
+**Input**: Design documents from `/specs/068-login-routing-unification/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/tds_connection_routing.md, quickstart.md
+
+**Tests**: INCLUDED. The spec makes testing decision D4 with acceptance criterion
+"All parser + hop-driver pins green", so test tasks are in scope and are written
+before the implementation they pin.
+
+**Organization**: grouped by user story. spec.md is written as decisions
+(D1–D4) rather than user stories, so the three stories below are derived from
+its three gaps — one per authentication path, prioritised by user impact.
+
+**Base**: `571e465` or later (must include PR #254/#255).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3
+- Exact file paths in every description
+
+## Path Conventions
+
+Single C++ tree: `src/` (implementation), `test/cpp/` (standalone unit tests),
+`docs/` + repo-root `*.md` (documentation). Line numbers cited below are from
+`571e465`.
+
+## ⚠️ Parallelism reality check
+
+Nearly all implementation lands in **one file**, `src/tds/tds_connection.cpp`.
+Those tasks are therefore **not** marked `[P]` even where they are logically
+independent — two agents editing that file concurrently will conflict. Genuine
+parallelism exists between: implementation vs. `test/cpp/*` vs. `docs/*`, and
+among the doc tasks. This is stated up front so nobody reads the sparse `[P]`
+markers as an oversight.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: build and CI wiring for the new test binary, before any code needs it
+
+- [X] T001 Add a `test-login-routing-hops` target to `Makefile` (near `test-login-error-state`, ~line 279) linking the TDS-only set from research.md R3: `test/cpp/test_login_routing_hops.cpp src/tds/tds_connection.cpp src/tds/tds_socket.cpp src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp src/tds/encoding/utf16.cpp src/tds/tls/tds_tls_context.cpp src/tds/tls/tds_tls_impl.cpp` plus `-lssl -lcrypto -lsimdutf -pthread`
+- [X] T002 [P] Create `test/cpp/test_login_routing_hops.cpp` skeleton — file-header comment (purpose, manual compile line, `make test-login-routing-hops`), the `CHECK` macro copied from `test/cpp/test_login_error_state.cpp:49`, and a `main` that prints a check count and exits 0 with zero cases registered
+- [X] T003 [P] Add the `test_login_routing_hops` group to `.github/workflows/ci.yml` in the **light** job alongside `test_login_error_state` (~line 369), with a comment stating why it needs no DuckDB build (research.md R3) — the heavy job is dispatch-gated and effectively does not run
+
+**Checkpoint**: `make test-login-routing-hops` builds and passes vacuously; the link set is proven before any logic depends on it.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: the routing types, the normalizer, the hop driver, and the migration of the one already-working path onto it
+
+**⚠️ CRITICAL**: no user story can begin until T004–T010 are done. T008–T009 are a **behaviour-preserving refactor** — the FEDAUTH path must emit `Route` in exactly the same circumstances as today (`success && has_routing`). The D1 ordering change for that path is US2, deliberately held back so the refactor can be reviewed as a no-op.
+
+- [X] T004 Add `enum class LoginAttemptOutcome : uint8_t { Success, Route, Failure }` to `src/include/tds/tds_connection.hpp` in namespace `duckdb::tds`, with the D1 invariant as a comment (data-model.md §1)
+- [X] T005 Add `using AuthenticatorFactory = std::function<std::shared_ptr<IAuthenticator>(const std::string &host, uint16_t port)>;` to `src/include/tds/tds_connection.hpp`, plus `#include <functional>`; document that `host` is the TCP/DNS host, never `tds_server_name_` (data-model.md §2, research.md R9)
+- [X] T006 Declare the private members `bool RunWithRoutingHops(const std::function<LoginAttemptOutcome()> &attempt);` and `void NormalizeRoutedTarget(const std::string &routed_server, uint16_t routed_port, std::string &out_host, uint16_t &out_port);` in `src/include/tds/tds_connection.hpp` (private section, near the existing `DoLogin7` declarations ~line 291)
+- [X] T007 Implement `TdsConnection::NormalizeRoutedTarget` in `src/tds/tds_connection.cpp` by lifting the block at lines 309–369 verbatim — trailing `:digits` beats the ENVCHANGE port, `tds_server_name_` keeps `\instance`, DNS host strips it, no SQL Browser lookup (data-model.md §3, research.md R5)
+- [X] T008 Implement `TdsConnection::RunWithRoutingHops` in `src/tds/tds_connection.cpp`: `MAX_ROUTING_HOPS = 5` with the current `while (hop <= MAX)` shape preserved, per-attempt reset of `has_routing_`/`routed_server_`/`routed_port_`/`next_packet_id_`/`tls_enabled_`/`fedauth_echo_` **including before the first attempt** (research.md R8), `socket_->Close()` + `NormalizeRoutedTarget` + `socket_->Connect()` on `Route`, and sole ownership of the `Idle`/`Disconnected` transitions (research.md R2)
+- [X] T009 Add the two stable driver error strings from contracts/ C3 to `RunWithRoutingHops` in `src/tds/tds_connection.cpp`: hop-limit `"Too many routing hops (N) - aborting; last routed target was <server>:<port>"` (extends the bare message at line 294) and reconnect-failure naming host, port and the socket error
+- [X] T010 Change `DoLogin7WithFedAuth` in `src/tds/tds_connection.cpp` (line ~450) to return `LoginAttemptOutcome`, and rewrite `AuthenticateWithFedAuth` (lines 243–391) as a thin wrapper passing a lambda that runs `DoPreloginWithFedAuth` + `DoLogin7WithFedAuth`; set `tds_server_name_ = host_` before the first attempt as line 255 does today. **No ordering change yet** — `Route` still requires `success`
+- [X] T011 [P] Add a fake-TDS-server helper to `test/cpp/test_login_routing_hops.cpp`: listener bound to `127.0.0.1:0` with `SO_REUSEADDR`, port read back via `getsockname`, served on a `std::thread`, answering PRELOGIN with `ENCRYPT_NOT_SUP` and LOGIN7 with a caller-supplied token stream; `accept` uses a poll timeout so a hang fails in seconds (research.md R4)
+- [X] T012 [P] Add builders to `test/cpp/test_login_routing_hops.cpp` for a ROUTING ENVCHANGE token (type 20: protocol byte 0, LE port, UTF-16LE server with char-count length) and for LOGINACK + DONE, so each scenario composes its own login response
+- [X] T013 Pin the foundational refactor in `test/cpp/test_login_routing_hops.cpp`: a **zero-hop** FEDAUTH-shaped login (LOGINACK + DONE, no ROUTING) reaches `GetState() == Idle` with the first packet's id equal to 1 — proves T010 changed no behaviour
+
+**Checkpoint**: driver exists, FEDAUTH runs through it unchanged, fake server works. User stories can start.
+
+---
+
+## Phase 3: User Story 1 — SQL auth follows routing (Priority: P1) 🎯 MVP
+
+**Goal**: A user ATTACHing Azure SQL with the Redirect connection policy (the default for traffic originating inside Azure), Azure SQL Managed Instance, or an on-prem AlwaysOn read-intent endpoint gets a working connection instead of a bogus "Authentication failed" — and, in the LOGINACK case, stops silently transacting against a gateway that told the client to leave. This is spec.md Gap 2.
+
+**Why P1**: it is the only gap that can currently produce *silent* wrong behaviour (constitution III), and it affects the default policy for in-Azure clients. It is also the path with the most callers — `mssql_catalog.cpp:222`, `mssql_storage.cpp` validation, and the deprecated `mssql_diagnostic.cpp:144`, which inherits the fix for free.
+
+**Independent Test**: `make test-login-routing-hops` — listener A answers LOGIN7 with ROUTING → listener B, B answers LOGINACK + DONE; `Authenticate()` returns true and the connection reports B's host/port. No SQL Server, no Azure.
+
+### Tests for User Story 1 ⚠️ write first, confirm they fail
+
+- [X] T014 [P] [US1] Add a parser pin to `test/cpp/test_login_error_state.cpp`: route-**with**-LOGINACK sets `has_routing == true` **and** `success == true`, with `routed_server`/`routed_port` extracted (D4 layer 1)
+- [X] T015 [P] [US1] Add a parser pin to `test/cpp/test_login_error_state.cpp`: ROUTING sitting **behind** a DONEINPROC run is still parsed — the composition with PR #254 that a routing Synapse would send
+- [X] T016 [P] [US1] Add hop scenario 1 to `test/cpp/test_login_routing_hops.cpp`: single hop under `Authenticate()`, asserting return `true`, `GetState() == Idle`, and final host/port equal to listener B's
+- [X] T017 [P] [US1] Add hop scenario 4 to `test/cpp/test_login_routing_hops.cpp`: listener B asserts the first packet it receives has `packet_id == 1`, pinning the per-hop sequence reset
+- [X] T018 [P] [US1] Add hop scenario 3 to `test/cpp/test_login_routing_hops.cpp`: a listener routing **to itself** aborts after exactly 5 hops, with `GetLastError()` containing both the count and the last routed target
+
+### Implementation for User Story 1
+
+- [X] T019 [US1] Change `DoLogin7` in `src/tds/tds_connection.cpp` (line 835) to return `LoginAttemptOutcome` and apply the data-model.md §5 statement order: `NoteFeatureAcks` → copy routing fields → return `Route` if `has_routing_` → `Failure` on `!success` (keeping the issue-#164 state-byte message at line 883) → `Success`
+- [X] T020 [US1] Fix the LOGIN7 ServerName in `DoLogin7` (`src/tds/tds_connection.cpp:847`): pass `tds_server_name_.empty() ? host_ : tds_server_name_` to `BuildLogin7`, matching the integrated path at line 725. Without this a routed `host\instance` sends the instance-stripped name (research.md R7)
+- [X] T021 [US1] Rewrite `Authenticate` in `src/tds/tds_connection.cpp` (line 149) as a `RunWithRoutingHops` wrapper whose lambda runs `DoPrelogin(use_encrypt)` then `DoLogin7(...)`; initialise `tds_server_name_ = host_` before the first attempt; delete the now-duplicated state transitions at lines 159/167/174
+- [X] T022 [US1] Verify no caller change is needed for `src/catalog/mssql_catalog.cpp:222`, `src/mssql_storage.cpp` SQL-auth validation, and `src/connection/mssql_diagnostic.cpp:144`; add a one-line comment at the diagnostic call site noting it now follows routing via the shared driver
+
+**Checkpoint**: SQL auth hops. US1 is shippable on its own — the other two paths still behave exactly as before.
+
+---
+
+## Phase 4: User Story 2 — a routed FEDAUTH login without LOGINACK follows the hop (Priority: P2)
+
+**Goal**: Close spec.md Gap 1. A gateway that answers the FEDAUTH token with ROUTING + DONE and **no** LOGINACK — legal per MS-TDS — currently dies as "Azure AD authentication failed" because `DoLogin7WithFedAuth` returns on `!success` (line 618) before capturing routing (line 633). After this, it hops.
+
+**Why P2**: real but unconfirmed in the field (the Azure gateways met so far send LOGINACK). It is a two-statement move once Foundational is in.
+
+**Independent Test**: parser pin (route-without-LOGINACK yields `has_routing == true`, `success == false`) plus a fake-server scenario where listener A omits LOGINACK — the login must still complete on B.
+
+### Tests for User Story 2 ⚠️ write first, confirm they fail
+
+- [X] T023 [P] [US2] Add the Gap-1 parser pin to `test/cpp/test_login_error_state.cpp`: ROUTING + DONE with no LOGINACK parses as `has_routing == true`, `success == false`, routed fields populated
+- [X] T024 [P] [US2] Add hop scenario 2 to `test/cpp/test_login_routing_hops.cpp`: listener A routes **without** LOGINACK and the connection still completes against listener B
+
+### Implementation for User Story 2
+
+- [X] T025 [US2] Apply the data-model.md §5 order to `DoLogin7WithFedAuth` in `src/tds/tds_connection.cpp`: move the routing capture (lines 633–639) **above** the `!success` return (line 618) and return `Route` from there, so `Route` no longer requires `success`
+- [X] T026 [US2] Re-read `AuthenticateWithFedAuth` after T025 and confirm the wrapper needs no change — the driver already treats `Route` uniformly; record the confirmation in the PR description rather than adding code
+
+**Checkpoint**: routing is honoured regardless of LOGINACK on both the SQL and FEDAUTH paths.
+
+---
+
+## Phase 5: User Story 3 — integrated auth follows routing with a per-hop SPN (Priority: P3)
+
+**Goal**: Close spec.md Gap 3 (D3). A Kerberos/SSPI login that is routed needs a service ticket for the **routed host's** SPN, not a retry of the gateway's. `AuthenticateIntegrated` takes an `AuthenticatorFactory` instead of a pre-built authenticator.
+
+**Why P3**: smallest affected population, largest unverifiable surface — no AD + routing front-end exists in any environment we control (spec.md risk 1). It also carries the only breaking internal signature change, so it is the story most worth landing last and reviewing hardest.
+
+**Independent Test**: `test/kerberos/` docker stack still authenticates end to end (proves the factory produces the same first-attempt behaviour as today), plus a fake-server hop scenario asserting the factory is invoked a second time with the **routed** host and port.
+
+### Tests for User Story 3 ⚠️ write first, confirm they fail
+
+- [X] T027 [P] [US3] Add a hop scenario to `test/cpp/test_login_routing_hops.cpp` that drives `AuthenticateIntegrated` with a stub `IAuthenticator` and records every `(host, port)` the factory is called with; assert two calls, the second carrying listener B's host and port
+- [X] T028 [P] [US3] Extend that scenario to assert the first authenticator's `Free()` was called before the second was constructed (research.md R9 — otherwise a GSSAPI context leaks per hop)
+- [X] T029 [P] [US3] Add a scenario where the factory returns `nullptr` on the **hop** (not the first call) and assert the error names the routed host — the spec's field-diagnosability mitigation
+
+### Implementation for User Story 3
+
+- [X] T030 [US3] Change `AuthenticateIntegrated`'s second parameter in `src/include/tds/tds_connection.hpp` (line ~74) and `src/tds/tds_connection.cpp` (line 662) from `std::shared_ptr<tds::IAuthenticator>` to `AuthenticatorFactory`, **without** adding a compatibility overload (contracts/ C2 states why)
+- [X] T031 [US3] Restructure `AuthenticateIntegrated` in `src/tds/tds_connection.cpp` as a `RunWithRoutingHops` wrapper: the lambda calls the factory with the current `host_`/`port_`, runs `DoPrelogin`, sends LOGIN7 with the SSPI blob, and drives the SPNEGO round loop; move all nine in-body `state_.store(Disconnected)` + `socket_->Close()` pairs out to the driver (research.md R2)
+- [X] T032 [US3] Inside that SPNEGO round loop, apply the data-model.md §5 ordering: check `has_routing` **before** the `success` branch (line 761) and before the `has_sspi_token` rejection (line 774), otherwise a routing answer with no SSPI token is misreported as "auth rejected by server (no SSPI token, no LOGINACK)"
+- [X] T033 [US3] Preserve the null-authenticator error in `src/tds/tds_connection.cpp`: a factory returning `nullptr` on the **first** call keeps the existing "compiled without Kerberos / SSPI support … Rebuild with -DENABLE_KRB5=ON" wording from line 677
+- [X] T034 [US3] Call `authenticator->Free()` on the `Route` outcome in `src/tds/tds_connection.cpp` before the next hop's factory call, matching the existing success-path `Free()` at line 770
+- [X] T035 [US3] Update the pool factory in `src/catalog/mssql_catalog.cpp` (lines 169–200) to pass a per-hop lambda that copies `info_copy`, overwrites `host`/`port` with the callable's arguments, and calls `AuthStrategyFactory::Create` inside a `try` — reference shape in contracts/ C2. Keep the existing stderr diagnostics
+- [X] T036 [US3] Update `ValidateIntegratedAuthConnection` in `src/mssql_storage.cpp` (lines 1303–1345) the same way; the `InvalidInputException` must be thrown **after** `AuthenticateIntegrated` returns, since the callable cannot throw across the TDS layer
+- [X] T037 [US3] Confirm `AuthStrategyFactory::DeriveSpn` in `src/tds/auth/auth_strategy_factory.cpp` needs no change — it already derives from `info.host`/`info.port` and returns an explicit `service_principal_name` verbatim, so both D3 requirements fall out of the existing code (research.md R9)
+
+**Checkpoint**: all three paths follow routing. The spec's acceptance criterion "ROUTING is followed on all three auth paths" is met.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T038 [P] Update `docs/tds-protocol.md`: ENVCHANGE 20 section gains the D1 contract (`has_routing` outranks `success`), the hop limit, and the no-SQL-Browser-on-hop rule
+- [X] T039 [P] Update `docs/architecture.md`: routing is a connection-level behaviour, not an Azure-only one; the per-path table collapses to a single row
+- [X] T040 [P] Update `Kerberos.md`: on a hop the SPN is derived for the routed host; an explicit `service_principal_name=` survives every hop verbatim
+- [X] T041 [P] Update `DATAMODEL.md` connection-layer section (and its diagram): login is now a hop loop — CLAUDE.md makes this mandatory in the same PR when an end-to-end flow changes
+- [X] T042 [P] Add a changelog entry for the behaviour change: SQL auth against a routing gateway that also sends LOGINACK now hops instead of "succeeding" against the gateway (spec.md risk 3)
+- [X] T043 Run `clang-format` **version 14** over the touched files — `/opt/homebrew/opt/llvm@14/bin/clang-format -i src/tds/tds_connection.cpp src/include/tds/tds_connection.hpp src/catalog/mssql_catalog.cpp src/mssql_storage.cpp test/cpp/test_login_routing_hops.cpp test/cpp/test_login_error_state.cpp`; the homebrew default (v22) formats macro continuations differently and CI will disagree
+> **Status of T044–T047 (the four open items).** Everything that can be verified
+> on this machine was: both unit suites are green (56 + 45 checks), every
+> translation unit that includes `tds_connection.hpp` was syntax-checked against
+> the pinned DuckDB submodule, and the routing pins were confirmed to FAIL under
+> the pre-068 behaviour before being confirmed green under the fix. What remains
+> needs infrastructure this worktree does not have: a completed vcpkg/DuckDB
+> build tree (`make debug`), a SQL Server container, a Kerberos stack, an Azure
+> subscription, and a Windows runner.
+
+- [ ] T044 Run the quickstart.md sequence steps 1–4: `make test-login-error-state`, `make test-login-routing-hops`, `make`, `make test`, then `make docker-up && make integration-test && make docker-down` — the docker server does not route, which is exactly what proves the zero-hop path unchanged
+- [ ] T045 Run the `test/kerberos/` docker stack (`docker compose up -d --build`, `docker compose exec test-client /run-tests.sh`, `docker compose down -v`) to validate US3's signature change end to end; note in the PR that it exercises no hop
+- [ ] T046 Dispatch the Azure Test workflow on the branch as FEDAUTH smoke, and record in the PR whether the gateway routed (subscription-dependent) so the next reader knows what was actually covered
+- [ ] T047 Verify the Windows leg compiles: the fake-server listener code in `test/cpp/test_login_routing_hops.cpp` needs the same `#ifdef _WIN32` split `TdsSocket` uses. Windows CI is dispatch-only and currently red for unrelated MSVC reasons (#165), so state plainly in the PR that this was compile-checked, not run (research.md R4)
+- [X] T048 Grep the diff for credential leakage before opening the PR — no FEDAUTH token bytes, SSPI blobs, or passwords in any new log line; the redaction comment at `src/tds/tds_connection.cpp:573` is the standard
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: needs Phase 1 (T002 creates the file T011–T013 extend). **Blocks all user stories**
+- **US1 (Phase 3)**, **US2 (Phase 4)**, **US3 (Phase 5)**: each depends only on Phase 2
+- **Polish (Phase 6)**: T038–T042 can start as soon as the story they document is done; T043–T048 need all desired stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: independent. Touches `DoLogin7` + `Authenticate` only
+- **US2 (P2)**: independent of US1. Touches `DoLogin7WithFedAuth` only
+- **US3 (P3)**: independent of US1 and US2. Touches `AuthenticateIntegrated` + its two callers
+
+The three stories were scoped along path boundaries precisely so no story depends on another. Note that the D1 ordering fix appears once per story rather than as a shared task — that is deliberate: each path's login helper has a different response-handling shape (a single parse, a two-phase token exchange, and a multi-round SPNEGO loop), and there is no shared function to change.
+
+### Within Each User Story
+
+- Tests first, confirmed failing, then implementation
+- Header declarations before definitions
+- `src/tds/` before its callers
+
+### Parallel Opportunities
+
+- T002 ‖ T003 (test file ‖ CI yaml)
+- T011 ‖ T012 within Foundational (both in the test file, but distinct helpers — sequence them if one agent)
+- Test tasks within a story: T014 ‖ T015 ‖ T016 ‖ T017 ‖ T018; T023 ‖ T024; T027 ‖ T028 ‖ T029
+- Doc tasks T038 ‖ T039 ‖ T040 ‖ T041 ‖ T042
+- **Whole stories** in parallel across people — but T019/T021 (US1), T025 (US2) and T031/T032 (US3) all edit `src/tds/tds_connection.cpp`, so parallel story work means merge conflicts in one file. With one agent, run the stories in priority order.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# All US1 pins, written before any implementation:
+Task: "Route-with-LOGINACK parser pin in test/cpp/test_login_error_state.cpp"
+Task: "ROUTING-behind-DONEINPROC parser pin in test/cpp/test_login_error_state.cpp"
+Task: "Single-hop SQL-auth scenario in test/cpp/test_login_routing_hops.cpp"
+Task: "Per-hop packet-id reset scenario in test/cpp/test_login_routing_hops.cpp"
+Task: "Hop-limit abort scenario in test/cpp/test_login_routing_hops.cpp"
+
+# Then implementation, strictly sequential — one file:
+#   T019 -> T020 -> T021 -> T022 in src/tds/tds_connection.cpp
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup (T001–T003)
+2. Phase 2 Foundational (T004–T013) — **the refactor must be reviewable as a no-op**
+3. Phase 3 US1 (T014–T022)
+4. **STOP and VALIDATE**: `make test-login-routing-hops` green, `make integration-test` unchanged against the non-routing docker server
+5. Shippable: Azure MI / Redirect-policy / AlwaysOn read-intent users are unblocked, and nothing silently talks to a gateway any more
+
+### Incremental Delivery
+
+1. Setup + Foundational → driver in place, FEDAUTH provably unchanged
+2. + US1 → SQL auth hops (MVP)
+3. + US2 → route-without-LOGINACK honoured on FEDAUTH too
+4. + US3 → integrated auth hops with a per-hop SPN
+5. + Polish → docs, changelog, live smoke
+
+Each increment is independently mergeable; US3 can be split into its own PR if the SPN-over-hop risk warrants separate review.
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependencies. Sparse here on purpose — see the parallelism note at the top
+- Verify each test fails before implementing the task it pins
+- Commit per task or per logical group; stop at any checkpoint to validate
+- Do not add a `shared_ptr` compatibility overload for `AuthenticateIntegrated` (contracts/ C2)
+- Do not introduce SQL Browser lookups on a hop (spec D2, contracts/ C4)
+- `src/tds/` must stay DuckDB-free — no DuckDB header may enter `tds_connection.hpp` or `iauthenticator.hpp`

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -175,23 +175,37 @@ void MSSQLCatalog::Initialize(bool load_builtin) {
 						info_copy.host.c_str(), static_cast<unsigned>(info_copy.port), conn->GetLastError().c_str());
 				return nullptr;
 			}
-			std::shared_ptr<tds::AuthenticationStrategy> strategy;
-			try {
-				strategy = tds::AuthStrategyFactory::Create(info_copy);
-			} catch (const std::exception &e) {
-				fprintf(stderr, "[MSSQL POOL] integrated-auth: AuthStrategyFactory::Create failed: %s\n", e.what());
-				return nullptr;
-			}
-			if (!strategy) {
-				fprintf(stderr, "[MSSQL POOL] integrated-auth: AuthStrategyFactory returned null strategy\n");
-				return nullptr;
-			}
-			auto authenticator = strategy->GetAuthenticator();
-			if (!authenticator) {
-				fprintf(stderr, "[MSSQL POOL] integrated-auth: strategy provided no authenticator\n");
-				return nullptr;
-			}
-			if (!conn->AuthenticateIntegrated(info_copy.database, authenticator, info_copy.use_encrypt, app_name,
+			// Spec 068 D3: a factory, not an instance. It is called once per
+			// login attempt, so a routing hop gets a ticket for the ROUTED
+			// host's SPN instead of a retry of the gateway's. The first call
+			// receives this connection's original host/port, which is what the
+			// pre-068 code built the authenticator from — so a non-routed login
+			// is unchanged. `DeriveSpn` reads info.host/info.port, and honours
+			// an explicit service_principal_name verbatim, so the override
+			// survives hops with no extra handling here.
+			auto auth_factory = [info_copy](const std::string &host,
+											uint16_t port) -> std::shared_ptr<tds::IAuthenticator> {
+				MSSQLConnectionInfo hop_info = info_copy;
+				hop_info.host = host;
+				hop_info.port = port;
+				std::shared_ptr<tds::AuthenticationStrategy> strategy;
+				try {
+					strategy = tds::AuthStrategyFactory::Create(hop_info);
+				} catch (const std::exception &e) {
+					fprintf(stderr, "[MSSQL POOL] integrated-auth: AuthStrategyFactory::Create failed: %s\n", e.what());
+					return nullptr;
+				}
+				if (!strategy) {
+					fprintf(stderr, "[MSSQL POOL] integrated-auth: AuthStrategyFactory returned null strategy\n");
+					return nullptr;
+				}
+				auto authenticator = strategy->GetAuthenticator();
+				if (!authenticator) {
+					fprintf(stderr, "[MSSQL POOL] integrated-auth: strategy provided no authenticator\n");
+				}
+				return authenticator;
+			};
+			if (!conn->AuthenticateIntegrated(info_copy.database, auth_factory, info_copy.use_encrypt, app_name,
 											  info_copy.login7_max_packet)) {
 				fprintf(stderr, "[MSSQL POOL] integrated-auth: %s\n", conn->GetLastError().c_str());
 				return nullptr;

--- a/src/connection/mssql_diagnostic.cpp
+++ b/src/connection/mssql_diagnostic.cpp
@@ -141,6 +141,11 @@ void MSSQLOpenFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 			throw IOException("Failed to connect to %s:%d: %s", host, port, conn->GetLastError());
 		}
 
+		// Spec 068: no change needed here -- Authenticate() now follows a
+		// login-time ROUTING redirect internally, so this deprecated diagnostic
+		// path reaches an Azure MI / Redirect-policy endpoint for free. The
+		// handle ends up bound to the routed server, which is the one that can
+		// actually answer queries.
 		if (!conn->Authenticate(user, password, database)) {
 			throw InvalidInputException("Login failed: %s", conn->GetLastError());
 		}

--- a/src/include/tds/tds_connection.hpp
+++ b/src/include/tds/tds_connection.hpp
@@ -301,9 +301,17 @@ private:
 	bool tls_enabled_;
 
 	// Connect timeout the caller supplied to Connect(), remembered so a routing
-	// hop reconnects on the SAME budget (spec 068). Without this a user who
-	// sets mssql_connection_timeout=5 and gets routed to an unreachable replica
-	// waits the compiled-in default per hop instead of the 5 they asked for.
+	// hop dials on the SAME budget (spec 068). Without this a user who sets
+	// mssql_connection_timeout=5 and gets routed to an unreachable replica waits
+	// the compiled-in default per hop instead of the 5 they asked for.
+	//
+	// Scope, precisely: this covers the TCP DIAL. The handshake receives that
+	// follow -- PRELOGIN response, TLS enable, LOGIN7 response, on all three
+	// auth paths -- still pass DEFAULT_CONNECTION_TIMEOUT, on the first attempt
+	// as well as on a hop. So a replica that accepts the connection and then
+	// never answers still costs the compiled-in default. Threading the caller's
+	// value through those sites would change every login's behaviour, not just a
+	// routed one, and belongs in its own change.
 	int connect_timeout_seconds_ = DEFAULT_CONNECTION_TIMEOUT;
 
 	// Frame size we ask for in LOGIN7 (spec 055). Defaults to the pre-055

--- a/src/include/tds/tds_connection.hpp
+++ b/src/include/tds/tds_connection.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 #include "tds/auth/iauthenticator.hpp"
@@ -12,6 +13,45 @@
 
 namespace duckdb {
 namespace tds {
+
+// Outcome of ONE login attempt against ONE target (spec 068 D1).
+//
+// The contract, in one rule: a login helper that sees ROUTING in the response
+// returns `Route`, whatever the response said about success. [MS-TDS] is
+// explicit that a routed session is not usable, so a routed answer that ALSO
+// carried a LOGINACK is still a redirect, not a success -- and a routed answer
+// with no LOGINACK is still a redirect, not a failure. Before spec 068 we got
+// one of each wrong: the FEDAUTH path returned early on `!success` and never
+// looked at the routing fields, while SQL auth never looked at them at all and
+// kept talking to a gateway that had told it to leave.
+//
+// A plain bool cannot express this -- it would force the driver to read
+// `has_routing_` as a side channel off a `false` return, which is the exact
+// arrangement that produced the bug. Hence three states.
+enum class LoginAttemptOutcome : uint8_t {
+	Success,  // LOGINACK received, no ROUTING -- the session on this socket is usable
+	Route,	  // ROUTING received (with OR without LOGINACK) -- hop to routed_server_/routed_port_
+	Failure	  // neither -- last_error_ has been set by the attempt
+};
+
+// Builds an authenticator for ONE login attempt against ONE target (spec 068 D3).
+//
+// Integrated auth binds its credential to the target's SPN, so a routing hop
+// cannot reuse the gateway's authenticator: it needs a service ticket for the
+// ROUTED host. The caller therefore hands over a factory rather than an
+// instance, and the hop driver calls it again per hop.
+//
+// `host` is the TCP/DNS host of the current hop -- instance-stripped, no port
+// suffix -- because that is what an AD SPN is registered against
+// ("MSSQLSvc/<fqdn>:<port>"). Never pass the LOGIN7 ServerName form
+// ("host\instance"), which is not a valid SPN component.
+//
+// Returning nullptr fails the login: on the first call with the existing
+// "compiled without Kerberos / SSPI support" message, on a hop with a message
+// naming the routed host. The factory must not throw -- it runs inside the TDS
+// layer, which is exception-free by contract -- and must capture by value only,
+// since pool refills run on worker threads (issues #178/#179).
+using AuthenticatorFactory = std::function<std::shared_ptr<IAuthenticator>(const std::string &host, uint16_t port)>;
 
 // Represents a single TDS connection to SQL Server
 // Implements connection state machine per FR-009
@@ -60,10 +100,15 @@ public:
 	// drives the multi-round continuation loop via 0xED tokens.
 	// Parameters:
 	//   database     - initial database to connect to
-	//   authenticator - IAuthenticator implementation (Krb5Authenticator on POSIX,
-	//                   WinSspiAuthenticator on Windows). The Phase 2 scaffold
-	//                   errors out unless a real implementation is supplied; the
-	//                   real implementations land in Phase 3 / 4.
+	//   authenticator_factory - builds an IAuthenticator for a given (host, port)
+	//                   (Krb5Authenticator on POSIX, WinSspiAuthenticator on
+	//                   Windows). A FACTORY rather than an instance because a
+	//                   routing hop needs a service ticket for the routed host's
+	//                   SPN, not a retry of the gateway's (spec 068 D3); it is
+	//                   called once per login attempt. Returning nullptr on the
+	//                   first call reproduces the pre-068 "no authenticator"
+	//                   error. There is deliberately NO shared_ptr overload: it
+	//                   would silently reuse the gateway's ticket on a hop.
 	//   use_encrypt  - if true, enables TLS encryption (typical for production)
 	//   app_name     - spec 047 FR-014; see SQL-auth Authenticate above.
 	//   login7_max_packet - TDS packet size to fragment the LOGIN7 / SSPI sends
@@ -74,7 +119,7 @@ public:
 	//                   smaller values are a TEST hook to force the multi-packet
 	//                   path. A plain size_t keeps the TDS layer DuckDB-free; the
 	//                   value originates from the mssql_login7_max_packet setting.
-	bool AuthenticateIntegrated(const std::string &database, std::shared_ptr<tds::IAuthenticator> authenticator,
+	bool AuthenticateIntegrated(const std::string &database, AuthenticatorFactory authenticator_factory,
 								bool use_encrypt = true, const std::string &app_name = "",
 								size_t login7_max_packet = 0);
 
@@ -288,16 +333,46 @@ private:
 	// Original gateway hostname for TLS SNI after routing (Azure Fabric session tracking)
 	std::string original_sni_hostname_;
 
+	// Login-time routing driver (spec 068 D2). Runs `attempt` against the
+	// current target and follows ROUTING up to MAX_ROUTING_HOPS times, with a
+	// full reconnect + handshake per hop.
+	//
+	// Pre:  state_ == Authenticating, socket_ connected, host_/port_ set.
+	// Post: true  -> state_ == Idle, socket_ connected to the final target;
+	//       false -> state_ == Disconnected, socket_ closed, last_error_ set.
+	//
+	// Guarantees to `attempt`: host_/port_/tds_server_name_ are already
+	// retargeted for this hop, the per-hop state is already reset, and the
+	// socket is connected and un-TLS'd (the attempt does its own PRELOGIN).
+	// Obligations on `attempt`: set last_error_ when returning Failure, and
+	// NEVER touch state_ or close the socket -- the driver owns both, because a
+	// hop has to close and reopen the socket while the state machine stays in
+	// Authenticating.
+	bool RunWithRoutingHops(const std::function<LoginAttemptOutcome()> &attempt);
+
+	// Split a ROUTING ENVCHANGE target into what TCP needs and what LOGIN7
+	// needs, and set tds_server_name_ as a side effect.
+	//
+	// Azure Fabric sends "hostname.pbidedicated.windows.net\INSTANCE:port": a
+	// trailing ":port" (digits only) wins over the ENVCHANGE port, the
+	// "hostname\instance" form (port stripped) is what LOGIN7's ServerName
+	// field wants, and everything from the backslash on is stripped for
+	// DNS/TCP. The SQL Browser is deliberately NOT consulted on a hop -- every
+	// observed gateway supplies the port, and inventing UDP traffic mid-login
+	// is how timeouts happen.
+	void NormalizeRoutedTarget(const std::string &routed_server, uint16_t routed_port, std::string &out_host,
+							   uint16_t &out_port);
+
 	// Internal helpers
 	bool DoPrelogin(bool use_encrypt);
-	bool DoLogin7(const std::string &username, const std::string &password, const std::string &database,
-				  const std::string &app_name);
+	LoginAttemptOutcome DoLogin7(const std::string &username, const std::string &password, const std::string &database,
+								 const std::string &app_name);
 
 	// Azure AD FEDAUTH helpers (T018/T020)
 	// Optional sni_hostname overrides default for TLS SNI (for Azure routing)
 	bool DoPreloginWithFedAuth(bool use_encrypt, const std::string &sni_hostname = "");
-	bool DoLogin7WithFedAuth(const std::string &database, const std::vector<uint8_t> &fedauth_token,
-							 const std::string &app_name);
+	LoginAttemptOutcome DoLogin7WithFedAuth(const std::string &database, const std::vector<uint8_t> &fedauth_token,
+											const std::string &app_name);
 };
 
 }  // namespace tds

--- a/src/include/tds/tds_connection.hpp
+++ b/src/include/tds/tds_connection.hpp
@@ -300,6 +300,12 @@ private:
 	// TLS state
 	bool tls_enabled_;
 
+	// Connect timeout the caller supplied to Connect(), remembered so a routing
+	// hop reconnects on the SAME budget (spec 068). Without this a user who
+	// sets mssql_connection_timeout=5 and gets routed to an unreachable replica
+	// waits the compiled-in default per hop instead of the 5 they asked for.
+	int connect_timeout_seconds_ = DEFAULT_CONNECTION_TIMEOUT;
+
 	// Frame size we ask for in LOGIN7 (spec 055). Defaults to the pre-055
 	// behaviour so anything that does not call SetRequestedPacketSize is
 	// unchanged.

--- a/src/include/tds/tds_connection.hpp
+++ b/src/include/tds/tds_connection.hpp
@@ -49,8 +49,13 @@ enum class LoginAttemptOutcome : uint8_t {
 // Returning nullptr fails the login: on the first call with the existing
 // "compiled without Kerberos / SSPI support" message, on a hop with a message
 // naming the routed host. The factory must not throw -- it runs inside the TDS
-// layer, which is exception-free by contract -- and must capture by value only,
-// since pool refills run on worker threads (issues #178/#179).
+// layer, which is exception-free by contract.
+//
+// On captures: a factory that outlives the call -- the pool's, which is stored
+// and re-run on every refill from a worker thread -- must capture by VALUE
+// (issues #178/#179). A factory built and consumed within a single synchronous
+// call, as the ATTACH-validation path does, may capture by reference; that is
+// how it reports a construction error the callable itself cannot throw.
 using AuthenticatorFactory = std::function<std::shared_ptr<IAuthenticator>(const std::string &host, uint16_t port)>;
 
 // Represents a single TDS connection to SQL Server
@@ -343,9 +348,6 @@ private:
 	// TDS ServerName for LOGIN7 - may differ from host_ when routing includes instance name
 	// Format: "hostname" or "hostname\instance" (instance name is for TDS protocol, not DNS)
 	std::string tds_server_name_;
-
-	// Original gateway hostname for TLS SNI after routing (Azure Fabric session tracking)
-	std::string original_sni_hostname_;
 
 	// Login-time routing driver (spec 068 D2). Runs `attempt` against the
 	// current target and follows ROUTING up to MAX_ROUTING_HOPS times, with a

--- a/src/include/tds/tds_protocol.hpp
+++ b/src/include/tds/tds_protocol.hpp
@@ -92,9 +92,16 @@ public:
 	//     of transcoding them to UTF-16 (0xE7), which halves the wire bytes for ASCII-heavy
 	//     data and lets the client copy them straight into the vector. A server that does not
 	//     support it omits the acknowledgement and keeps sending UTF-16, so asking is safe.
+	// `server_name` fills the LOGIN7 ServerName field ([MS-TDS] 2.2.6.4) when it
+	// differs from `host`, which happens after a login-time routing hop: the
+	// routed target is "hostname\instance" for ServerName but the bare hostname
+	// for DNS/TCP (spec 068). Empty keeps the historical behaviour of mirroring
+	// `host` into both HostName and ServerName, so every existing caller is
+	// unaffected.
 	static TdsPacket BuildLogin7(const std::string &host, const std::string &username, const std::string &password,
 								 const std::string &database, const std::string &app_name = "DuckDB MSSQL Extension",
-								 uint32_t packet_size = TDS_DEFAULT_PACKET_SIZE, bool request_utf8_support = true);
+								 uint32_t packet_size = TDS_DEFAULT_PACKET_SIZE, bool request_utf8_support = true,
+								 const std::string &server_name = "");
 
 	// Parse LOGIN7 response (LOGINACK token and potential errors)
 	static LoginResponse ParseLoginResponse(const std::vector<uint8_t> &data);

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1315,29 +1315,39 @@ void ValidateIntegratedAuthConnection(MSSQLConnectionInfo &info, int timeout_sec
 		throw IOException("MSSQL connection validation failed: %s", translated);
 	}
 
-	// Build the strategy; this triggers Krb5Authenticator construction (which
-	// validates the keytab/realm/etc. early).
-	std::shared_ptr<tds::AuthenticationStrategy> strategy;
-	try {
-		strategy = tds::AuthStrategyFactory::Create(info);
-	} catch (const std::exception &e) {
-		conn.Close();
-		throw InvalidInputException("MSSQL connection validation failed: %s", e.what());
-	}
-	if (!strategy) {
-		conn.Close();
-		throw InvalidInputException("MSSQL connection validation failed: failed to construct integrated-auth strategy");
-	}
-	auto authenticator = strategy->GetAuthenticator();
-	if (!authenticator) {
-		conn.Close();
-		throw InvalidInputException(
-			"MSSQL connection validation failed: integrated-auth strategy did not provide an authenticator");
-	}
+	// Build the strategy per login attempt; this triggers Krb5Authenticator
+	// construction (which validates the keytab/realm/etc. early). Spec 068 D3:
+	// a factory rather than an instance, so a routing hop obtains a ticket for
+	// the routed host's SPN. The factory cannot throw across the TDS layer, so
+	// construction errors are captured here and re-thrown after the call
+	// returns — `strategy_error` holds the message the callable could not raise.
+	string strategy_error;
+	auto auth_factory = [&info, &strategy_error](const std::string &host,
+												 uint16_t port) -> std::shared_ptr<tds::IAuthenticator> {
+		MSSQLConnectionInfo hop_info = info;
+		hop_info.host = host;
+		hop_info.port = port;
+		std::shared_ptr<tds::AuthenticationStrategy> strategy;
+		try {
+			strategy = tds::AuthStrategyFactory::Create(hop_info);
+		} catch (const std::exception &e) {
+			strategy_error = e.what();
+			return nullptr;
+		}
+		if (!strategy) {
+			strategy_error = "failed to construct integrated-auth strategy";
+			return nullptr;
+		}
+		auto authenticator = strategy->GetAuthenticator();
+		if (!authenticator) {
+			strategy_error = "integrated-auth strategy did not provide an authenticator";
+		}
+		return authenticator;
+	};
 
-	if (!conn.AuthenticateIntegrated(info.database, authenticator, info.use_encrypt, ResolveAppName(info),
+	if (!conn.AuthenticateIntegrated(info.database, auth_factory, info.use_encrypt, ResolveAppName(info),
 									 info.login7_max_packet)) {
-		string error = conn.GetLastError();
+		string error = strategy_error.empty() ? conn.GetLastError() : strategy_error;
 		conn.Close();
 		throw InvalidInputException("MSSQL connection validation failed: %s", error);
 	}

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1347,7 +1347,17 @@ void ValidateIntegratedAuthConnection(MSSQLConnectionInfo &info, int timeout_sec
 
 	if (!conn.AuthenticateIntegrated(info.database, auth_factory, info.use_encrypt, ResolveAppName(info),
 									 info.login7_max_packet)) {
-		string error = strategy_error.empty() ? conn.GetLastError() : strategy_error;
+		// Keep BOTH messages. The connection's own error is the one that says
+		// WHICH target failed -- after a routing hop it names the routed server
+		// and the SPN that would have been requested, which `Kerberos.md`
+		// documents as the one-round field diagnosis for the SPN-over-hop path.
+		// `strategy_error` is the GSSAPI/SSPI cause, which the callable could
+		// not throw across the TDS layer. Reporting only the cause would drop
+		// the routed host; reporting only the driver would drop the reason.
+		string error = conn.GetLastError();
+		if (!strategy_error.empty()) {
+			error += " (" + strategy_error + ")";
+		}
 		conn.Close();
 		throw InvalidInputException("MSSQL connection validation failed: %s", error);
 	}

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1322,6 +1322,12 @@ void ValidateIntegratedAuthConnection(MSSQLConnectionInfo &info, int timeout_sec
 	// construction errors are captured here and re-thrown after the call
 	// returns — `strategy_error` holds the message the callable could not raise.
 	string strategy_error;
+	// By reference, deliberately, and the exception to the by-value rule in
+	// AuthenticatorFactory's docs: this factory is built and consumed inside
+	// this one synchronous call, and `strategy_error` is how a construction
+	// failure gets back out -- the callable cannot throw across the TDS layer.
+	// The pool's factory (mssql_catalog.cpp) captures by value, because it is
+	// stored and re-run on worker threads.
 	auto auth_factory = [&info, &strategy_error](const std::string &host,
 												 uint16_t port) -> std::shared_ptr<tds::IAuthenticator> {
 		MSSQLConnectionInfo hop_info = info;

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -157,6 +157,10 @@ bool TdsConnection::Authenticate(const std::string &username, const std::string 
 	// Initialize the LOGIN7 ServerName to the host we dialled; a routing hop
 	// replaces it with the routed "hostname\instance" form.
 	tds_server_name_ = host_;
+	// Set before the driver runs, so the successful attempt publishes
+	// state_ == Idle with database_ already correct -- the driver stores Idle
+	// itself, and other threads observe the connection through that atomic.
+	database_ = database;
 
 	// Spec 068: SQL auth follows ROUTING like every other path. Azure SQL with
 	// the Redirect connection policy (the DEFAULT for traffic originating
@@ -178,7 +182,6 @@ bool TdsConnection::Authenticate(const std::string &username, const std::string 
 		return false;
 	}
 
-	database_ = database;
 	UpdateLastUsed();
 	return true;
 }
@@ -323,13 +326,20 @@ bool TdsConnection::RunWithRoutingHops(const std::function<LoginAttemptOutcome()
 		MSSQL_CONN_DEBUG_LOG(1, "RunWithRoutingHops: authentication attempt %d on %s:%d", routing_hop + 1,
 							 host_.c_str(), port_);
 
-		// Per-attempt state. Cleared BEFORE the first attempt too, so a reused
-		// TdsConnection cannot inherit a stale route from an earlier login.
-		// next_packet_id_/tls_enabled_ are already correct on the first pass
-		// (fresh socket); resetting them is what makes hops 2..N correct.
+		// Per-attempt state, cleared before EVERY attempt including the first.
+		// Hops 2..N obviously need it. The first attempt needs it too: Close()
+		// resets state_ but not next_packet_id_, so a reused TdsConnection
+		// (Close -> Connect -> Authenticate) would otherwise open its LOGIN7
+		// with a stale sequence id, and would inherit a stale route from the
+		// previous login. tls_enabled_/fedauth_echo_ are self-correcting (both
+		// PRELOGIN flavours assign them unconditionally) but are reset here
+		// anyway, so the whole per-attempt set lives in one place.
 		has_routing_ = false;
 		routed_server_.clear();
 		routed_port_ = 0;
+		next_packet_id_ = 1;
+		tls_enabled_ = false;
+		fedauth_echo_ = false;
 
 		const LoginAttemptOutcome outcome = attempt();
 
@@ -370,9 +380,6 @@ bool TdsConnection::RunWithRoutingHops(const std::function<LoginAttemptOutcome()
 		// the latter demands the Disconnected state, and the state machine must
 		// stay in Authenticating across a hop.
 		socket_->Close();
-		next_packet_id_ = 1;
-		tls_enabled_ = false;
-		fedauth_echo_ = false;
 
 		// host_ is the stripped hostname for TCP/DNS and for TLS SNI (per
 		// go-mssqldb, SNI follows the routed host, not the original gateway);
@@ -415,6 +422,8 @@ bool TdsConnection::AuthenticateWithFedAuth(const std::string &database, const s
 
 	// Initialize TDS server name to host - may be updated if routing includes instance name
 	tds_server_name_ = host_;
+	// See Authenticate(): set before the driver publishes state_ == Idle.
+	database_ = database;
 
 	// The hop loop that used to live inline here is now RunWithRoutingHops
 	// (spec 068 D2) -- same behaviour, shared with the other two auth paths.
@@ -433,7 +442,6 @@ bool TdsConnection::AuthenticateWithFedAuth(const std::string &database, const s
 		return false;
 	}
 
-	database_ = database;
 	UpdateLastUsed();
 	MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: Azure AD authentication successful");
 	return true;
@@ -738,6 +746,8 @@ bool TdsConnection::AuthenticateIntegrated(const std::string &database, Authenti
 	// Initialize the LOGIN7 ServerName to the host we dialled; a routing hop
 	// replaces it with the routed "hostname\instance" form.
 	tds_server_name_ = host_;
+	// See Authenticate(): set before the driver publishes state_ == Idle.
+	database_ = database;
 
 	bool first_attempt = true;
 	const bool ok = RunWithRoutingHops([&]() -> LoginAttemptOutcome {
@@ -917,7 +927,6 @@ bool TdsConnection::AuthenticateIntegrated(const std::string &database, Authenti
 		return false;
 	}
 
-	database_ = database;
 	UpdateLastUsed();
 	return true;
 }

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -1123,6 +1123,12 @@ void TdsConnection::Close() {
 
 	state_.store(ConnectionState::Disconnected);
 	spid_ = 0;
+	// This connection is no longer logged in anywhere, so it is no longer "in"
+	// a database either -- same reason spid_ is zeroed here. Without this the
+	// invariant that state_ == Disconnected implies an empty GetDatabase()
+	// would hold after an aborted login and not after a normal close, and a
+	// half-enforced invariant is the kind a later caller reads the wrong way.
+	database_.clear();
 }
 
 bool TdsConnection::SendAttention() {

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -134,6 +134,7 @@ bool TdsConnection::Connect(const std::string &host, uint16_t port, int timeout_
 
 	host_ = host;
 	port_ = port;
+	connect_timeout_seconds_ = timeout_seconds;
 	last_error_.clear();
 
 	if (!socket_->Connect(host, port, timeout_seconds)) {
@@ -391,7 +392,9 @@ bool TdsConnection::RunWithRoutingHops(const std::function<LoginAttemptOutcome()
 		host_ = next_server;
 		port_ = next_port;
 
-		if (!socket_->Connect(next_server, next_port, DEFAULT_CONNECTION_TIMEOUT)) {
+		// The caller's timeout, not the compiled-in default: a hop is part of the
+		// same connection attempt and must not silently cost more than asked.
+		if (!socket_->Connect(next_server, next_port, connect_timeout_seconds_)) {
 			last_error_ = "Failed to connect to routed server " + next_server + ":" + std::to_string(next_port) + ": " +
 						  socket_->GetLastError();
 			state_.store(ConnectionState::Disconnected);
@@ -1124,10 +1127,16 @@ void TdsConnection::Close() {
 	state_.store(ConnectionState::Disconnected);
 	spid_ = 0;
 	// This connection is no longer logged in anywhere, so it is no longer "in"
-	// a database either -- same reason spid_ is zeroed here. Without this the
-	// invariant that state_ == Disconnected implies an empty GetDatabase()
-	// would hold after an aborted login and not after a normal close, and a
-	// half-enforced invariant is the kind a later caller reads the wrong way.
+	// a database either -- same reason spid_ is zeroed here.
+	//
+	// Scope, precisely: database_ is cleared on the DELIBERATE teardown (here)
+	// and on the failed-login paths. It is NOT a class-wide invariant that
+	// state_ == Disconnected implies an empty GetDatabase(): Ping, SendAttention,
+	// WaitForAttentionAck, ExecuteBatch and ReceiveData all store Disconnected
+	// directly, and the early return above means a connection that died
+	// mid-query still reports its last database. Making that invariant real
+	// would mean funnelling every one of those through a MarkDisconnected()
+	// helper -- worth doing, but it is not this change's business.
 	database_.clear();
 }
 

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -938,20 +938,24 @@ LoginAttemptOutcome TdsConnection::DoLogin7(const std::string &username, const s
 	// Spec 047 FR-014: LOGIN7 program_name from caller (already clamped). Empty
 	// preserves the prior extension default.
 	const std::string login7_app_name = app_name.empty() ? "DuckDB MSSQL Extension" : app_name;
-	// ServerName: tds_server_name_ when set, which is what a routing hop leaves
-	// behind -- "hostname\instance", the form [MS-TDS] wants in this field.
-	// host_ is the instance-STRIPPED name used for DNS/TCP, so passing it here
-	// (as this did before spec 068) sends the wrong ServerName after a hop to a
-	// named instance. On a first attempt the driver sets tds_server_name_ =
-	// host_, so a non-routed login is byte-identical to the pre-068 packet.
+	// ServerName goes in as its own argument rather than by overwriting `host`:
+	// BuildLogin7 mirrors its first argument into BOTH HostName and ServerName,
+	// so passing the routed "hostname\instance" form as `host` would have moved
+	// HostName too -- a different field with a different meaning ([MS-TDS]
+	// 2.2.6.4: client workstation, not destination). A routing hop leaves the
+	// instance form in tds_server_name_ while host_ holds the instance-STRIPPED
+	// name used for DNS/TCP; before spec 068 only host_ existed here, so a
+	// routed named instance received the wrong ServerName. On a first attempt
+	// the driver sets tds_server_name_ = host_, leaving a non-routed login
+	// byte-identical to the pre-068 packet.
 	const std::string &server_name = tds_server_name_.empty() ? host_ : tds_server_name_;
 	// Request our configured frame size. The server answers with
 	// min(requested, its own maximum) via the PACKETSIZE ENVCHANGE — it never
 	// raises the value on its own, so asking for the 4096 default (as this did
 	// unconditionally before spec 055) pinned every packet in both directions
 	// at 4096 for the life of the connection.
-	TdsPacket login = TdsProtocol::BuildLogin7(server_name, username, password, database, login7_app_name,
-											   requested_packet_size_, request_utf8_support_);
+	TdsPacket login = TdsProtocol::BuildLogin7(host_, username, password, database, login7_app_name,
+											   requested_packet_size_, request_utf8_support_, server_name);
 	login.SetPacketId(next_packet_id_++);
 
 	if (!socket_->SendPacket(login)) {

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -154,24 +154,31 @@ bool TdsConnection::Authenticate(const std::string &username, const std::string 
 		return false;
 	}
 
-	// Step 1: PRELOGIN handshake (negotiates encryption)
-	if (!DoPrelogin(use_encrypt)) {
-		state_.store(ConnectionState::Disconnected);
-		socket_->Close();
+	// Initialize the LOGIN7 ServerName to the host we dialled; a routing hop
+	// replaces it with the routed "hostname\instance" form.
+	tds_server_name_ = host_;
+
+	// Spec 068: SQL auth follows ROUTING like every other path. Azure SQL with
+	// the Redirect connection policy (the DEFAULT for traffic originating
+	// inside Azure), Azure SQL Managed Instance, and on-prem AlwaysOn
+	// read-intent routing all answer LOGIN7 with an ENVCHANGE 20. Before this,
+	// such an answer either failed as "Authentication failed" (no LOGINACK) or
+	// -- worse, because it was silent -- "succeeded" against a gateway that had
+	// just told us to go elsewhere.
+	const bool ok = RunWithRoutingHops([&]() -> LoginAttemptOutcome {
+		// Step 1: PRELOGIN handshake (negotiates encryption)
+		if (!DoPrelogin(use_encrypt)) {
+			return LoginAttemptOutcome::Failure;
+		}
+		// Step 2: LOGIN7 authentication
+		// Note: If TLS was enabled during PRELOGIN, all subsequent traffic is encrypted
+		return DoLogin7(username, password, database, app_name);
+	});
+	if (!ok) {
 		return false;
 	}
 
-	// Step 2: LOGIN7 authentication
-	// Note: If TLS was enabled during PRELOGIN, all subsequent traffic is encrypted
-	if (!DoLogin7(username, password, database, app_name)) {
-		state_.store(ConnectionState::Disconnected);
-		socket_->Close();
-		return false;
-	}
-
-	// Success - transition to Idle
 	database_ = database;
-	state_.store(ConnectionState::Idle);
 	UpdateLastUsed();
 	return true;
 }
@@ -237,6 +244,161 @@ bool TdsConnection::DoPrelogin(bool use_encrypt) {
 }
 
 //===----------------------------------------------------------------------===//
+// Login-time routing -- spec 068
+//
+// ENVCHANGE type 20 tells the client "this session is not usable, log in over
+// there instead". It arrives during login, before the connection is ever Idle,
+// so no query or ATTENTION interaction exists here. The loop below was
+// originally inline in AuthenticateWithFedAuth, where it was built and proven
+// against the Azure SQL / Fabric gateways; spec 068 lifted it out so SQL auth
+// and integrated auth get the same behaviour instead of two different wrong
+// ones.
+//===----------------------------------------------------------------------===//
+
+void TdsConnection::NormalizeRoutedTarget(const std::string &routed_server, uint16_t routed_port, std::string &out_host,
+										  uint16_t &out_port) {
+	// Format from Azure Fabric: "hostname.pbidedicated.windows.net\INSTANCE-NAME:port".
+	// We need (1) the bare hostname for DNS resolution, (2) the port from after
+	// the instance name if present, else the ROUTING ENVCHANGE port.
+	std::string next_server = routed_server;
+	uint16_t next_port = routed_port;
+
+	MSSQL_CONN_DEBUG_LOG(2, "NormalizeRoutedTarget: parsing routed server '%s', envchange_port=%d", next_server.c_str(),
+						 next_port);
+
+	// A trailing ":digits" is a port suffix and wins over the ENVCHANGE port.
+	// Scanning the decoded UTF-8 for ':' and '\\' is safe: every continuation
+	// byte of a multi-byte sequence is >= 0x80, so neither can appear inside one.
+	size_t last_colon = next_server.rfind(':');
+	if (last_colon != std::string::npos) {
+		std::string port_str = next_server.substr(last_colon + 1);
+		bool is_port = !port_str.empty();
+		for (char c : port_str) {
+			if (!std::isdigit(static_cast<unsigned char>(c))) {
+				is_port = false;
+				break;
+			}
+		}
+		if (is_port) {
+			try {
+				int parsed_port = std::stoi(port_str);
+				if (parsed_port > 0 && parsed_port <= 65535) {
+					next_port = static_cast<uint16_t>(parsed_port);
+					next_server = next_server.substr(0, last_colon);
+					MSSQL_CONN_DEBUG_LOG(2, "NormalizeRoutedTarget: extracted port %d from server string", next_port);
+				}
+			} catch (...) {
+				// Ignore parse errors -- keep the ENVCHANGE port.
+			}
+		}
+	}
+
+	// Server name (with instance, without port) for the LOGIN7 ServerName field.
+	// Per [MS-TDS] and go-mssqldb: ServerName is "hostname\instance", no port.
+	tds_server_name_ = next_server;
+
+	// Strip the instance name for DNS/TCP. We do not consult the SQL Browser on
+	// a hop (see the header comment); the routed target carries its own port.
+	size_t backslash_pos = next_server.find('\\');
+	if (backslash_pos != std::string::npos) {
+		MSSQL_CONN_DEBUG_LOG(2, "NormalizeRoutedTarget: stripping instance name, keeping hostname '%s'",
+							 next_server.substr(0, backslash_pos).c_str());
+		next_server = next_server.substr(0, backslash_pos);
+	}
+
+	MSSQL_CONN_DEBUG_LOG(1, "NormalizeRoutedTarget: final routed target: %s:%d (tds_name=%s)", next_server.c_str(),
+						 next_port, tds_server_name_.c_str());
+
+	out_host = next_server;
+	out_port = next_port;
+}
+
+bool TdsConnection::RunWithRoutingHops(const std::function<LoginAttemptOutcome()> &attempt) {
+	// Azure SQL / Fabric may route through several layers of gateway
+	// infrastructure. Each hop is a full reconnect + PRELOGIN + LOGIN7.
+	constexpr int MAX_ROUTING_HOPS = 5;
+	int routing_hop = 0;
+
+	while (routing_hop <= MAX_ROUTING_HOPS) {
+		MSSQL_CONN_DEBUG_LOG(1, "RunWithRoutingHops: authentication attempt %d on %s:%d", routing_hop + 1,
+							 host_.c_str(), port_);
+
+		// Per-attempt state. Cleared BEFORE the first attempt too, so a reused
+		// TdsConnection cannot inherit a stale route from an earlier login.
+		// next_packet_id_/tls_enabled_ are already correct on the first pass
+		// (fresh socket); resetting them is what makes hops 2..N correct.
+		has_routing_ = false;
+		routed_server_.clear();
+		routed_port_ = 0;
+
+		const LoginAttemptOutcome outcome = attempt();
+
+		if (outcome == LoginAttemptOutcome::Success) {
+			state_.store(ConnectionState::Idle);
+			MSSQL_CONN_DEBUG_LOG(1, "RunWithRoutingHops: login successful after %d routing hop(s)", routing_hop);
+			return true;
+		}
+
+		if (outcome == LoginAttemptOutcome::Failure) {
+			// last_error_ was set by the attempt.
+			state_.store(ConnectionState::Disconnected);
+			socket_->Close();
+			return false;
+		}
+
+		// Route. The session on this socket is dead either way -- whether or
+		// not a LOGINACK came with it.
+		routing_hop++;
+		MSSQL_CONN_DEBUG_LOG(1, "RunWithRoutingHops: routing hop %d -> %s:%d", routing_hop, routed_server_.c_str(),
+							 routed_port_);
+
+		if (routing_hop > MAX_ROUTING_HOPS) {
+			last_error_ = "Too many routing hops (" + std::to_string(routing_hop) +
+						  ") - aborting; last routed target " + "was " + routed_server_ + ":" +
+						  std::to_string(routed_port_);
+			state_.store(ConnectionState::Disconnected);
+			socket_->Close();
+			return false;
+		}
+
+		std::string next_server;
+		uint16_t next_port = 0;
+		NormalizeRoutedTarget(routed_server_, routed_port_, next_server, next_port);
+
+		// Close the current connection and reset everything that is per-socket.
+		// Note we call socket_->Connect() rather than TdsConnection::Connect():
+		// the latter demands the Disconnected state, and the state machine must
+		// stay in Authenticating across a hop.
+		socket_->Close();
+		next_packet_id_ = 1;
+		tls_enabled_ = false;
+		fedauth_echo_ = false;
+
+		// host_ is the stripped hostname for TCP/DNS and for TLS SNI (per
+		// go-mssqldb, SNI follows the routed host, not the original gateway);
+		// tds_server_name_ carries the full name for LOGIN7.
+		host_ = next_server;
+		port_ = next_port;
+
+		if (!socket_->Connect(next_server, next_port, DEFAULT_CONNECTION_TIMEOUT)) {
+			last_error_ = "Failed to connect to routed server " + next_server + ":" + std::to_string(next_port) + ": " +
+						  socket_->GetLastError();
+			state_.store(ConnectionState::Disconnected);
+			return false;
+		}
+
+		MSSQL_CONN_DEBUG_LOG(1, "RunWithRoutingHops: connected to routed server %s:%d", next_server.c_str(), next_port);
+		// Loop continues with a fresh handshake on the new server.
+	}
+
+	// Unreachable: the hop-limit check above returns first.
+	last_error_ = "Routing hop loop exited unexpectedly";
+	state_.store(ConnectionState::Disconnected);
+	socket_->Close();
+	return false;
+}
+
+//===----------------------------------------------------------------------===//
 // Azure AD FEDAUTH Authentication (T018/T020)
 //===----------------------------------------------------------------------===//
 
@@ -254,139 +416,26 @@ bool TdsConnection::AuthenticateWithFedAuth(const std::string &database, const s
 	// Initialize TDS server name to host - may be updated if routing includes instance name
 	tds_server_name_ = host_;
 
-	// Azure SQL/Fabric may require multiple routing hops through gateway infrastructure
-	// Each hop requires full PRELOGIN + LOGIN7 handshake
-	constexpr int MAX_ROUTING_HOPS = 5;
-	int routing_hop = 0;
-
-	while (routing_hop <= MAX_ROUTING_HOPS) {
-		MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: authentication attempt %d on %s:%d", routing_hop + 1,
-							 host_.c_str(), port_);
-
+	// The hop loop that used to live inline here is now RunWithRoutingHops
+	// (spec 068 D2) -- same behaviour, shared with the other two auth paths.
+	// Per go-mssqldb: after routing, TLS SNI follows the NEW routed hostname,
+	// not the original gateway. The driver has already retargeted host_ by the
+	// time this lambda runs, and DoPreloginWithFedAuth defaults its SNI to host_.
+	const bool ok = RunWithRoutingHops([&]() -> LoginAttemptOutcome {
 		// Step 1: PRELOGIN handshake with FEDAUTHREQUIRED
-		// Per go-mssqldb: after routing, use the NEW routed hostname for TLS SNI (not the original gateway)
-		// The host_ is already updated to the routed server in the loop below
 		if (!DoPreloginWithFedAuth(use_encrypt, "" /* use host_ for TLS SNI */)) {
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
+			return LoginAttemptOutcome::Failure;
 		}
-
 		// Step 2: LOGIN7 with FEDAUTH feature extension
-		if (!DoLogin7WithFedAuth(database, fedauth_token, app_name)) {
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
-		}
-
-		// Step 3: Check if server requested routing (Azure SQL/Fabric gateway redirection)
-		if (!has_routing_) {
-			// No more routing - authentication complete
-			break;
-		}
-
-		// Handle routing to next server
-		routing_hop++;
-		MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: routing hop %d -> %s:%d", routing_hop, routed_server_.c_str(),
-							 routed_port_);
-
-		if (routing_hop > MAX_ROUTING_HOPS) {
-			last_error_ = "Too many routing hops (" + std::to_string(routing_hop) + ") - aborting";
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
-		}
-
-		// Close current connection
-		socket_->Close();
-
-		// Reset state for new connection
-		// Parse routed server - may contain instance name and/or port suffix
-		// Format from Azure Fabric: "hostname.pbidedicated.windows.net\INSTANCE-NAME:port"
-		// We need:
-		// 1. Just the hostname part for DNS resolution
-		// 2. The port from after instance name (if present), otherwise use ROUTING ENVCHANGE port
-		std::string next_server = routed_server_;
-		uint16_t next_port = routed_port_;
-
-		MSSQL_CONN_DEBUG_LOG(2, "AuthenticateWithFedAuth: parsing routed server '%s', envchange_port=%d",
-							 next_server.c_str(), next_port);
-
-		// First, check for port suffix in the full string (after instance name)
-		// Format: hostname\instance:port - the :port is at the very end
-		size_t last_colon = next_server.rfind(':');
-		if (last_colon != std::string::npos) {
-			// Check if this looks like a port (all digits after colon)
-			std::string port_str = next_server.substr(last_colon + 1);
-			bool is_port = !port_str.empty();
-			for (char c : port_str) {
-				if (!std::isdigit(static_cast<unsigned char>(c))) {
-					is_port = false;
-					break;
-				}
-			}
-			if (is_port) {
-				try {
-					int parsed_port = std::stoi(port_str);
-					if (parsed_port > 0 && parsed_port <= 65535) {
-						next_port = static_cast<uint16_t>(parsed_port);
-						next_server = next_server.substr(0, last_colon);
-						MSSQL_CONN_DEBUG_LOG(2, "AuthenticateWithFedAuth: extracted port %d from server string",
-											 next_port);
-					}
-				} catch (...) {
-					// Ignore parse errors
-				}
-			}
-		}
-
-		// Store server name (with instance, without port) for LOGIN7 ServerName field
-		// Per TDS spec and go-mssqldb: ServerName should be "hostname\instance" but NOT include port
-		tds_server_name_ = next_server;
-
-		// Now strip instance name (after backslash) - we don't use SQL Browser service
-		// Keep hostname only for DNS resolution
-		size_t backslash_pos = next_server.find('\\');
-		if (backslash_pos != std::string::npos) {
-			MSSQL_CONN_DEBUG_LOG(2, "AuthenticateWithFedAuth: stripping instance name, keeping hostname '%s'",
-								 next_server.substr(0, backslash_pos).c_str());
-			next_server = next_server.substr(0, backslash_pos);
-		}
-
-		MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: final routed target: %s:%d (tds_name=%s)",
-							 next_server.c_str(), next_port, tds_server_name_.c_str());
-
-		has_routing_ = false;
-		routed_server_.clear();
-		routed_port_ = 0;
-		next_packet_id_ = 1;
-		tls_enabled_ = false;
-		fedauth_echo_ = false;
-
-		// Update connection target
-		// host_ is stripped hostname for TCP/DNS, tds_server_name_ is full name for LOGIN7
-		host_ = next_server;
-		port_ = next_port;
-
-		// Connect to routed server
-		if (!socket_->Connect(next_server, next_port, DEFAULT_CONNECTION_TIMEOUT)) {
-			last_error_ = "Failed to connect to routed server " + next_server + ":" + std::to_string(next_port) + ": " +
-						  socket_->GetLastError();
-			state_.store(ConnectionState::Disconnected);
-			return false;
-		}
-
-		MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: connected to routed server %s:%d", next_server.c_str(),
-							 next_port);
-		// Loop continues with PRELOGIN + LOGIN7 on new server
+		return DoLogin7WithFedAuth(database, fedauth_token, app_name);
+	});
+	if (!ok) {
+		return false;
 	}
 
-	// Success - transition to Idle
 	database_ = database;
-	state_.store(ConnectionState::Idle);
 	UpdateLastUsed();
-	MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: Azure AD authentication successful after %d routing hop(s)",
-						 routing_hop);
+	MSSQL_CONN_DEBUG_LOG(1, "AuthenticateWithFedAuth: Azure AD authentication successful");
 	return true;
 }
 
@@ -465,8 +514,9 @@ bool TdsConnection::DoPreloginWithFedAuth(bool use_encrypt, const std::string &s
 	return true;
 }
 
-bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::vector<uint8_t> &fedauth_token,
-										const std::string &app_name) {
+LoginAttemptOutcome TdsConnection::DoLogin7WithFedAuth(const std::string &database,
+													   const std::vector<uint8_t> &fedauth_token,
+													   const std::string &app_name) {
 	// Get local hostname for LOGIN7 HostName field (per go-mssqldb: HostName = client workstation)
 	std::string client_hostname = GetClientHostname();
 	// Spec 047 FR-014: LOGIN7 program_name from caller (already clamped). Empty
@@ -506,7 +556,7 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 
 	if (!socket_->SendPacket(login)) {
 		last_error_ = "Failed to send LOGIN7: " + socket_->GetLastError();
-		return false;
+		return LoginAttemptOutcome::Failure;
 	}
 
 	MSSQL_CONN_DEBUG_LOG(2, "DoLogin7WithFedAuth: LOGIN7 with ADAL sent, waiting for FEDAUTHINFO response...");
@@ -516,7 +566,7 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 	if (!socket_->ReceiveMessage(response, DEFAULT_CONNECTION_TIMEOUT * 1000)) {
 		last_error_ = "Failed to receive LOGIN7 response: " + socket_->GetLastError();
 		MSSQL_CONN_DEBUG_LOG(1, "DoLogin7WithFedAuth: ReceiveMessage failed: %s", last_error_.c_str());
-		return false;
+		return LoginAttemptOutcome::Failure;
 	}
 
 	MSSQL_CONN_DEBUG_LOG(2, "DoLogin7WithFedAuth: received %zu bytes response", response.size());
@@ -582,7 +632,7 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 			if (!socket_->SendPacket(token_packets[i])) {
 				last_error_ =
 					"Failed to send FEDAUTH_TOKEN packet " + std::to_string(i) + ": " + socket_->GetLastError();
-				return false;
+				return LoginAttemptOutcome::Failure;
 			}
 		}
 
@@ -593,7 +643,7 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 		if (!socket_->ReceiveMessage(response, DEFAULT_CONNECTION_TIMEOUT * 1000)) {
 			last_error_ = "Failed to receive LOGINACK after FEDAUTH_TOKEN: " + socket_->GetLastError();
 			MSSQL_CONN_DEBUG_LOG(1, "DoLogin7WithFedAuth: ReceiveMessage after token failed: %s", last_error_.c_str());
-			return false;
+			return LoginAttemptOutcome::Failure;
 		}
 
 		MSSQL_CONN_DEBUG_LOG(2, "DoLogin7WithFedAuth: received %zu bytes final response", response.size());
@@ -614,6 +664,20 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 		NoteFeatureAcks(login_response);
 	}
 
+	// Routing is checked BEFORE success (spec 068 D1). A gateway may answer the
+	// token with ROUTING + DONE and no LOGINACK -- legal per [MS-TDS], and the
+	// session on this socket is unusable either way. Reading `success` first (as
+	// this did until spec 068) turned that answer into "Azure AD authentication
+	// failed" and the hop loop never saw the redirect.
+	if (login_response.has_routing) {
+		has_routing_ = true;
+		routed_server_ = login_response.routed_server;
+		routed_port_ = login_response.routed_port;
+		MSSQL_CONN_DEBUG_LOG(1, "DoLogin7WithFedAuth: ROUTING requested to %s:%d (loginack=%d)", routed_server_.c_str(),
+							 routed_port_, login_response.success ? 1 : 0);
+		return LoginAttemptOutcome::Route;
+	}
+
 	// Check for success
 	if (!login_response.success) {
 		if (login_response.error_number > 0) {
@@ -622,26 +686,17 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 		} else {
 			last_error_ = "Azure AD authentication failed: " + login_response.error_message;
 		}
-		return false;
+		return LoginAttemptOutcome::Failure;
 	}
 
 	spid_ = login_response.spid;
 	negotiated_packet_size_ = login_response.negotiated_packet_size;
 	ApplyNegotiatedFraming();
 
-	// Check for routing (Azure SQL/Fabric gateway redirection)
-	if (login_response.has_routing) {
-		has_routing_ = true;
-		routed_server_ = login_response.routed_server;
-		routed_port_ = login_response.routed_port;
-		MSSQL_CONN_DEBUG_LOG(1, "DoLogin7WithFedAuth: ROUTING requested to %s:%d", routed_server_.c_str(),
-							 routed_port_);
-	}
-
 	MSSQL_CONN_DEBUG_LOG(1, "DoLogin7WithFedAuth: Azure AD login successful, spid=%d, packet_size=%d", spid_,
 						 negotiated_packet_size_);
 
-	return true;
+	return LoginAttemptOutcome::Success;
 }
 
 //===----------------------------------------------------------------------===//
@@ -658,10 +713,16 @@ bool TdsConnection::DoLogin7WithFedAuth(const std::string &database, const std::
 // Phase 2 wires the loop and validates the LOGIN7 builder + 0xED parser.
 // Phase 3/4 provides the concrete Krb5Authenticator / WinSspiAuthenticator
 // implementations. Without one, this returns a clear error per FR-012.
+//
+// Spec 068 D3: the authenticator arrives as a FACTORY, not an instance. The
+// credential is bound to the target's SPN, so a routing hop must obtain a
+// service ticket for the ROUTED host -- reusing the gateway's blob would fail
+// validation on the new server. The factory is called once per attempt; a
+// non-routed login therefore behaves exactly as before (one fresh authenticator
+// per connection, spec 042 semantics preserved).
 //===----------------------------------------------------------------------===//
-bool TdsConnection::AuthenticateIntegrated(const std::string &database,
-										   std::shared_ptr<tds::IAuthenticator> authenticator, bool use_encrypt,
-										   const std::string &app_name, size_t login7_max_packet) {
+bool TdsConnection::AuthenticateIntegrated(const std::string &database, AuthenticatorFactory authenticator_factory,
+										   bool use_encrypt, const std::string &app_name, size_t login7_max_packet) {
 	// Validate the (DuckDB-setting-sourced) fragmentation boundary. 0 or an
 	// out-of-range value falls back to the 4096 pre-negotiation default; small
 	// in-range values are the TEST hook to force the multi-packet path. The
@@ -673,190 +734,226 @@ bool TdsConnection::AuthenticateIntegrated(const std::string &database,
 		last_error_ = "Cannot authenticate: not in Authenticating state";
 		return false;
 	}
-	if (!authenticator) {
-		last_error_ =
-			"MSSQL Error: This build of the mssql extension was compiled without Kerberos / SSPI support. "
-			"Rebuild with -DENABLE_KRB5=ON or use SQL authentication.";
-		state_.store(ConnectionState::Disconnected);
-		socket_->Close();
-		return false;
-	}
 
-	// Step 1: PRELOGIN (encryption only; integrated auth does NOT set FEDAUTHREQUIRED)
-	if (!DoPrelogin(use_encrypt)) {
-		state_.store(ConnectionState::Disconnected);
-		socket_->Close();
-		return false;
-	}
+	// Initialize the LOGIN7 ServerName to the host we dialled; a routing hop
+	// replaces it with the routed "hostname\instance" form.
+	tds_server_name_ = host_;
 
-	// Step 2: Initial SPNEGO blob from the authenticator.
-	std::vector<uint8_t> initial_blob;
-	try {
-		initial_blob = authenticator->InitialBytes();
-	} catch (const std::exception &e) {
-		// Authenticator already prefixes with "MSSQL Kerberos auth failed:";
-		// just propagate verbatim to avoid double-prefixing.
-		last_error_ = e.what();
-		state_.store(ConnectionState::Disconnected);
-		socket_->Close();
-		return false;
-	}
-	if (initial_blob.empty()) {
-		last_error_ = "MSSQL Kerberos auth failed: authenticator returned empty initial SPNEGO blob";
-		state_.store(ConnectionState::Disconnected);
-		socket_->Close();
-		return false;
-	}
-
-	// Step 3: LOGIN7 with SSPI field populated. The HostName field is the
-	// CLIENT workstation name (per [MS-TDS] 2.2.6.4 -- surfaces in
-	// sys.dm_exec_sessions.host_name, sp_who, audit logs); the ServerName
-	// field is the destination. Passing host_ (the destination) into both
-	// positions makes DBA tooling see every connection as if the server were
-	// connecting to itself. spec 042 ultrareview bug_029.
-	const std::string client_hostname = GetClientHostname();
-	MSSQL_CONN_DEBUG_LOG(1,
-						 "AuthenticateIntegrated: sending LOGIN7 with SSPI blob (%zu bytes), client_host='%s', db='%s'",
-						 initial_blob.size(), client_hostname.c_str(), database.c_str());
-	// Spec 047 FR-014: LOGIN7 program_name from caller (already clamped). Empty
-	// preserves the prior extension default.
-	const std::string login7_app_name = app_name.empty() ? "DuckDB MSSQL Extension" : app_name;
-	TdsPacket login =
-		TdsProtocol::BuildLogin7WithSSPI(client_hostname, tds_server_name_.empty() ? host_ : tds_server_name_, database,
-										 initial_blob, login7_app_name, requested_packet_size_, request_utf8_support_);
-
-	// A Kerberos LOGIN7 carrying a real Active Directory PAC routinely exceeds
-	// the 4096-byte pre-negotiation packet size. LOGIN7 is sent before
-	// packet-size negotiation completes, so it MUST be fragmented to the default
-	// packet size with EOM on the last packet only -- otherwise SQL Server
-	// TCP-resets the connection while we read the response. issue #138.
-	std::vector<TdsPacket> login_packets = TdsProtocol::SplitIntoPackets(login, login7_fragment_size);
-	MSSQL_CONN_DEBUG_LOG(1, "AuthenticateIntegrated: LOGIN7 payload=%zu bytes -> %zu TDS packet(s) (max_packet=%zu)",
-						 login.GetPayload().size(), login_packets.size(), login7_fragment_size);
-	for (size_t i = 0; i < login_packets.size(); i++) {
-		TdsPacket &pkt = login_packets[i];
-		pkt.SetPacketId(next_packet_id_++);
-		if (!socket_->SendPacket(pkt)) {
-			last_error_ = "Failed to send LOGIN7 (integrated) packet " + std::to_string(i + 1) + "/" +
-						  std::to_string(login_packets.size()) + ": " + socket_->GetLastError();
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
+	bool first_attempt = true;
+	const bool ok = RunWithRoutingHops([&]() -> LoginAttemptOutcome {
+		// Step 0: a fresh authenticator for THIS target. On a hop the SPN
+		// follows the routed host (an explicit service_principal_name= override
+		// is honoured verbatim by the strategy factory, so it survives hops).
+		std::shared_ptr<IAuthenticator> authenticator;
+		if (authenticator_factory) {
+			authenticator = authenticator_factory(host_, port_);
 		}
-	}
-
-	// Step 4: Continuation loop on 0xED SSPI tokens.
-	constexpr int MAX_SSPI_ROUNDS = 8;	// SPNEGO with cross-realm trust typically 2-3 rounds
-	for (int round = 0; round < MAX_SSPI_ROUNDS; round++) {
-		std::vector<uint8_t> response;
-		if (!socket_->ReceiveMessage(response, DEFAULT_CONNECTION_TIMEOUT * 1000)) {
-			last_error_ = "Failed to receive LOGIN7 response (integrated): " + socket_->GetLastError();
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
-		}
-
-		LoginResponse login_response = TdsProtocol::ParseLoginResponse(response);
-		NoteFeatureAcks(login_response);
-		if (login_response.success) {
-			spid_ = login_response.spid;
-			negotiated_packet_size_ = login_response.negotiated_packet_size;
-			ApplyNegotiatedFraming();
-			MSSQL_CONN_DEBUG_LOG(1, "AuthenticateIntegrated: success after %d round(s), spid=%d, packet_size=%d",
-								 round + 1, spid_, negotiated_packet_size_);
-			database_ = database;
-			state_.store(ConnectionState::Idle);
-			UpdateLastUsed();
-			authenticator->Free();
-			return true;
-		}
-
-		if (!login_response.has_sspi_token) {
-			// No continuation requested and no LOGINACK -- server rejected the auth.
-			if (login_response.error_number > 0) {
-				last_error_ = "MSSQL Kerberos auth rejected by server (error " +
-							  std::to_string(login_response.error_number) + "): " + login_response.error_message;
-			} else if (!login_response.error_message.empty()) {
-				last_error_ = "MSSQL Kerberos auth rejected: " + login_response.error_message;
+		if (!authenticator) {
+			if (first_attempt) {
+				last_error_ =
+					"MSSQL Error: This build of the mssql extension was compiled without Kerberos / SSPI support. "
+					"Rebuild with -DENABLE_KRB5=ON or use SQL authentication.";
 			} else {
-				last_error_ = "MSSQL Kerberos auth rejected by server (no SSPI token, no LOGINACK)";
+				// A hop-specific failure: the ticket for the routed host could
+				// not be obtained. Name the target so a field report is
+				// diagnosable in one round (the default SPN derivation is
+				// MSSQLSvc/<host>:<port>; an explicit service_principal_name=
+				// overrides it).
+				last_error_ = "MSSQL Kerberos auth failed: could not build an authenticator for routed server " +
+							  host_ + ":" + std::to_string(port_) + " (expected SPN MSSQLSvc/" + host_ + ":" +
+							  std::to_string(port_) + " unless service_principal_name= overrides it)";
 			}
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
+			return LoginAttemptOutcome::Failure;
+		}
+		first_attempt = false;
+
+		// Step 1: PRELOGIN (encryption only; integrated auth does NOT set FEDAUTHREQUIRED)
+		if (!DoPrelogin(use_encrypt)) {
+			return LoginAttemptOutcome::Failure;
 		}
 
-		// Continue the SPNEGO negotiation.
-		std::vector<uint8_t> next_blob;
+		// Step 2: Initial SPNEGO blob from the authenticator.
+		std::vector<uint8_t> initial_blob;
 		try {
-			next_blob = authenticator->NextBytes(login_response.sspi_token);
+			initial_blob = authenticator->InitialBytes();
 		} catch (const std::exception &e) {
-			// Authenticator already prefixes; just propagate verbatim.
+			// Authenticator already prefixes with "MSSQL Kerberos auth failed:";
+			// just propagate verbatim to avoid double-prefixing.
 			last_error_ = e.what();
-			state_.store(ConnectionState::Disconnected);
-			socket_->Close();
-			return false;
+			return LoginAttemptOutcome::Failure;
+		}
+		if (initial_blob.empty()) {
+			last_error_ = "MSSQL Kerberos auth failed: authenticator returned empty initial SPNEGO blob";
+			return LoginAttemptOutcome::Failure;
 		}
 
-		if (next_blob.empty()) {
-			// SPNEGO complete on our side but server hasn't sent LOGINACK yet --
-			// just read the next message in the next loop iteration.
-			MSSQL_CONN_DEBUG_LOG(2, "AuthenticateIntegrated: round %d -- authenticator complete, awaiting LOGINACK",
-								 round + 1);
-			continue;
-		}
+		// Step 3: LOGIN7 with SSPI field populated. The HostName field is the
+		// CLIENT workstation name (per [MS-TDS] 2.2.6.4 -- surfaces in
+		// sys.dm_exec_sessions.host_name, sp_who, audit logs); the ServerName
+		// field is the destination. Passing host_ (the destination) into both
+		// positions makes DBA tooling see every connection as if the server were
+		// connecting to itself. spec 042 ultrareview bug_029.
+		const std::string client_hostname = GetClientHostname();
+		MSSQL_CONN_DEBUG_LOG(
+			1, "AuthenticateIntegrated: sending LOGIN7 with SSPI blob (%zu bytes), client_host='%s', db='%s'",
+			initial_blob.size(), client_hostname.c_str(), database.c_str());
+		// Spec 047 FR-014: LOGIN7 program_name from caller (already clamped). Empty
+		// preserves the prior extension default.
+		const std::string login7_app_name = app_name.empty() ? "DuckDB MSSQL Extension" : app_name;
+		TdsPacket login = TdsProtocol::BuildLogin7WithSSPI(
+			client_hostname, tds_server_name_.empty() ? host_ : tds_server_name_, database, initial_blob,
+			login7_app_name, requested_packet_size_, request_utf8_support_);
 
-		MSSQL_CONN_DEBUG_LOG(2, "AuthenticateIntegrated: round %d -- sending continuation blob (%zu bytes)", round + 1,
-							 next_blob.size());
-		// Continuation tokens are usually small, but fragment defensively to the
-		// same boundary as the initial LOGIN7 for the same reason (#138).
-		TdsPacket sspi_msg = TdsProtocol::BuildSSPIMessage(next_blob);
-		std::vector<TdsPacket> sspi_packets = TdsProtocol::SplitIntoPackets(sspi_msg, login7_fragment_size);
-		for (size_t i = 0; i < sspi_packets.size(); i++) {
-			TdsPacket &pkt = sspi_packets[i];
+		// A Kerberos LOGIN7 carrying a real Active Directory PAC routinely exceeds
+		// the 4096-byte pre-negotiation packet size. LOGIN7 is sent before
+		// packet-size negotiation completes, so it MUST be fragmented to the default
+		// packet size with EOM on the last packet only -- otherwise SQL Server
+		// TCP-resets the connection while we read the response. issue #138.
+		std::vector<TdsPacket> login_packets = TdsProtocol::SplitIntoPackets(login, login7_fragment_size);
+		MSSQL_CONN_DEBUG_LOG(1,
+							 "AuthenticateIntegrated: LOGIN7 payload=%zu bytes -> %zu TDS packet(s) (max_packet=%zu)",
+							 login.GetPayload().size(), login_packets.size(), login7_fragment_size);
+		for (size_t i = 0; i < login_packets.size(); i++) {
+			TdsPacket &pkt = login_packets[i];
 			pkt.SetPacketId(next_packet_id_++);
 			if (!socket_->SendPacket(pkt)) {
-				last_error_ = "Failed to send SSPI continuation packet " + std::to_string(i + 1) + "/" +
-							  std::to_string(sspi_packets.size()) + ": " + socket_->GetLastError();
-				state_.store(ConnectionState::Disconnected);
-				socket_->Close();
-				return false;
+				last_error_ = "Failed to send LOGIN7 (integrated) packet " + std::to_string(i + 1) + "/" +
+							  std::to_string(login_packets.size()) + ": " + socket_->GetLastError();
+				return LoginAttemptOutcome::Failure;
 			}
 		}
+
+		// Step 4: Continuation loop on 0xED SSPI tokens.
+		constexpr int MAX_SSPI_ROUNDS = 8;	// SPNEGO with cross-realm trust typically 2-3 rounds
+		for (int round = 0; round < MAX_SSPI_ROUNDS; round++) {
+			std::vector<uint8_t> response;
+			if (!socket_->ReceiveMessage(response, DEFAULT_CONNECTION_TIMEOUT * 1000)) {
+				last_error_ = "Failed to receive LOGIN7 response (integrated): " + socket_->GetLastError();
+				return LoginAttemptOutcome::Failure;
+			}
+
+			LoginResponse login_response = TdsProtocol::ParseLoginResponse(response);
+			NoteFeatureAcks(login_response);
+
+			// Routing outranks BOTH the success branch and the no-SSPI-token
+			// rejection below (spec 068 D1). A routed answer can arrive at any
+			// round, and one without an SSPI token would otherwise be reported
+			// as "auth rejected by server (no SSPI token, no LOGINACK)".
+			if (login_response.has_routing) {
+				has_routing_ = true;
+				routed_server_ = login_response.routed_server;
+				routed_port_ = login_response.routed_port;
+				MSSQL_CONN_DEBUG_LOG(1, "AuthenticateIntegrated: ROUTING requested to %s:%d (loginack=%d)",
+									 routed_server_.c_str(), routed_port_, login_response.success ? 1 : 0);
+				// Release this hop's GSSAPI/SSPI context before the next hop
+				// builds its own -- otherwise every hop leaks one.
+				authenticator->Free();
+				return LoginAttemptOutcome::Route;
+			}
+
+			if (login_response.success) {
+				spid_ = login_response.spid;
+				negotiated_packet_size_ = login_response.negotiated_packet_size;
+				ApplyNegotiatedFraming();
+				MSSQL_CONN_DEBUG_LOG(1, "AuthenticateIntegrated: success after %d round(s), spid=%d, packet_size=%d",
+									 round + 1, spid_, negotiated_packet_size_);
+				authenticator->Free();
+				return LoginAttemptOutcome::Success;
+			}
+
+			if (!login_response.has_sspi_token) {
+				// No continuation requested and no LOGINACK -- server rejected the auth.
+				if (login_response.error_number > 0) {
+					last_error_ = "MSSQL Kerberos auth rejected by server (error " +
+								  std::to_string(login_response.error_number) + "): " + login_response.error_message;
+				} else if (!login_response.error_message.empty()) {
+					last_error_ = "MSSQL Kerberos auth rejected: " + login_response.error_message;
+				} else {
+					last_error_ = "MSSQL Kerberos auth rejected by server (no SSPI token, no LOGINACK)";
+				}
+				return LoginAttemptOutcome::Failure;
+			}
+
+			// Continue the SPNEGO negotiation.
+			std::vector<uint8_t> next_blob;
+			try {
+				next_blob = authenticator->NextBytes(login_response.sspi_token);
+			} catch (const std::exception &e) {
+				// Authenticator already prefixes; just propagate verbatim.
+				last_error_ = e.what();
+				return LoginAttemptOutcome::Failure;
+			}
+
+			if (next_blob.empty()) {
+				// SPNEGO complete on our side but server hasn't sent LOGINACK yet --
+				// just read the next message in the next loop iteration.
+				MSSQL_CONN_DEBUG_LOG(2, "AuthenticateIntegrated: round %d -- authenticator complete, awaiting LOGINACK",
+									 round + 1);
+				continue;
+			}
+
+			MSSQL_CONN_DEBUG_LOG(2, "AuthenticateIntegrated: round %d -- sending continuation blob (%zu bytes)",
+								 round + 1, next_blob.size());
+			// Continuation tokens are usually small, but fragment defensively to the
+			// same boundary as the initial LOGIN7 for the same reason (#138).
+			TdsPacket sspi_msg = TdsProtocol::BuildSSPIMessage(next_blob);
+			std::vector<TdsPacket> sspi_packets = TdsProtocol::SplitIntoPackets(sspi_msg, login7_fragment_size);
+			for (size_t i = 0; i < sspi_packets.size(); i++) {
+				TdsPacket &pkt = sspi_packets[i];
+				pkt.SetPacketId(next_packet_id_++);
+				if (!socket_->SendPacket(pkt)) {
+					last_error_ = "Failed to send SSPI continuation packet " + std::to_string(i + 1) + "/" +
+								  std::to_string(sspi_packets.size()) + ": " + socket_->GetLastError();
+					return LoginAttemptOutcome::Failure;
+				}
+			}
+		}
+
+		last_error_ = "MSSQL Kerberos auth failed: SPNEGO did not converge in " + std::to_string(MAX_SSPI_ROUNDS) +
+					  " rounds (possible cross-realm misconfiguration)";
+		return LoginAttemptOutcome::Failure;
+	});
+	if (!ok) {
+		return false;
 	}
 
-	last_error_ = "MSSQL Kerberos auth failed: SPNEGO did not converge in " + std::to_string(MAX_SSPI_ROUNDS) +
-				  " rounds (possible cross-realm misconfiguration)";
-	state_.store(ConnectionState::Disconnected);
-	socket_->Close();
-	return false;
+	database_ = database;
+	UpdateLastUsed();
+	return true;
 }
 
-bool TdsConnection::DoLogin7(const std::string &username, const std::string &password, const std::string &database,
-							 const std::string &app_name) {
+LoginAttemptOutcome TdsConnection::DoLogin7(const std::string &username, const std::string &password,
+											const std::string &database, const std::string &app_name) {
 	MSSQL_CONN_DEBUG_LOG(1, "DoLogin7: starting authentication for user='%s', db='%s'", username.c_str(),
 						 database.c_str());
 	// Spec 047 FR-014: LOGIN7 program_name from caller (already clamped). Empty
 	// preserves the prior extension default.
 	const std::string login7_app_name = app_name.empty() ? "DuckDB MSSQL Extension" : app_name;
+	// ServerName: tds_server_name_ when set, which is what a routing hop leaves
+	// behind -- "hostname\instance", the form [MS-TDS] wants in this field.
+	// host_ is the instance-STRIPPED name used for DNS/TCP, so passing it here
+	// (as this did before spec 068) sends the wrong ServerName after a hop to a
+	// named instance. On a first attempt the driver sets tds_server_name_ =
+	// host_, so a non-routed login is byte-identical to the pre-068 packet.
+	const std::string &server_name = tds_server_name_.empty() ? host_ : tds_server_name_;
 	// Request our configured frame size. The server answers with
 	// min(requested, its own maximum) via the PACKETSIZE ENVCHANGE — it never
 	// raises the value on its own, so asking for the 4096 default (as this did
 	// unconditionally before spec 055) pinned every packet in both directions
 	// at 4096 for the life of the connection.
-	TdsPacket login = TdsProtocol::BuildLogin7(host_, username, password, database, login7_app_name,
+	TdsPacket login = TdsProtocol::BuildLogin7(server_name, username, password, database, login7_app_name,
 											   requested_packet_size_, request_utf8_support_);
 	login.SetPacketId(next_packet_id_++);
 
 	if (!socket_->SendPacket(login)) {
 		last_error_ = "Failed to send LOGIN7: " + socket_->GetLastError();
-		return false;
+		return LoginAttemptOutcome::Failure;
 	}
 
 	std::vector<uint8_t> response;
 	if (!socket_->ReceiveMessage(response, DEFAULT_CONNECTION_TIMEOUT * 1000)) {
 		last_error_ = "Failed to receive LOGIN7 response: " + socket_->GetLastError();
-		return false;
+		return LoginAttemptOutcome::Failure;
 	}
 
 	// Debug dump of the login response, mirroring DoLogin7WithFedAuth. The
@@ -875,6 +972,22 @@ bool TdsConnection::DoLogin7(const std::string &username, const std::string &pas
 
 	LoginResponse login_response = TdsProtocol::ParseLoginResponse(response);
 	NoteFeatureAcks(login_response);
+
+	// Routing outranks success (spec 068 D1). Azure SQL under the Redirect
+	// connection policy, Azure SQL Managed Instance and AlwaysOn read-intent
+	// routing all answer a SQL-auth LOGIN7 with ENVCHANGE 20 -- with or without
+	// a LOGINACK beside it. Before spec 068 this code never read the routing
+	// fields at all: the with-LOGINACK shape "succeeded" against the gateway,
+	// silently, and the without-LOGINACK shape failed as a login error.
+	if (login_response.has_routing) {
+		has_routing_ = true;
+		routed_server_ = login_response.routed_server;
+		routed_port_ = login_response.routed_port;
+		MSSQL_CONN_DEBUG_LOG(1, "DoLogin7: ROUTING requested to %s:%d (loginack=%d)", routed_server_.c_str(),
+							 routed_port_, login_response.success ? 1 : 0);
+		return LoginAttemptOutcome::Route;
+	}
+
 	if (!login_response.success) {
 		if (login_response.error_number > 0) {
 			// Include the ERROR-token State byte: for 18456 it is the only field
@@ -885,7 +998,7 @@ bool TdsConnection::DoLogin7(const std::string &username, const std::string &pas
 		} else {
 			last_error_ = "Authentication failed: " + login_response.error_message;
 		}
-		return false;
+		return LoginAttemptOutcome::Failure;
 	}
 
 	spid_ = login_response.spid;
@@ -895,7 +1008,7 @@ bool TdsConnection::DoLogin7(const std::string &username, const std::string &pas
 	MSSQL_CONN_DEBUG_LOG(1, "DoLogin7: authentication successful, spid=%d, packet_size=%d", spid_,
 						 negotiated_packet_size_);
 
-	return true;
+	return LoginAttemptOutcome::Success;
 }
 
 void TdsConnection::ApplyNegotiatedFraming() {

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -81,6 +81,14 @@ TdsConnection::~TdsConnection() noexcept {
 	}
 }
 
+// NOTE: these move operations carry most, but not all, of the object. Several
+// members predating spec 068 -- requested_packet_size_, request_utf8_support_,
+// needs_reset_, fedauth_echo_, tds_server_name_ -- are not carried, and that is
+// an omission rather than a decision. Nothing moves a TdsConnection today (the
+// pool holds shared_ptr and the stack-local ones in mssql_storage.cpp are never
+// moved), which is why it has stayed harmless. connect_timeout_seconds_ IS
+// carried: it is a policy the caller asked for, and dropping it would silently
+// restore the compiled-in default for any later hop.
 TdsConnection::TdsConnection(TdsConnection &&other) noexcept
 	: socket_(std::move(other.socket_)),
 	  state_(other.state_.load()),
@@ -93,6 +101,7 @@ TdsConnection::TdsConnection(TdsConnection &&other) noexcept
 	  last_error_(std::move(other.last_error_)),
 	  tls_enabled_(other.tls_enabled_),
 	  next_packet_id_(other.next_packet_id_),
+	  connect_timeout_seconds_(other.connect_timeout_seconds_),
 	  negotiated_packet_size_(other.negotiated_packet_size_) {
 	other.state_.store(ConnectionState::Disconnected);
 	other.spid_ = 0;
@@ -114,6 +123,7 @@ TdsConnection &TdsConnection::operator=(TdsConnection &&other) noexcept {
 		last_error_ = std::move(other.last_error_);
 		tls_enabled_ = other.tls_enabled_;
 		next_packet_id_ = other.next_packet_id_;
+		connect_timeout_seconds_ = other.connect_timeout_seconds_;
 		negotiated_packet_size_ = other.negotiated_packet_size_;
 
 		other.state_.store(ConnectionState::Disconnected);

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -179,6 +179,10 @@ bool TdsConnection::Authenticate(const std::string &username, const std::string 
 		return DoLogin7(username, password, database, app_name);
 	});
 	if (!ok) {
+		// The login failed, so this connection is not "in" any database. Leaving
+		// the attempted name behind would weaken GetDatabase() from "the database
+		// this connection is logged into" to "the last one tried".
+		database_.clear();
 		return false;
 	}
 
@@ -439,6 +443,10 @@ bool TdsConnection::AuthenticateWithFedAuth(const std::string &database, const s
 		return DoLogin7WithFedAuth(database, fedauth_token, app_name);
 	});
 	if (!ok) {
+		// The login failed, so this connection is not "in" any database. Leaving
+		// the attempted name behind would weaken GetDatabase() from "the database
+		// this connection is logged into" to "the last one tried".
+		database_.clear();
 		return false;
 	}
 
@@ -924,6 +932,10 @@ bool TdsConnection::AuthenticateIntegrated(const std::string &database, Authenti
 		return LoginAttemptOutcome::Failure;
 	});
 	if (!ok) {
+		// The login failed, so this connection is not "in" any database. Leaving
+		// the attempted name behind would weaken GetDatabase() from "the database
+		// this connection is logged into" to "the last one tried".
+		database_.clear();
 		return false;
 	}
 
@@ -948,14 +960,18 @@ LoginAttemptOutcome TdsConnection::DoLogin7(const std::string &username, const s
 	// routed named instance received the wrong ServerName. On a first attempt
 	// the driver sets tds_server_name_ = host_, leaving a non-routed login
 	// byte-identical to the pre-068 packet.
-	const std::string &server_name = tds_server_name_.empty() ? host_ : tds_server_name_;
+	//
+	// tds_server_name_ is passed RAW: an empty one means "mirror host", and
+	// that rule lives in BuildLogin7 alone. Re-applying it here as well would
+	// put the same fallback in two places, free to disagree the moment a caller
+	// passes a `host` that is not host_.
 	// Request our configured frame size. The server answers with
 	// min(requested, its own maximum) via the PACKETSIZE ENVCHANGE — it never
 	// raises the value on its own, so asking for the 4096 default (as this did
 	// unconditionally before spec 055) pinned every packet in both directions
 	// at 4096 for the life of the connection.
 	TdsPacket login = TdsProtocol::BuildLogin7(host_, username, password, database, login7_app_name,
-											   requested_packet_size_, request_utf8_support_, server_name);
+											   requested_packet_size_, request_utf8_support_, tds_server_name_);
 	login.SetPacketId(next_packet_id_++);
 
 	if (!socket_->SendPacket(login)) {

--- a/src/tds/tds_protocol.cpp
+++ b/src/tds/tds_protocol.cpp
@@ -229,7 +229,7 @@ static void AppendUtf8SupportFeature(TdsPacket &packet) {
 
 TdsPacket TdsProtocol::BuildLogin7(const std::string &host, const std::string &username, const std::string &password,
 								   const std::string &database, const std::string &app_name, uint32_t packet_size,
-								   bool request_utf8_support) {
+								   bool request_utf8_support, const std::string &server_name) {
 	TdsPacket packet(PacketType::LOGIN7);
 
 	// LOGIN7 fixed header is 94 bytes; variable-length strings follow.
@@ -244,7 +244,14 @@ TdsPacket TdsProtocol::BuildLogin7(const std::string &host, const std::string &u
 	Login7VarField field_username = EncodeLogin7VarField("UserName", username, var_offset);
 	Login7VarField field_password = EncodeLogin7VarField("Password", password, var_offset, /*obfuscate_password=*/true);
 	Login7VarField field_appname = EncodeLogin7VarField("AppName", app_name, var_offset);
-	Login7VarField field_servername = EncodeLogin7VarField("ServerName", host, var_offset);	 // ServerName mirrors host
+	// ServerName mirrors host unless the caller supplies one explicitly, which
+	// is what a routing hop does: the routed target keeps "\\instance" here but
+	// is stripped for DNS/TCP, so host and ServerName stop being the same
+	// string (spec 068). HostName above is deliberately left alone -- it is a
+	// separate field with a separate meaning and changing it is not this
+	// change's business.
+	Login7VarField field_servername =
+		EncodeLogin7VarField("ServerName", server_name.empty() ? host : server_name, var_offset);
 
 	// Unused / extension / CltIntName / Language all have length 0 and share
 	// the current cumulative offset (per MS-TDS §2.2.6.4 zero-length fields

--- a/test/cpp/test_login_error_state.cpp
+++ b/test/cpp/test_login_error_state.cpp
@@ -140,6 +140,28 @@ void AppendLoginAckToken(std::vector<uint8_t> &buf) {
 	buf.insert(buf.end(), body.begin(), body.end());
 }
 
+// ROUTING ENVCHANGE (type 20 / 0x14) per [MS-TDS] 2.2.7.13. Layout inside the
+// ENVCHANGE token: Type(1) NewValueLen(2, LE) Protocol(1, 0=TCP)
+// Port(2, LE) AltServerLen(2, LE, in CHARACTERS) AltServer(UTF-16LE)
+// OldValue(2, always 0). Spec 068.
+void AppendRoutingEnvChange(std::vector<uint8_t> &buf, const std::string &server, uint16_t port) {
+	std::vector<uint8_t> routing;
+	routing.push_back(0x00);									 // Protocol: TCP
+	AppendU16LE(routing, port);									 // ProtocolProperty: port
+	AppendU16LE(routing, static_cast<uint16_t>(server.size()));	 // AltServer length in chars
+	AppendUtf16LE(routing, server);
+
+	std::vector<uint8_t> body;
+	body.push_back(20);										   // ENVCHANGE type 20 = ROUTING
+	AppendU16LE(body, static_cast<uint16_t>(routing.size()));  // NewValue length
+	body.insert(body.end(), routing.begin(), routing.end());
+	AppendU16LE(body, 0);  // OldValue length = 0
+
+	buf.push_back(static_cast<uint8_t>(TokenType::ENVCHANGE));
+	AppendU16LE(buf, static_cast<uint16_t>(body.size()));
+	buf.insert(buf.end(), body.begin(), body.end());
+}
+
 //===----------------------------------------------------------------------===//
 // Tests
 //===----------------------------------------------------------------------===//
@@ -465,6 +487,89 @@ void TestTruncatedDoneDoesNotOverread() {
 
 }  // namespace
 
+//===----------------------------------------------------------------------===//
+// Spec 068 -- login-time routing (ENVCHANGE 20)
+//
+// The parser half of the contract: `has_routing` must be reported independently
+// of `success`, because the connection layer now treats routing as outranking
+// both. The two shapes below are the two the connection layer used to get
+// wrong in opposite directions.
+//===----------------------------------------------------------------------===//
+
+// Shape 1 -- ROUTING alongside a LOGINACK. This is what the Azure gateways we
+// have actually met send. The parser must report BOTH; the connection layer
+// then hops rather than transacting against the gateway.
+void TestRoutingWithLoginAck() {
+	std::vector<uint8_t> stream;
+	AppendLoginAckToken(stream);
+	AppendRoutingEnvChange(stream, "routed.database.windows.net", 11003);
+	AppendDoneFamilyToken(stream, TokenType::DONE, 0x0000, 0x0000, 0);
+
+	LoginResponse resp = TdsProtocol::ParseLoginResponse(stream);
+
+	CHECK(resp.success == true);	  // LOGINACK was there...
+	CHECK(resp.has_routing == true);  // ...and so was the redirect
+	CHECK(resp.routed_server == "routed.database.windows.net");
+	CHECK(resp.routed_port == 11003);
+	std::cout << "  [ok] ROUTING + LOGINACK reports both success and has_routing (spec 068 D1)" << std::endl;
+}
+
+// Shape 2 -- ROUTING with NO LOGINACK: legal per [MS-TDS], and the shape that
+// used to die as "authentication failed" on the FEDAUTH path because the
+// !success return came before the routing capture (spec 068 Gap 1).
+void TestRoutingWithoutLoginAck() {
+	std::vector<uint8_t> stream;
+	AppendRoutingEnvChange(stream, "routed.database.windows.net", 11003);
+	AppendDoneFamilyToken(stream, TokenType::DONE, 0x0000, 0x0000, 0);
+
+	LoginResponse resp = TdsProtocol::ParseLoginResponse(stream);
+
+	CHECK(resp.success == false);	  // no LOGINACK on this socket...
+	CHECK(resp.has_routing == true);  // ...but the redirect is still there
+	CHECK(resp.routed_server == "routed.database.windows.net");
+	CHECK(resp.routed_port == 11003);
+	CHECK(resp.error_number == 0);	// and it is NOT an error
+	std::cout << "  [ok] ROUTING without LOGINACK still reports has_routing (spec 068 Gap 1)" << std::endl;
+}
+
+// The routed target may carry an instance name and a port suffix -- Fabric
+// sends "hostname\INSTANCE:port". The parser hands the string over verbatim;
+// splitting it is NormalizeRoutedTarget's job. Pins that the UTF-16LE decode
+// keeps the backslash and the colon intact.
+void TestRoutedTargetWithInstanceAndPortSurvivesDecode() {
+	std::vector<uint8_t> stream;
+	AppendRoutingEnvChange(stream, "host.pbidedicated.windows.net\\INST01:1433", 1433);
+	AppendDoneFamilyToken(stream, TokenType::DONE, 0x0000, 0x0000, 0);
+
+	LoginResponse resp = TdsProtocol::ParseLoginResponse(stream);
+
+	CHECK(resp.has_routing == true);
+	CHECK(resp.routed_server == "host.pbidedicated.windows.net\\INST01:1433");
+	std::cout << "  [ok] routed target keeps instance + port suffix through the UTF-16 decode" << std::endl;
+}
+
+// Composition with PR #254: a Synapse-style DONEINPROC run ahead of the real
+// tokens. #254 fixed the 12-byte TDS 7.2+ DONE body size; if that regressed,
+// the walk would desync and never reach the ROUTING behind it. This is the
+// shape a routing Synapse Serverless endpoint would send.
+void TestRoutingBehindDoneInProcRun() {
+	std::vector<uint8_t> stream;
+	for (int i = 0; i < 3; i++) {
+		AppendDoneFamilyToken(stream, TokenType::DONEINPROC, 0x0001 /* DONE_MORE */, 0x00E6, 0);
+	}
+	AppendLoginAckToken(stream);
+	AppendRoutingEnvChange(stream, "routed.sql.azuresynapse.net", 1433);
+	AppendDoneFamilyToken(stream, TokenType::DONE, 0x0000, 0x0000, 0);
+
+	LoginResponse resp = TdsProtocol::ParseLoginResponse(stream);
+
+	CHECK(resp.success == true);
+	CHECK(resp.has_routing == true);
+	CHECK(resp.routed_server == "routed.sql.azuresynapse.net");
+	CHECK(resp.routed_port == 1433);
+	std::cout << "  [ok] ROUTING behind a DONEINPROC run still parsed (composition with #254)" << std::endl;
+}
+
 int main() {
 	std::cout << "test_login_error_state (issue #164: capture 18456 State byte)" << std::endl;
 
@@ -484,6 +589,10 @@ int main() {
 	TestPlainDoneBeforeLoginAck();
 	TestDoneExactlyAtBufferEnd();
 	TestTruncatedDoneDoesNotOverread();
+	TestRoutingWithLoginAck();
+	TestRoutingWithoutLoginAck();
+	TestRoutedTargetWithInstanceAndPortSurvivesDecode();
+	TestRoutingBehindDoneInProcRun();
 
 	std::cout << "All " << g_checks << " checks passed." << std::endl;
 	return 0;

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -542,6 +542,7 @@ void TestZeroHopLoginUnchanged() {
 
 	CHECK(conn.GetState() == ConnectionState::Idle);
 	CHECK(conn.GetPort() == server.GetPort());
+	CHECK(conn.GetDatabase() == "TestDB");	// logged in -> the accessor names the database
 	CHECK(server.ConnectionCount() == 1);
 	CHECK(server.FirstPacketIds().size() == 1);
 	CHECK(server.FirstPacketIds()[0] == 1);
@@ -627,6 +628,9 @@ void TestHopLimitAborts() {
 	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false) == false);
 
 	CHECK(conn.GetState() == ConnectionState::Disconnected);
+	// ...and the connection is not "in" any database: GetDatabase() means the
+	// database this connection is logged INTO, not the last one attempted.
+	CHECK(conn.GetDatabase().empty());
 	const std::string err = conn.GetLastError();
 	CHECK(err.find("Too many routing hops") != std::string::npos);
 	CHECK(err.find("127.0.0.1") != std::string::npos);	// last routed target named

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -35,6 +35,7 @@
 //       -lsimdutf -lssl -lcrypto -o build/test/test_login_routing_hops
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -484,10 +485,10 @@ std::vector<uint8_t> LoginAckStream() {
 	return s;
 }
 
-std::vector<uint8_t> RouteWithLoginAckStream(uint16_t port) {
+std::vector<uint8_t> RouteWithLoginAckStream(uint16_t port, const std::string &host = "127.0.0.1") {
 	std::vector<uint8_t> s;
 	AppendLoginAck(s);
-	AppendRoutingEnvChange(s, "127.0.0.1", port);
+	AppendRoutingEnvChange(s, host, port);
 	AppendDone(s);
 	return s;
 }
@@ -736,13 +737,26 @@ void TestRoutedTargetWithInstanceAndPortSuffix() {
 // the timeout instead, but DEFAULT_CONNECTION_TIMEOUT is compiled in at 30s
 // here, which is not a unit test.
 void TestUnreachableRoutedTargetFails() {
+	// Take a listener's port and stop it, so the port is genuinely closed and
+	// the connect is REFUSED immediately.
+	//
+	// The tempting alternative -- keep a socket bound but never listen(), so the
+	// port cannot be reassigned -- is wrong on macOS: measured here, connecting
+	// to a bound-but-unlistening 127.0.0.1 port does NOT get an RST, the SYN is
+	// dropped and connect() sits for ~7.8s. That is a Linux behaviour, not a
+	// portable one. So the port is freed, and the premise the test rests on
+	// ("nothing is listening there") is enforced by assertion instead: if the
+	// kernel handed the gateway that same port, the gateway would route to
+	// itself and this would fail with the hop-limit message, pointing at the
+	// wrong code.
 	uint16_t dead_port = 0;
 	{
 		FakeTdsServer doomed([](int) { return LoginAckStream(); });
 		dead_port = doomed.GetPort();
-		doomed.Stop();	// nothing listens there now
+		doomed.Stop();
 	}
 	FakeTdsServer gateway([dead_port](int) { return RouteWithLoginAckStream(dead_port); });
+	CHECK(gateway.GetPort() != dead_port);	// the premise, enforced
 
 	TdsConnection conn;
 	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
@@ -760,6 +774,34 @@ void TestUnreachableRoutedTargetFails() {
 
 	gateway.Stop();
 	std::cout << "  [ok] an unreachable routed target fails with the routed address named" << std::endl;
+}
+
+// The caller's connect timeout must apply to the HOP, not just the first dial.
+// Connect() used to take timeout_seconds, use it once and forget it, so a hop
+// always reconnected on the compiled-in 30s default -- a user asking for 5s and
+// routed to a black-holed replica waited 30s per hop, up to five times.
+//
+// 192.0.2.1 is TEST-NET-1 (RFC 5737): reserved for documentation, so it is
+// never a real host. What the network does with it varies -- a SYN that gets
+// dropped exercises the timeout, an ICMP unreachable comes back immediately --
+// so this asserts a generous upper bound rather than a precise duration. It
+// discriminates the fix wherever packets are dropped (30s -> ~2s) and merely
+// passes cheaply where they are rejected outright.
+void TestHopHonoursCallerConnectTimeout() {
+	FakeTdsServer gateway([](int) { return RouteWithLoginAckStream(1433, "192.0.2.1"); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), /*timeout_seconds=*/2));
+	const auto started = std::chrono::steady_clock::now();
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false) == false);
+	const auto elapsed = std::chrono::steady_clock::now() - started;
+
+	CHECK(conn.GetLastError().find("Failed to connect to routed server") != std::string::npos);
+	const auto secs = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+	CHECK(secs < 15);  // the old behaviour would sit here for DEFAULT_CONNECTION_TIMEOUT
+	gateway.Stop();
+	std::cout << "  [ok] a hop reconnects on the caller's timeout, not the compiled-in default (" << secs << "s)"
+			  << std::endl;
 }
 
 // D3: the integrated path takes a FACTORY, and a hop re-invokes it with the
@@ -863,6 +905,7 @@ int main() {
 	TestReusedConnectionRestartsPacketSequence();
 	TestRoutedTargetWithInstanceAndPortSuffix();
 	TestUnreachableRoutedTargetFails();
+	TestHopHonoursCallerConnectTimeout();
 	TestHopLimitAborts();
 	TestIntegratedAuthFactoryRebuiltPerHop();
 	TestIntegratedAuthFactoryNullOnHopNamesRoutedHost();

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -1,0 +1,684 @@
+// test/cpp/test_login_routing_hops.cpp
+// Unit tests for login-time routing (ENVCHANGE type 20) -- spec 068.
+//
+// These tests do NOT require a running SQL Server, an Azure subscription or an
+// Active Directory. They stand up a loopback fake TDS server on 127.0.0.1 that
+// speaks exactly three things -- a PRELOGIN response, a LOGIN7 response, and
+// nothing else -- and drive a REAL TdsConnection against it.
+//
+// What they pin (spec 068):
+//   D1: ROUTING outranks success. A routed answer is a hop whether or not a
+//       LOGINACK came with it. Before 068 the FEDAUTH path failed the
+//       no-LOGINACK shape as "authentication failed", and SQL auth silently
+//       "succeeded" against a gateway that had told it to leave.
+//   D2: one hop driver behind all three auth paths, with MAX_ROUTING_HOPS=5,
+//       a full handshake per hop, and a per-hop packet-id reset.
+//   D3: integrated auth takes an authenticator FACTORY, so a hop obtains a
+//       ticket for the routed host's SPN rather than retrying the gateway's.
+//
+// The fake server runs unencrypted (use_encrypt=false), so no TLS keys and no
+// OpenSSL handshake are involved -- OpenSSL is linked only because
+// tds_socket.hpp pulls the TLS context in.
+//
+// Build + run via the Makefile (matches the CI source set exactly):
+//   make test-login-routing-hops
+//
+// Or compile manually (macOS/brew example):
+//   c++ -std=c++17 -pthread -I src/include \
+//       -I/opt/homebrew/opt/simdutf/include -I/opt/homebrew/opt/openssl@3/include \
+//       test/cpp/test_login_routing_hops.cpp \
+//       src/tds/tds_connection.cpp src/tds/tds_socket.cpp \
+//       src/tds/tls/tds_tls_context.cpp src/tds/tls/tds_tls_impl.cpp \
+//       src/tds/tds_packet.cpp src/tds/tds_protocol.cpp src/tds/tds_types.cpp \
+//       src/tds/encoding/utf16.cpp \
+//       -L/opt/homebrew/opt/simdutf/lib -L/opt/homebrew/opt/openssl@3/lib \
+//       -lsimdutf -lssl -lcrypto -o build/test/test_login_routing_hops
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using socket_t = SOCKET;
+#define CLOSE_SOCKET closesocket
+#define INVALID_SOCK INVALID_SOCKET
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using socket_t = int;
+#define CLOSE_SOCKET ::close
+#define INVALID_SOCK (-1)
+#endif
+
+#include "tds/tds_connection.hpp"
+#include "tds/tds_protocol.hpp"
+#include "tds/tds_types.hpp"
+
+using namespace duckdb;
+using namespace duckdb::tds;
+
+namespace {
+
+int g_checks = 0;
+
+#define CHECK(cond)                                                                                             \
+	do {                                                                                                        \
+		g_checks++;                                                                                             \
+		if (!(cond)) {                                                                                          \
+			std::cerr << "ASSERT FAILED: " << #cond << " (" << __FILE__ << ":" << __LINE__ << ")" << std::endl; \
+			std::exit(1);                                                                                       \
+		}                                                                                                       \
+	} while (0)
+
+//===----------------------------------------------------------------------===//
+// Token builders (same wire shapes as test_login_error_state.cpp)
+//===----------------------------------------------------------------------===//
+
+void AppendU16LE(std::vector<uint8_t> &buf, uint16_t v) {
+	buf.push_back(static_cast<uint8_t>(v & 0xFF));
+	buf.push_back(static_cast<uint8_t>((v >> 8) & 0xFF));
+}
+
+void AppendU32LE(std::vector<uint8_t> &buf, uint32_t v) {
+	for (int i = 0; i < 4; i++) {
+		buf.push_back(static_cast<uint8_t>((v >> (i * 8)) & 0xFF));
+	}
+}
+
+void AppendU64LE(std::vector<uint8_t> &buf, uint64_t v) {
+	for (int i = 0; i < 8; i++) {
+		buf.push_back(static_cast<uint8_t>((v >> (i * 8)) & 0xFF));
+	}
+}
+
+void AppendUtf16LE(std::vector<uint8_t> &buf, const std::string &s) {
+	for (char c : s) {
+		buf.push_back(static_cast<uint8_t>(c));
+		buf.push_back(0x00);
+	}
+}
+
+// Minimal successful LOGINACK (interface + TDS 7.4 + empty progname + progver).
+void AppendLoginAck(std::vector<uint8_t> &buf) {
+	std::vector<uint8_t> body;
+	body.push_back(0x01);
+	AppendU32LE(body, 0x74000004);
+	body.push_back(0x00);
+	AppendU32LE(body, 0x00000000);
+	buf.push_back(static_cast<uint8_t>(TokenType::LOGINACK));
+	AppendU16LE(buf, static_cast<uint16_t>(body.size()));
+	buf.insert(buf.end(), body.begin(), body.end());
+}
+
+// Final DONE in the TDS 7.2+ layout: Status(2) CurCmd(2) RowCount(8).
+void AppendDone(std::vector<uint8_t> &buf) {
+	buf.push_back(static_cast<uint8_t>(TokenType::DONE));
+	AppendU16LE(buf, 0x0000);
+	AppendU16LE(buf, 0x0000);
+	AppendU64LE(buf, 0);
+}
+
+// ROUTING ENVCHANGE (type 20) per [MS-TDS] 2.2.7.13.
+void AppendRoutingEnvChange(std::vector<uint8_t> &buf, const std::string &server, uint16_t port) {
+	std::vector<uint8_t> routing;
+	routing.push_back(0x00);  // Protocol: TCP
+	AppendU16LE(routing, port);
+	AppendU16LE(routing, static_cast<uint16_t>(server.size()));	 // length in CHARACTERS
+	AppendUtf16LE(routing, server);
+
+	std::vector<uint8_t> body;
+	body.push_back(20);	 // ENVCHANGE type 20 = ROUTING
+	AppendU16LE(body, static_cast<uint16_t>(routing.size()));
+	body.insert(body.end(), routing.begin(), routing.end());
+	AppendU16LE(body, 0);  // OldValue length
+
+	buf.push_back(static_cast<uint8_t>(TokenType::ENVCHANGE));
+	AppendU16LE(buf, static_cast<uint16_t>(body.size()));
+	buf.insert(buf.end(), body.begin(), body.end());
+}
+
+//===----------------------------------------------------------------------===//
+// Loopback fake TDS server
+//
+// Binds 127.0.0.1:0 (kernel-assigned port, read back with getsockname) so
+// nothing collides with a developer's SQL Server or a parallel CI job. One
+// thread accepts connections in a loop and answers PRELOGIN + LOGIN7 with
+// caller-supplied bytes. Accept and recv both poll with a timeout, so a wiring
+// bug fails the test in seconds instead of hanging the job.
+//===----------------------------------------------------------------------===//
+
+constexpr int POLL_TIMEOUT_MS = 5000;
+
+class FakeTdsServer {
+public:
+	// `login_response` is the token stream sent in answer to LOGIN7. It is a
+	// callback so a scenario can vary its answer per connection (e.g. route on
+	// the first, accept on the second).
+	using LoginResponder = std::function<std::vector<uint8_t>(int connection_index)>;
+
+	explicit FakeTdsServer(LoginResponder responder) : responder_(std::move(responder)) {
+		listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+		if (listen_fd_ == INVALID_SOCK) {
+			std::cerr << "fake server: socket() failed" << std::endl;
+			std::exit(1);
+		}
+		int reuse = 1;
+		::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&reuse), sizeof(reuse));
+
+		sockaddr_in addr = {};
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+		addr.sin_port = 0;	// kernel picks
+		if (::bind(listen_fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+			std::cerr << "fake server: bind() failed" << std::endl;
+			std::exit(1);
+		}
+		if (::listen(listen_fd_, 8) != 0) {
+			std::cerr << "fake server: listen() failed" << std::endl;
+			std::exit(1);
+		}
+		socklen_t len = sizeof(addr);
+		if (::getsockname(listen_fd_, reinterpret_cast<sockaddr *>(&addr), &len) != 0) {
+			std::cerr << "fake server: getsockname() failed" << std::endl;
+			std::exit(1);
+		}
+		port_ = ntohs(addr.sin_port);
+
+		thread_ = std::thread([this]() { Serve(); });
+	}
+
+	~FakeTdsServer() {
+		Stop();
+	}
+
+	void Stop() {
+		if (stopped_) {
+			return;
+		}
+		stopped_ = true;
+		running_ = false;
+		if (thread_.joinable()) {
+			thread_.join();
+		}
+		if (listen_fd_ != INVALID_SOCK) {
+			CLOSE_SOCKET(listen_fd_);
+			listen_fd_ = INVALID_SOCK;
+		}
+	}
+
+	uint16_t GetPort() const {
+		return port_;
+	}
+	int ConnectionCount() const {
+		return connections_.load();
+	}
+	// Packet id of the FIRST packet of the FIRST message on each connection.
+	// A hop must reset the sequence, so every connection must see 1.
+	const std::vector<int> &FirstPacketIds() const {
+		return first_packet_ids_;
+	}
+
+private:
+	void Serve() {
+		while (running_) {
+			socket_t client = AcceptWithTimeout();
+			if (client == INVALID_SOCK) {
+				continue;
+			}
+			const int index = connections_.fetch_add(1);
+			HandleConnection(client, index);
+			CLOSE_SOCKET(client);
+		}
+	}
+
+	socket_t AcceptWithTimeout() {
+#if defined(_WIN32)
+		fd_set readfds;
+		FD_ZERO(&readfds);
+		FD_SET(listen_fd_, &readfds);
+		timeval tv = {0, 200 * 1000};
+		int rc = ::select(0, &readfds, nullptr, nullptr, &tv);
+		if (rc <= 0) {
+			return INVALID_SOCK;
+		}
+#else
+		pollfd pfd = {};
+		pfd.fd = listen_fd_;
+		pfd.events = POLLIN;
+		int rc = ::poll(&pfd, 1, 200);
+		if (rc <= 0) {
+			return INVALID_SOCK;
+		}
+#endif
+		return ::accept(listen_fd_, nullptr, nullptr);
+	}
+
+	// Read one complete TDS message (packets until the EOM status bit).
+	// Returns false on timeout / peer close. Records the first packet's id.
+	bool ReadMessage(socket_t fd, bool record_first_id) {
+		bool eom = false;
+		bool first = true;
+		while (!eom) {
+			uint8_t header[8];
+			if (!ReadExactly(fd, header, sizeof(header))) {
+				return false;
+			}
+			if (first && record_first_id) {
+				first_packet_ids_.push_back(static_cast<int>(header[6]));
+				first = false;
+			}
+			const uint16_t length = (static_cast<uint16_t>(header[2]) << 8) | header[3];
+			if (length < 8) {
+				return false;
+			}
+			std::vector<uint8_t> payload(length - 8);
+			if (!payload.empty() && !ReadExactly(fd, payload.data(), payload.size())) {
+				return false;
+			}
+			eom = (header[1] & 0x01) != 0;
+		}
+		return true;
+	}
+
+	static bool ReadExactly(socket_t fd, uint8_t *buf, size_t n) {
+		size_t got = 0;
+		while (got < n) {
+#if defined(_WIN32)
+			fd_set readfds;
+			FD_ZERO(&readfds);
+			FD_SET(fd, &readfds);
+			timeval tv = {POLL_TIMEOUT_MS / 1000, 0};
+			if (::select(0, &readfds, nullptr, nullptr, &tv) <= 0) {
+				return false;
+			}
+			int rc = ::recv(fd, reinterpret_cast<char *>(buf + got), static_cast<int>(n - got), 0);
+#else
+			pollfd pfd = {};
+			pfd.fd = fd;
+			pfd.events = POLLIN;
+			if (::poll(&pfd, 1, POLL_TIMEOUT_MS) <= 0) {
+				return false;
+			}
+			ssize_t rc = ::recv(fd, buf + got, n - got, 0);
+#endif
+			if (rc <= 0) {
+				return false;
+			}
+			got += static_cast<size_t>(rc);
+		}
+		return true;
+	}
+
+	static bool SendAll(socket_t fd, const std::vector<uint8_t> &data) {
+		size_t sent = 0;
+		while (sent < data.size()) {
+#if defined(_WIN32)
+			int rc =
+				::send(fd, reinterpret_cast<const char *>(data.data() + sent), static_cast<int>(data.size() - sent), 0);
+#else
+			ssize_t rc = ::send(fd, data.data() + sent, data.size() - sent, 0);
+#endif
+			if (rc <= 0) {
+				return false;
+			}
+			sent += static_cast<size_t>(rc);
+		}
+		return true;
+	}
+
+	// Wrap a payload in one TDS TABULAR_RESULT packet with EOM set.
+	static std::vector<uint8_t> Frame(const std::vector<uint8_t> &payload) {
+		std::vector<uint8_t> out;
+		const uint16_t length = static_cast<uint16_t>(payload.size() + 8);
+		out.push_back(static_cast<uint8_t>(PacketType::TABULAR_RESULT));
+		out.push_back(0x01);  // EOM
+		out.push_back(static_cast<uint8_t>((length >> 8) & 0xFF));
+		out.push_back(static_cast<uint8_t>(length & 0xFF));
+		out.push_back(0x00);  // SPID hi
+		out.push_back(0x00);  // SPID lo
+		out.push_back(0x01);  // packet id
+		out.push_back(0x00);  // window
+		out.insert(out.end(), payload.begin(), payload.end());
+		return out;
+	}
+
+	// PRELOGIN response advertising VERSION + ENCRYPT_NOT_SUP. The client runs
+	// with use_encrypt=false, which accepts anything except ENCRYPT_REQ.
+	static std::vector<uint8_t> BuildPreloginResponse() {
+		// Option headers: VERSION(0), ENCRYPTION(1), TERMINATOR(0xFF).
+		// Offsets are big-endian and relative to the start of the payload.
+		const uint16_t header_size = 5 + 5 + 1;
+		std::vector<uint8_t> out;
+		out.push_back(0x00);  // VERSION
+		out.push_back(static_cast<uint8_t>((header_size >> 8) & 0xFF));
+		out.push_back(static_cast<uint8_t>(header_size & 0xFF));
+		out.push_back(0x00);
+		out.push_back(0x06);  // len 6
+		out.push_back(0x01);  // ENCRYPTION
+		out.push_back(static_cast<uint8_t>(((header_size + 6) >> 8) & 0xFF));
+		out.push_back(static_cast<uint8_t>((header_size + 6) & 0xFF));
+		out.push_back(0x00);
+		out.push_back(0x01);  // len 1
+		out.push_back(0xFF);  // TERMINATOR
+		// VERSION data: 16.0.1000 build, 0 sub-build
+		out.push_back(16);
+		out.push_back(0);
+		out.push_back(0x03);
+		out.push_back(0xE8);
+		out.push_back(0);
+		out.push_back(0);
+		// ENCRYPTION data
+		out.push_back(static_cast<uint8_t>(EncryptionOption::ENCRYPT_NOT_SUP));
+		return out;
+	}
+
+	void HandleConnection(socket_t client, int index) {
+		// 1. PRELOGIN
+		if (!ReadMessage(client, /*record_first_id=*/true)) {
+			return;
+		}
+		if (!SendAll(client, Frame(BuildPreloginResponse()))) {
+			return;
+		}
+		// 2. LOGIN7 -> one answer, then we are done with this connection. The
+		//    integrated scenarios need no SPNEGO round trip: StubAuthenticator
+		//    completes on InitialBytes(), so the server's single answer is the
+		//    LOGINACK (or the ROUTING) the client is waiting for.
+		if (!ReadMessage(client, /*record_first_id=*/false)) {
+			return;
+		}
+		std::vector<uint8_t> answer = responder_(index);
+		if (answer.empty()) {
+			return;
+		}
+		SendAll(client, Frame(answer));
+	}
+
+	LoginResponder responder_;
+	socket_t listen_fd_ = INVALID_SOCK;
+	uint16_t port_ = 0;
+	std::thread thread_;
+	std::atomic<bool> running_{true};
+	bool stopped_ = false;
+	std::atomic<int> connections_{0};
+	std::vector<int> first_packet_ids_;
+};
+
+// Response streams the scenarios reuse.
+std::vector<uint8_t> LoginAckStream() {
+	std::vector<uint8_t> s;
+	AppendLoginAck(s);
+	AppendDone(s);
+	return s;
+}
+
+std::vector<uint8_t> RouteWithLoginAckStream(uint16_t port) {
+	std::vector<uint8_t> s;
+	AppendLoginAck(s);
+	AppendRoutingEnvChange(s, "127.0.0.1", port);
+	AppendDone(s);
+	return s;
+}
+
+std::vector<uint8_t> RouteWithoutLoginAckStream(uint16_t port) {
+	std::vector<uint8_t> s;
+	AppendRoutingEnvChange(s, "127.0.0.1", port);
+	AppendDone(s);
+	return s;
+}
+
+//===----------------------------------------------------------------------===//
+// A stub authenticator: records its lifecycle so the integrated-path tests can
+// assert the factory was re-invoked per hop and the previous context freed.
+//===----------------------------------------------------------------------===//
+
+struct AuthTrace {
+	std::vector<std::pair<std::string, uint16_t>> factory_calls;
+	int frees = 0;
+	int frees_before_second_build = -1;
+};
+
+class StubAuthenticator : public IAuthenticator {
+public:
+	explicit StubAuthenticator(AuthTrace *trace) : trace_(trace) {}
+	std::vector<uint8_t> InitialBytes() override {
+		return {0x60, 0x01, 0x02, 0x03};  // non-empty SPNEGO-shaped blob
+	}
+	std::vector<uint8_t> NextBytes(const std::vector<uint8_t> &) override {
+		return {};	// negotiation complete on our side
+	}
+	void Free() override {
+		trace_->frees++;
+	}
+
+private:
+	AuthTrace *trace_;
+};
+
+//===----------------------------------------------------------------------===//
+// Scenarios
+//===----------------------------------------------------------------------===//
+
+// Baseline: no ROUTING anywhere. Proves the hop driver did not change the
+// zero-hop path when AuthenticateWithFedAuth's loop was extracted into it.
+void TestZeroHopLoginUnchanged() {
+	FakeTdsServer server([](int) { return LoginAckStream(); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+
+	CHECK(conn.GetState() == ConnectionState::Idle);
+	CHECK(conn.GetPort() == server.GetPort());
+	CHECK(server.ConnectionCount() == 1);
+	CHECK(server.FirstPacketIds().size() == 1);
+	CHECK(server.FirstPacketIds()[0] == 1);
+	conn.Close();
+	server.Stop();
+	std::cout << "  [ok] zero-hop login unchanged by the hop driver" << std::endl;
+}
+
+// D1 + Gap 2: SQL auth follows a ROUTING that arrives WITH a LOGINACK.
+// Before spec 068 this "succeeded" against the gateway -- silently.
+void TestSqlAuthSingleHopWithLoginAck() {
+	FakeTdsServer target([](int) { return LoginAckStream(); });
+	const uint16_t target_port = target.GetPort();
+	FakeTdsServer gateway([target_port](int) { return RouteWithLoginAckStream(target_port); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+
+	CHECK(conn.GetState() == ConnectionState::Idle);
+	CHECK(conn.GetPort() == target_port);  // we ended up on the ROUTED server
+	CHECK(conn.GetHost() == "127.0.0.1");
+	CHECK(gateway.ConnectionCount() == 1);
+	CHECK(target.ConnectionCount() == 1);
+	conn.Close();
+	gateway.Stop();
+	target.Stop();
+	std::cout << "  [ok] SQL auth follows ROUTING + LOGINACK to the routed server (spec 068 Gap 2)" << std::endl;
+}
+
+// D1 + Gap 1: the routed answer carries NO LOGINACK. This is the shape that
+// used to abort the login as an authentication failure.
+void TestRouteWithoutLoginAckFollowsHop() {
+	FakeTdsServer target([](int) { return LoginAckStream(); });
+	const uint16_t target_port = target.GetPort();
+	FakeTdsServer gateway([target_port](int) { return RouteWithoutLoginAckStream(target_port); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+
+	CHECK(conn.GetState() == ConnectionState::Idle);
+	CHECK(conn.GetPort() == target_port);
+	conn.Close();
+	gateway.Stop();
+	target.Stop();
+	std::cout << "  [ok] ROUTING without LOGINACK follows the hop instead of failing (spec 068 Gap 1)" << std::endl;
+}
+
+// The per-hop packet-id reset: every new socket must start its sequence at 1.
+// A carried-over id makes SQL Server drop the connection mid-login.
+void TestPerHopPacketIdReset() {
+	FakeTdsServer target([](int) { return LoginAckStream(); });
+	const uint16_t target_port = target.GetPort();
+	FakeTdsServer gateway([target_port](int) { return RouteWithLoginAckStream(target_port); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+
+	CHECK(target.FirstPacketIds().size() == 1);
+	CHECK(target.FirstPacketIds()[0] == 1);	 // the HOP's first packet, not 3 or 4
+	conn.Close();
+	gateway.Stop();
+	target.Stop();
+	std::cout << "  [ok] packet id resets to 1 on the routed connection" << std::endl;
+}
+
+// A server that routes to itself must be stopped by MAX_ROUTING_HOPS, and the
+// error must name both the count and the last routed target so a field report
+// is diagnosable in one round.
+void TestHopLimitAborts() {
+	// The responder reads self_port by reference: it is filled in right after
+	// construction, before the first connection can possibly arrive.
+	uint16_t self_port = 0;
+	FakeTdsServer server([&self_port](int) { return RouteWithLoginAckStream(self_port); });
+	self_port = server.GetPort();
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false) == false);
+
+	CHECK(conn.GetState() == ConnectionState::Disconnected);
+	const std::string err = conn.GetLastError();
+	CHECK(err.find("Too many routing hops") != std::string::npos);
+	CHECK(err.find("127.0.0.1") != std::string::npos);	// last routed target named
+	// 1 initial login + MAX_ROUTING_HOPS(5) hops = 6 connections, then abort.
+	CHECK(server.ConnectionCount() == 6);
+	server.Stop();
+	std::cout << "  [ok] hop limit aborts after 5 hops, naming count + last target" << std::endl;
+}
+
+// D3: the integrated path takes a FACTORY, and a hop re-invokes it with the
+// ROUTED host/port -- that is what makes the Kerberos/SSPI ticket match the
+// routed server's SPN instead of the gateway's.
+void TestIntegratedAuthFactoryRebuiltPerHop() {
+	FakeTdsServer target([](int) { return LoginAckStream(); });
+	const uint16_t target_port = target.GetPort();
+	FakeTdsServer gateway([target_port](int) { return RouteWithLoginAckStream(target_port); });
+
+	AuthTrace trace;
+	auto factory = [&trace](const std::string &host, uint16_t port) -> std::shared_ptr<IAuthenticator> {
+		if (trace.factory_calls.size() == 1) {
+			// About to build the SECOND authenticator: how many Free()s so far?
+			trace.frees_before_second_build = trace.frees;
+		}
+		trace.factory_calls.emplace_back(host, port);
+		return std::make_shared<StubAuthenticator>(&trace);
+	};
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.AuthenticateIntegrated("TestDB", factory, /*use_encrypt=*/false));
+
+	CHECK(conn.GetState() == ConnectionState::Idle);
+	CHECK(trace.factory_calls.size() == 2);						// gateway, then routed server
+	CHECK(trace.factory_calls[0].second == gateway.GetPort());	// first attempt: the gateway
+	CHECK(trace.factory_calls[1].second == target_port);		// hop: the ROUTED target
+	CHECK(trace.factory_calls[1].first == "127.0.0.1");
+	// The gateway's context must be released before the hop's is built,
+	// otherwise every hop leaks a GSSAPI/SSPI context.
+	CHECK(trace.frees_before_second_build == 1);
+	conn.Close();
+	gateway.Stop();
+	target.Stop();
+	std::cout << "  [ok] integrated auth rebuilds the authenticator for the routed host, freeing the old one"
+			  << std::endl;
+}
+
+// A factory that cannot produce a ticket for the ROUTED host must fail with an
+// error naming that host -- the spec's mitigation for shipping the SPN-over-hop
+// design without a live AD + routing environment to verify it against.
+void TestIntegratedAuthFactoryNullOnHopNamesRoutedHost() {
+	FakeTdsServer target([](int) { return LoginAckStream(); });
+	const uint16_t target_port = target.GetPort();
+	FakeTdsServer gateway([target_port](int) { return RouteWithLoginAckStream(target_port); });
+
+	AuthTrace trace;
+	auto factory = [&trace](const std::string &host, uint16_t port) -> std::shared_ptr<IAuthenticator> {
+		trace.factory_calls.emplace_back(host, port);
+		if (trace.factory_calls.size() == 1) {
+			return std::make_shared<StubAuthenticator>(&trace);
+		}
+		return nullptr;	 // no ticket for the routed host
+	};
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.AuthenticateIntegrated("TestDB", factory, /*use_encrypt=*/false) == false);
+
+	const std::string err = conn.GetLastError();
+	CHECK(err.find("routed server") != std::string::npos);
+	CHECK(err.find(std::to_string(target_port)) != std::string::npos);
+	// Must NOT be the "compiled without Kerberos support" message -- that one
+	// belongs to a first-attempt nullptr only.
+	CHECK(err.find("compiled without") == std::string::npos);
+	gateway.Stop();
+	target.Stop();
+	std::cout << "  [ok] a hop with no obtainable ticket names the routed host in the error" << std::endl;
+}
+
+// A first-attempt nullptr keeps the pre-068 wording, which users have in their
+// notes and issue reports.
+void TestIntegratedAuthNullFactoryFirstAttemptKeepsWording() {
+	FakeTdsServer server([](int) { return LoginAckStream(); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
+	auto factory = [](const std::string &, uint16_t) -> std::shared_ptr<IAuthenticator> { return nullptr; };
+	CHECK(conn.AuthenticateIntegrated("TestDB", factory, /*use_encrypt=*/false) == false);
+
+	CHECK(conn.GetLastError().find("compiled without Kerberos / SSPI support") != std::string::npos);
+	CHECK(conn.GetState() == ConnectionState::Disconnected);
+	server.Stop();
+	std::cout << "  [ok] first-attempt null factory keeps the pre-068 error wording" << std::endl;
+}
+
+}  // namespace
+
+int main() {
+#if defined(_WIN32)
+	WSADATA wsa;
+	WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+	std::cout << "test_login_routing_hops (spec 068: ENVCHANGE 20 on every auth path)" << std::endl;
+
+	TestZeroHopLoginUnchanged();
+	TestSqlAuthSingleHopWithLoginAck();
+	TestRouteWithoutLoginAckFollowsHop();
+	TestPerHopPacketIdReset();
+	TestHopLimitAborts();
+	TestIntegratedAuthFactoryRebuiltPerHop();
+	TestIntegratedAuthFactoryNullOnHopNamesRoutedHost();
+	TestIntegratedAuthNullFactoryFirstAttemptKeepsWording();
+
+	std::cout << "All " << g_checks << " checks passed." << std::endl;
+	return 0;
+}

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -724,6 +724,44 @@ void TestRoutedTargetWithInstanceAndPortSuffix() {
 			  << std::endl;
 }
 
+// A routed target that cannot be reached. The gateway's answer is perfectly
+// well-formed; the hop just fails to connect -- a stale AlwaysOn routing list,
+// a firewalled replica, a gateway naming an address the client cannot see.
+// Before this, RunWithRoutingHops's reconnect-failure branch and its error
+// string were the only paths in the driver with no coverage at all.
+//
+// The unreachable port is a listener's own port after it has been stopped, so
+// the connection is REFUSED immediately. A black-holed address (the
+// 10.255.255.x trick Microsoft's mssql-rs failover tests use) would exercise
+// the timeout instead, but DEFAULT_CONNECTION_TIMEOUT is compiled in at 30s
+// here, which is not a unit test.
+void TestUnreachableRoutedTargetFails() {
+	uint16_t dead_port = 0;
+	{
+		FakeTdsServer doomed([](int) { return LoginAckStream(); });
+		dead_port = doomed.GetPort();
+		doomed.Stop();	// nothing listens there now
+	}
+	FakeTdsServer gateway([dead_port](int) { return RouteWithLoginAckStream(dead_port); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false) == false);
+
+	CHECK(conn.GetState() == ConnectionState::Disconnected);
+	CHECK(conn.GetDatabase().empty());
+	const std::string err = conn.GetLastError();
+	// The message must name the target that could not be reached -- "connection
+	// failed" without the routed address sends the reader back to the gateway,
+	// which was working fine.
+	CHECK(err.find("Failed to connect to routed server") != std::string::npos);
+	CHECK(err.find(std::to_string(dead_port)) != std::string::npos);
+	CHECK(gateway.ConnectionCount() == 1);
+
+	gateway.Stop();
+	std::cout << "  [ok] an unreachable routed target fails with the routed address named" << std::endl;
+}
+
 // D3: the integrated path takes a FACTORY, and a hop re-invokes it with the
 // ROUTED host/port -- that is what makes the Kerberos/SSPI ticket match the
 // routed server's SPN instead of the gateway's.
@@ -824,6 +862,7 @@ int main() {
 	TestPerHopPacketIdReset();
 	TestReusedConnectionRestartsPacketSequence();
 	TestRoutedTargetWithInstanceAndPortSuffix();
+	TestUnreachableRoutedTargetFails();
 	TestHopLimitAborts();
 	TestIntegratedAuthFactoryRebuiltPerHop();
 	TestIntegratedAuthFactoryNullOnHopNamesRoutedHost();

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -36,9 +36,11 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -151,6 +153,31 @@ void AppendRoutingEnvChange(std::vector<uint8_t> &buf, const std::string &server
 	buf.insert(buf.end(), body.begin(), body.end());
 }
 
+// Pull the ServerName out of a LOGIN7 payload. [MS-TDS] 2.2.6.4: the fixed
+// portion is 94 bytes and the (offset, length) pairs start at byte 36 in field
+// order HostName, UserName, Password, AppName, ServerName -- so ibServerName is
+// at 52 and cchServerName (in UTF-16 code units, not bytes) at 54. Offsets are
+// relative to the start of the LOGIN7 payload. Returns "" if anything is out of
+// range, which fails the assertion rather than silently passing.
+std::string ExtractLogin7ServerName(const std::vector<uint8_t> &payload) {
+	if (payload.size() < 56) {
+		return "";
+	}
+	const uint16_t ib = static_cast<uint16_t>(payload[52] | (payload[53] << 8));
+	const uint16_t cch = static_cast<uint16_t>(payload[54] | (payload[55] << 8));
+	if (static_cast<size_t>(ib) + static_cast<size_t>(cch) * 2 > payload.size()) {
+		return "";
+	}
+	std::string out;
+	for (uint16_t i = 0; i < cch; i++) {
+		const uint16_t unit = static_cast<uint16_t>(payload[ib + i * 2] | (payload[ib + i * 2 + 1] << 8));
+		// Every fixture here is ASCII-range; anything else would be a bug in
+		// the test, not in the code under test.
+		out.push_back(static_cast<char>(unit & 0xFF));
+	}
+	return out;
+}
+
 //===----------------------------------------------------------------------===//
 // Loopback fake TDS server
 //
@@ -228,8 +255,19 @@ public:
 	}
 	// Packet id of the FIRST packet of the FIRST message on each connection.
 	// A hop must reset the sequence, so every connection must see 1.
-	const std::vector<int> &FirstPacketIds() const {
+	// Returns a COPY under the lock: the server thread appends to the vector
+	// and could reallocate under a returned reference.
+	std::vector<int> FirstPacketIds() const {
+		std::lock_guard<std::mutex> guard(mutex_);
 		return first_packet_ids_;
+	}
+
+	// The LOGIN7 ServerName field ([MS-TDS] 2.2.6.4) captured per connection,
+	// decoded from UTF-16LE. This is what pins the routed-target handling: on a
+	// hop it must be the "hostname\instance" form, not the DNS name.
+	std::vector<std::string> ServerNames() const {
+		std::lock_guard<std::mutex> guard(mutex_);
+		return server_names_;
 	}
 
 private:
@@ -268,8 +306,9 @@ private:
 	}
 
 	// Read one complete TDS message (packets until the EOM status bit).
-	// Returns false on timeout / peer close. Records the first packet's id.
-	bool ReadMessage(socket_t fd, bool record_first_id) {
+	// Returns false on timeout / peer close. Records the first packet's id, and
+	// appends the reassembled payload to `payload_out` when given.
+	bool ReadMessage(socket_t fd, bool record_first_id, std::vector<uint8_t> *payload_out = nullptr) {
 		bool eom = false;
 		bool first = true;
 		while (!eom) {
@@ -278,6 +317,7 @@ private:
 				return false;
 			}
 			if (first && record_first_id) {
+				std::lock_guard<std::mutex> guard(mutex_);
 				first_packet_ids_.push_back(static_cast<int>(header[6]));
 				first = false;
 			}
@@ -288,6 +328,9 @@ private:
 			std::vector<uint8_t> payload(length - 8);
 			if (!payload.empty() && !ReadExactly(fd, payload.data(), payload.size())) {
 				return false;
+			}
+			if (payload_out) {
+				payload_out->insert(payload_out->end(), payload.begin(), payload.end());
 			}
 			eom = (header[1] & 0x01) != 0;
 		}
@@ -398,8 +441,13 @@ private:
 		//    integrated scenarios need no SPNEGO round trip: StubAuthenticator
 		//    completes on InitialBytes(), so the server's single answer is the
 		//    LOGINACK (or the ROUTING) the client is waiting for.
-		if (!ReadMessage(client, /*record_first_id=*/false)) {
+		std::vector<uint8_t> login_payload;
+		if (!ReadMessage(client, /*record_first_id=*/false, &login_payload)) {
 			return;
+		}
+		{
+			std::lock_guard<std::mutex> guard(mutex_);
+			server_names_.push_back(ExtractLogin7ServerName(login_payload));
 		}
 		std::vector<uint8_t> answer = responder_(index);
 		if (answer.empty()) {
@@ -409,6 +457,7 @@ private:
 	}
 
 	LoginResponder responder_;
+	mutable std::mutex mutex_;	// guards first_packet_ids_ / server_names_
 	socket_t listen_fd_ = INVALID_SOCK;
 	uint16_t port_ = 0;
 	std::thread thread_;
@@ -416,6 +465,7 @@ private:
 	bool stopped_ = false;
 	std::atomic<int> connections_{0};
 	std::vector<int> first_packet_ids_;
+	std::vector<std::string> server_names_;
 };
 
 // Response streams the scenarios reuse.
@@ -556,11 +606,13 @@ void TestPerHopPacketIdReset() {
 // error must name both the count and the last routed target so a field report
 // is diagnosable in one round.
 void TestHopLimitAborts() {
-	// The responder reads self_port by reference: it is filled in right after
-	// construction, before the first connection can possibly arrive.
-	uint16_t self_port = 0;
-	FakeTdsServer server([&self_port](int) { return RouteWithLoginAckStream(self_port); });
-	self_port = server.GetPort();
+	// The responder reads self_port from the server thread while the main
+	// thread writes it right after construction; atomic because "the socket
+	// round-trip orders it in practice" is not something the memory model
+	// promises, and TSAN would rightly complain.
+	std::atomic<uint16_t> self_port{0};
+	FakeTdsServer server([&self_port](int) { return RouteWithLoginAckStream(self_port.load()); });
+	self_port.store(server.GetPort());
 
 	TdsConnection conn;
 	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
@@ -574,6 +626,57 @@ void TestHopLimitAborts() {
 	CHECK(server.ConnectionCount() == 6);
 	server.Stop();
 	std::cout << "  [ok] hop limit aborts after 5 hops, naming count + last target" << std::endl;
+}
+
+// The routed target in its full Fabric shape: "host\INSTANCE:port". Three
+// separate rules meet here, and with a bare "127.0.0.1" target none of them are
+// exercised — which is how the whole suite stayed green with the ServerName fix
+// reverted:
+//   1. the trailing ":port" beats the ENVCHANGE port field (deliberately wrong
+//      below, so taking the ENVCHANGE value connects to the wrong place);
+//   2. "\INSTANCE" is stripped for DNS/TCP;
+//   3. "\INSTANCE" is KEPT for the LOGIN7 ServerName field, which is the
+//      spec-068 R7 fix — before it, DoLogin7 sent host_ and the routed named
+//      instance received the instance-stripped name.
+void TestRoutedTargetWithInstanceAndPortSuffix() {
+	FakeTdsServer target([](int) { return LoginAckStream(); });
+	const uint16_t target_port = target.GetPort();
+
+	// ENVCHANGE port is 9 (discard protocol) — if the suffix does not win, the
+	// hop connects there and the login fails.
+	const std::string routed = "127.0.0.1\\INST01:" + std::to_string(target_port);
+	FakeTdsServer gateway([routed](int) {
+		std::vector<uint8_t> s;
+		AppendLoginAck(s);
+		AppendRoutingEnvChange(s, routed, 9);
+		AppendDone(s);
+		return s;
+	});
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", gateway.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+
+	CHECK(conn.GetState() == ConnectionState::Idle);
+	CHECK(conn.GetPort() == target_port);  // rule 1: suffix beat the ENVCHANGE port
+	CHECK(conn.GetHost() == "127.0.0.1");  // rule 2: instance stripped for TCP
+	CHECK(target.ConnectionCount() == 1);
+
+	// rule 3: the routed server's LOGIN7 carried the instance form...
+	const std::vector<std::string> routed_names = target.ServerNames();
+	CHECK(routed_names.size() == 1);
+	CHECK(routed_names[0] == "127.0.0.1\\INST01");
+	// ...while the gateway's first LOGIN7 carried the plain dialled host, so
+	// this pins the hop specifically and not just "ServerName is ever set".
+	const std::vector<std::string> gw_names = gateway.ServerNames();
+	CHECK(gw_names.size() == 1);
+	CHECK(gw_names[0] == "127.0.0.1");
+
+	conn.Close();
+	gateway.Stop();
+	target.Stop();
+	std::cout << "  [ok] routed host\\instance:port — suffix wins, instance stripped for TCP, kept in ServerName"
+			  << std::endl;
 }
 
 // D3: the integrated path takes a FACTORY, and a hop re-invokes it with the
@@ -674,6 +777,7 @@ int main() {
 	TestSqlAuthSingleHopWithLoginAck();
 	TestRouteWithoutLoginAckFollowsHop();
 	TestPerHopPacketIdReset();
+	TestRoutedTargetWithInstanceAndPortSuffix();
 	TestHopLimitAborts();
 	TestIntegratedAuthFactoryRebuiltPerHop();
 	TestIntegratedAuthFactoryNullOnHopNamesRoutedHost();

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -157,16 +157,24 @@ void AppendRoutingEnvChange(std::vector<uint8_t> &buf, const std::string &server
 // portion is 94 bytes and the (offset, length) pairs start at byte 36 in field
 // order HostName, UserName, Password, AppName, ServerName -- so ibServerName is
 // at 52 and cchServerName (in UTF-16 code units, not bytes) at 54. Offsets are
-// relative to the start of the LOGIN7 payload. Returns "" if anything is out of
-// range, which fails the assertion rather than silently passing.
+// relative to the start of the LOGIN7 payload.
+//
+// Anomalies return a DISTINGUISHABLE sentinel rather than "". This helper exists
+// to make the ServerName fix non-revertible, so when a CHECK on its result
+// fails, the message has to say whether the harness misread the packet or the
+// code under test sent the wrong name -- collapsing both into "" would read as
+// a production regression when it might be a bug in this file.
 std::string ExtractLogin7ServerName(const std::vector<uint8_t> &payload) {
-	if (payload.size() < 56) {
-		return "";
+	if (payload.size() < 94) {	// [MS-TDS] 2.2.6.4 fixed portion is 94 bytes
+		return "<short-payload>";
 	}
 	const uint16_t ib = static_cast<uint16_t>(payload[52] | (payload[53] << 8));
 	const uint16_t cch = static_cast<uint16_t>(payload[54] | (payload[55] << 8));
+	if (ib < 94) {	// variable data cannot start inside the fixed portion
+		return "<offset-in-header>";
+	}
 	if (static_cast<size_t>(ib) + static_cast<size_t>(cch) * 2 > payload.size()) {
-		return "";
+		return "<oob-offset>";
 	}
 	std::string out;
 	for (uint16_t i = 0; i < cch; i++) {
@@ -628,6 +636,33 @@ void TestHopLimitAborts() {
 	std::cout << "  [ok] hop limit aborts after 5 hops, naming count + last target" << std::endl;
 }
 
+// The per-attempt reset covers the FIRST attempt too, not just hops 2..N.
+// Close() resets state_ but leaves next_packet_id_ where the last login left
+// it, so a reused connection would open its second PRELOGIN at 3. Nothing else
+// in the suite discriminates that: TestPerHopPacketIdReset only exercises the
+// hop, so deleting `next_packet_id_ = 1` from the first-attempt reset leaves it
+// green.
+void TestReusedConnectionRestartsPacketSequence() {
+	FakeTdsServer server([](int) { return LoginAckStream(); });
+
+	TdsConnection conn;
+	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+	conn.Close();
+
+	// Same object, second login: PRELOGIN must be packet id 1 again.
+	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
+	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+
+	const std::vector<int> ids = server.FirstPacketIds();
+	CHECK(ids.size() == 2);
+	CHECK(ids[0] == 1);
+	CHECK(ids[1] == 1);	 // without the reset this is 3 (PRELOGIN 1, LOGIN7 2)
+	conn.Close();
+	server.Stop();
+	std::cout << "  [ok] a reused connection restarts its packet sequence at 1" << std::endl;
+}
+
 // The routed target in its full Fabric shape: "host\INSTANCE:port". Three
 // separate rules meet here, and with a bare "127.0.0.1" target none of them are
 // exercised — which is how the whole suite stayed green with the ServerName fix
@@ -660,6 +695,8 @@ void TestRoutedTargetWithInstanceAndPortSuffix() {
 	CHECK(conn.GetState() == ConnectionState::Idle);
 	CHECK(conn.GetPort() == target_port);  // rule 1: suffix beat the ENVCHANGE port
 	CHECK(conn.GetHost() == "127.0.0.1");  // rule 2: instance stripped for TCP
+	// Exactly one attempt against each: no retry, no second pass at the gateway.
+	CHECK(gateway.ConnectionCount() == 1);
 	CHECK(target.ConnectionCount() == 1);
 
 	// rule 3: the routed server's LOGIN7 carried the instance form...
@@ -777,6 +814,7 @@ int main() {
 	TestSqlAuthSingleHopWithLoginAck();
 	TestRouteWithoutLoginAckFollowsHop();
 	TestPerHopPacketIdReset();
+	TestReusedConnectionRestartsPacketSequence();
 	TestRoutedTargetWithInstanceAndPortSuffix();
 	TestHopLimitAborts();
 	TestIntegratedAuthFactoryRebuiltPerHop();

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -652,7 +652,11 @@ void TestReusedConnectionRestartsPacketSequence() {
 	TdsConnection conn;
 	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));
 	CHECK(conn.Authenticate("sa", "pw", "TestDB", /*use_encrypt=*/false));
+	CHECK(conn.GetDatabase() == "TestDB");
 	conn.Close();
+	// The other exit from "logged in": a normal close must leave the accessor
+	// empty too, not just an aborted login.
+	CHECK(conn.GetDatabase().empty());
 
 	// Same object, second login: PRELOGIN must be packet id 1 again.
 	CHECK(conn.Connect("127.0.0.1", server.GetPort(), 5));

--- a/test/cpp/test_login_routing_hops.cpp
+++ b/test/cpp/test_login_routing_hops.cpp
@@ -731,11 +731,11 @@ void TestRoutedTargetWithInstanceAndPortSuffix() {
 // Before this, RunWithRoutingHops's reconnect-failure branch and its error
 // string were the only paths in the driver with no coverage at all.
 //
-// The unreachable port is a listener's own port after it has been stopped, so
-// the connection is REFUSED immediately. A black-holed address (the
-// 10.255.255.x trick Microsoft's mssql-rs failover tests use) would exercise
-// the timeout instead, but DEFAULT_CONNECTION_TIMEOUT is compiled in at 30s
-// here, which is not a unit test.
+// This is the REFUSAL branch: the unreachable port is a listener's own, after
+// it has been stopped. The TIMEOUT branch is the next test down
+// (TestHopHonoursCallerConnectTimeout), which became a viable unit test once
+// the hop started honouring the caller's timeout rather than the compiled-in
+// 30s default.
 void TestUnreachableRoutedTargetFails() {
 	// Take a listener's port and stop it, so the port is genuinely closed and
 	// the connect is REFUSED immediately.


### PR DESCRIPTION
Closes #256. Implements the spec from #257. Draft: opened to get CI signal — see the risk note at the bottom.

## What changed

`TdsConnection::RunWithRoutingHops` now owns the hop loop that used to live inline in `AuthenticateWithFedAuth`; all three auth paths are thin wrappers over it.

- **D1 — the contract.** If the login response carries ROUTING, the outcome on that socket is *hop*, whatever it said about `success`. A `bool` cannot express that (it forces the driver to read `has_routing_` as a side channel off a `false` return — the arrangement that produced the bug), so an attempt reports `LoginAttemptOutcome{Success, Route, Failure}`.
- **D2 — one driver.** It also owns every state transition. `AuthenticateIntegrated` used to store `Disconnected` + close the socket at nine points inside its own body; a callback doing that mid-loop leaves the state machine dead while the next socket connects. Hop budget (5), routed-target normalization (`host\instance:port`, no SQL Browser on a hop) and per-hop resets unchanged; the hop-limit error now names the last routed target.
- **D3 — authenticator factory.** `AuthenticateIntegrated` takes `(host, port) -> IAuthenticator`. No compatibility overload: it would make replaying the gateway's ticket the easy thing. `DeriveSpn` needed no change — it already reads `info.host`/`info.port` and passes an explicit `service_principal_name` through verbatim, so both D3 requirements fall out of existing code.

**Not in the spec, found on the way:** `DoLogin7` passed `host_` as the LOGIN7 ServerName while the integrated path passed `tds_server_name_`. Once SQL auth can hop, a routed named instance would have received the instance-stripped name. Non-routed logins stay byte-identical — the driver seeds `tds_server_name_ = host_` before the first attempt.

**No change needed** in `AuthenticateWithFedAuth` after the ordering fix (the driver treats `Route` uniformly), nor at `mssql_diagnostic.cpp:144`, which inherits routing through `Authenticate()`.

## Tests

- `test/cpp/test_login_routing_hops.cpp` — **new**, 45 checks. Drives a real `TdsConnection` against a loopback fake TDS server (two listeners on `127.0.0.1:0`, `use_encrypt=false`, no DuckDB link, ~200 ms). Pins: zero-hop unchanged, single hop with LOGINACK, hop without LOGINACK, per-hop packet-id reset, hop-limit abort, integrated-auth factory re-invoked with the routed host, `Free()` before the next build, hop-failure error naming the routed host, first-attempt-null wording preserved.
- `test/cpp/test_login_error_state.cpp` — 4 parser pins added (56 checks total), including ROUTING behind a DONEINPROC run, the composition with #254.

The hop pins were confirmed to **fail** under the pre-068 behaviour before being confirmed green under the fix.

## Behaviour change

SQL auth against an endpoint answering ROUTING *and* LOGINACK now redirects instead of transacting against the gateway. Correct per [MS-TDS] — a routed session is not usable — but visible to anyone unknowingly relying on the old behaviour. Changelog entry included.

Internal API: `AuthenticateIntegrated`'s signature change affects embedders calling the TDS layer directly.

## ⚠️ The one unverified thing

The new test is wired into the **ungated** `cpp-unit-tests` job (a routing regression should fail the PR that causes it, and the `build` job is dispatch/schedule-gated). That job has no vcpkg, so the step installs simdutf via `apt-get install libsimdutf-dev` on Linux and `brew install simdutf` on macOS. **Package availability on `ubuntu-latest` was not verifiable locally** — this is the step most likely to go red here, and it fails loudly rather than silently.

## Not run

Full `make` / `make test`, the SQL Server integration suite, the `test/kerberos/` stack, and the Azure smoke job. The Windows socket code in the new test has the `#ifdef` split but has never been compiled on Windows. Tracked as open items T044–T047 in `specs/068-login-routing-unification/tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
