### PR TITLE
fix: SPN from IP, SSPI coverage, a Kerberos routing hop, and error translation (#259 #260 #261 #262)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,6 +908,27 @@ jobs:
       # package location; here the prefix is already built above.
       # Consequence: Windows coverage of this test is dispatch-gated, unlike
       # Linux/macOS which run it on every PR.
+      # Issue #260: the SSPI path had no automated coverage at all -- its only
+      # test assumes a domain-joined host and is therefore never run. Acquiring
+      # a Negotiate credential and producing the first SPNEGO token needs the
+      # local logon session, not a domain and not a SQL Server, so it runs here
+      # on a bare runner. secur32 is the SSPI library; the rest is the TDS layer
+      # the authenticator sits in.
+      - name: Build + run Windows SSPI context test (issue #260)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $prefix = "build/release/vcpkg_installed/x64-windows-static-release"
+          cl /std:c++17 /EHsc /nologo /MT /DMSSQL_ENABLE_SSPI=1 `
+            /I src/include /I "$prefix/include" `
+            test/cpp/test_winsspi_context.cpp `
+            src/tds/auth/winsspi_authenticator.cpp `
+            /Fe:test_winsspi_context.exe `
+            /link secur32.lib
+          if ($LASTEXITCODE -ne 0) { throw "compile failed" }
+          ./test_winsspi_context.exe
+          if ($LASTEXITCODE -ne 0) { throw "test failed" }
+
       - name: Build + run login routing hop-driver test (spec 068)
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,48 @@ jobs:
           /tmp/test_load_policy
 
   # ============================================================================
+  # Windows SSPI Unit Test - ungated, like cpp-unit-tests above.
+  #
+  # Issue #260: WinSspiAuthenticator had no automated coverage. Its only test
+  # assumes a domain-joined host and sits on the never-set allowlist in
+  # check_require_env.sh, and the Windows BUILD jobs are dispatch-gated -- so
+  # putting it there would trade a test nobody runs for a test that runs when
+  # somebody ticks a box.
+  #
+  # It belongs in its own job rather than as a windows entry in the
+  # cpp-unit-tests matrix because five of that job's steps are POSIX-only
+  # (pkg-config, readelf, shasum, `c++`) and would each need an `if:` guard.
+  #
+  # No vcpkg needed: winsspi_authenticator.cpp includes only its own header and
+  # the Windows SDK. Acquiring a Negotiate credential and producing the first
+  # token uses the local logon session -- no domain, no SQL Server, no network.
+  # ============================================================================
+  windows-sspi-test:
+    name: Windows SSPI Unit Test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Visual Studio Environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Build + run Windows SSPI context test (issue #260)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          cl /std:c++17 /EHsc /nologo /MT /DMSSQL_ENABLE_SSPI=1 `
+            /I src/include `
+            test/cpp/test_winsspi_context.cpp `
+            src/tds/auth/winsspi_authenticator.cpp `
+            /Fe:test_winsspi_context.exe `
+            /link secur32.lib
+          if ($LASTEXITCODE -ne 0) { throw "compile failed" }
+          ./test_winsspi_context.exe
+          if ($LASTEXITCODE -ne 0) { throw "test failed" }
+
+  # ============================================================================
   # Build Job - Build against DuckDB stable on representative platforms
   # (Manual trigger only via workflow_dispatch)
   # ============================================================================
@@ -908,27 +950,6 @@ jobs:
       # package location; here the prefix is already built above.
       # Consequence: Windows coverage of this test is dispatch-gated, unlike
       # Linux/macOS which run it on every PR.
-      # Issue #260: the SSPI path had no automated coverage at all -- its only
-      # test assumes a domain-joined host and is therefore never run. Acquiring
-      # a Negotiate credential and producing the first SPNEGO token needs the
-      # local logon session, not a domain and not a SQL Server, so it runs here
-      # on a bare runner. secur32 is the SSPI library; the rest is the TDS layer
-      # the authenticator sits in.
-      - name: Build + run Windows SSPI context test (issue #260)
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $prefix = "build/release/vcpkg_installed/x64-windows-static-release"
-          cl /std:c++17 /EHsc /nologo /MT /DMSSQL_ENABLE_SSPI=1 `
-            /I src/include /I "$prefix/include" `
-            test/cpp/test_winsspi_context.cpp `
-            src/tds/auth/winsspi_authenticator.cpp `
-            /Fe:test_winsspi_context.exe `
-            /link secur32.lib
-          if ($LASTEXITCODE -ne 0) { throw "compile failed" }
-          ./test_winsspi_context.exe
-          if ($LASTEXITCODE -ne 0) { throw "test failed" }
-
       - name: Build + run login routing hop-driver test (spec 068)
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ docs/assets/download-metrics.svg
 website/node_modules/
 website/build/
 website/.docusaurus/
+
+# Python bytecode (e.g. test/kerberos/gateway helpers imported locally)
+__pycache__/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,8 @@ STANDALONE_TEST_SOURCES := \
     test/cpp/test_ddl_translator.cpp \
     test/cpp/test_ctas_type_mapping.cpp \
     test/cpp/test_catalog_filter.cpp \
+    test/cpp/test_connection_error_translation.cpp \
+    test/cpp/test_spn_host_resolution.cpp \
     test/cpp/test_insert_bulk_sql.cpp \
     test/cpp/test_vector_encodings.cpp \
     test/cpp/codec/test_binary_codec.cpp \

--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -240,10 +240,14 @@ struct MSSQLConnectionInfo {
 // `server_error` / `server_state` are the SERVER's ERROR-token fields (0 when
 // the failure never reached a login). When a number is present it classifies
 // the failure; otherwise a few string heuristics cover socket/TLS/DNS errors.
+// MSSQL-prefixed per CLAUDE.md's namespace rule: an exported free function in
+// the shared `duckdb` namespace needs the prefix, and this name is generic
+// enough to collide.
+//
 // Declared here rather than kept static so the classification can be unit
 // tested -- issue #262 was a misclassification that no test could have caught.
-string TranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
-								const string &database, uint32_t server_error = 0, uint8_t server_state = 0);
+string MSSQLTranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
+									 const string &database, uint32_t server_error = 0, uint8_t server_state = 0);
 
 string ResolveAppName(const MSSQLConnectionInfo &info);
 

--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -235,6 +235,16 @@ struct MSSQLConnectionInfo {
 // manual token / integrated) goes through the same logic. A future
 // change to the default string only touches the impl.
 //===----------------------------------------------------------------------===//
+// Turn a connection/login failure into something a user can act on.
+//
+// `server_error` / `server_state` are the SERVER's ERROR-token fields (0 when
+// the failure never reached a login). When a number is present it classifies
+// the failure; otherwise a few string heuristics cover socket/TLS/DNS errors.
+// Declared here rather than kept static so the classification can be unit
+// tested -- issue #262 was a misclassification that no test could have caught.
+string TranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
+								const string &database, uint32_t server_error = 0, uint8_t server_state = 0);
+
 string ResolveAppName(const MSSQLConnectionInfo &info);
 
 //===----------------------------------------------------------------------===//

--- a/src/include/tds/auth/auth_strategy_factory.hpp
+++ b/src/include/tds/auth/auth_strategy_factory.hpp
@@ -14,6 +14,7 @@
 #include "tds/auth/manual_token_strategy.hpp"
 #include "tds/auth/sql_auth_strategy.hpp"
 
+#include <cstdint>
 #include <string>
 
 namespace duckdb {
@@ -43,6 +44,17 @@ namespace tds {
 //
 // Separately declared so it can be unit tested without a KDC.
 std::string ResolveHostForSpn(const std::string &host);
+
+// The canonical default SPN, "MSSQLSvc/<fqdn>:<port>", with `host` run through
+// ResolveHostForSpn first. Throws when `host` is an IP literal with no PTR
+// record, because a silently-unmatchable SPN is worse than a clear refusal.
+//
+// Shared deliberately: mssql_kerberos_auth_test / mssql_winsspi_auth_test are
+// the tools users are pointed at when a Kerberos login fails, and each used to
+// carry its own copy of this formatting. A diagnostic that reports a different
+// SPN than the connection would actually request sends the reader in the wrong
+// direction -- exactly the situation issue #259 is about.
+std::string DeriveDefaultSpn(const std::string &host, uint16_t port);
 
 class AuthStrategyFactory {
 public:

--- a/src/include/tds/auth/auth_strategy_factory.hpp
+++ b/src/include/tds/auth/auth_strategy_factory.hpp
@@ -14,6 +14,8 @@
 #include "tds/auth/manual_token_strategy.hpp"
 #include "tds/auth/sql_auth_strategy.hpp"
 
+#include <string>
+
 namespace duckdb {
 
 // Forward declarations
@@ -25,6 +27,22 @@ namespace tds {
 //===----------------------------------------------------------------------===//
 // AuthStrategyFactory - Creates appropriate auth strategy based on connection
 //===----------------------------------------------------------------------===//
+
+// Reverse-resolve a host for SPN construction (issue #259).
+//
+// Active Directory registers SQL Server SPNs against the FQDN, so a connection
+// made by IP -- Server=10.1.2.3,1433 -- yields "MSSQLSvc/10.1.2.3:1433", which
+// can never match and fails with a KDC "server not found in Kerberos database"
+// that says nothing about the address form being the problem.
+//
+// Returns the FQDN when `host` is an IP literal that reverse-resolves. Returns
+// `host` unchanged when it is already a name (the overwhelmingly common case,
+// and no lookup is performed). Returns an empty string when `host` is an IP
+// literal that does NOT reverse-resolve, which the caller turns into an error
+// naming the fix, because silently building an unmatched SPN is worse.
+//
+// Separately declared so it can be unit tested without a KDC.
+std::string ResolveHostForSpn(const std::string &host);
 
 class AuthStrategyFactory {
 public:

--- a/src/include/tds/auth/auth_strategy_factory.hpp
+++ b/src/include/tds/auth/auth_strategy_factory.hpp
@@ -56,6 +56,12 @@ std::string ResolveHostForSpn(const std::string &host);
 // direction -- exactly the situation issue #259 is about.
 std::string DeriveDefaultSpn(const std::string &host, uint16_t port);
 
+// Non-throwing form for the diagnostic functions, whose contract is to RETURN a
+// status string rather than abort the query -- an unresolvable IP is exactly
+// what a user runs them to diagnose. Returns false and fills `error` with the
+// explanation; the caller decides how to prefix it.
+bool TryDeriveDefaultSpn(const std::string &host, uint16_t port, std::string &spn, std::string &error);
+
 class AuthStrategyFactory {
 public:
 	// Create strategy from connection info

--- a/src/include/tds/tds_connection.hpp
+++ b/src/include/tds/tds_connection.hpp
@@ -177,6 +177,23 @@ public:
 	const std::string &GetLastError() const {
 		return last_error_;
 	}
+
+	// The SERVER's own error number and state from the last failed login, or 0
+	// when the failure had no ERROR token (a socket error, a TLS failure).
+	//
+	// These exist because the alternative -- deciding what went wrong by
+	// pattern-matching the formatted message -- reads our own wrapper text
+	// rather than the server's, and every login failure begins "Authentication
+	// failed", so everything looked like a bad password (issue #262). The
+	// number is also what distinguishes retryable conditions (Azure 40613, a
+	// serverless database resuming) from a credential problem, and the state is
+	// what separates the several distinct causes of 18456 (issue #164).
+	uint32_t GetLastErrorNumber() const {
+		return last_error_number_;
+	}
+	uint8_t GetLastErrorState() const {
+		return last_error_state_;
+	}
 	bool IsTlsEnabled() const {
 		return tls_enabled_;
 	}
@@ -293,6 +310,8 @@ private:
 
 	// Error tracking
 	std::string last_error_;
+	uint32_t last_error_number_ = 0;
+	uint8_t last_error_state_ = 0;
 
 	// Packet sequencing
 	uint8_t next_packet_id_;

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1033,11 +1033,14 @@ string MSSQLTranslateConnectionError(const string &error, const string &host, ui
 				"resuming, or the service is being reconfigured; retry shortly. Server said: %s",
 				database, host, port, server_error, error);
 		case 18456:	 // Login failed. State is the only field that says WHY (issue #164).
+			// `user` is empty on the token-authenticated paths, where the identity
+			// comes from the token rather than a User Id -- naming user '' there
+			// is less informative than the server's own text.
 			return StringUtil::Format(
-				"Authentication failed for user '%s' (server error 18456, state %d) - state 8 is a wrong password, "
-				"state 38/40 an inaccessible initial database, state 1 an unspecified cause the server logs but "
-				"does not disclose. Server said: %s",
-				user, server_state, error);
+				"Authentication failed%s (server error 18456, state %d) - state 8 is a wrong "
+				"password, state 38/40 an inaccessible initial database, state 1 an unspecified "
+				"cause the server logs but does not disclose. Server said: %s",
+				user.empty() ? "" : StringUtil::Format(" for user '%s'", user), server_state, error);
 		case 4060:	// Cannot open database requested by the login
 			return StringUtil::Format(
 				"Cannot access database '%s' - check database name and permissions (server "
@@ -1054,19 +1057,21 @@ string MSSQLTranslateConnectionError(const string &error, const string &host, ui
 	// word "authentication", which appears in our own wrapper for every login
 	// failure and is what made this arm swallow everything (issue #262).
 	if (lower_error.find("login failed") != string::npos) {
-		return StringUtil::Format("Authentication failed for user '%s' - check username and password. Server said: %s",
-								  user, error);
+		return StringUtil::Format("Authentication failed%s - check username and password. Server said: %s",
+								  user.empty() ? "" : StringUtil::Format(" for user '%s'", user), error);
 	}
 
 	// Database access failures
 	if (lower_error.find("cannot open database") != string::npos) {
-		return StringUtil::Format("Cannot access database '%s' - check database name and permissions", database);
+		return StringUtil::Format("Cannot access database '%s' - check database name and permissions. Details: %s",
+								  database, error);
 	}
 
 	// TLS failures
 	if (lower_error.find("tls") != string::npos || lower_error.find("ssl") != string::npos ||
 		lower_error.find("handshake") != string::npos) {
-		return StringUtil::Format("TLS handshake failed to %s:%d - check TLS configuration", host, port);
+		return StringUtil::Format("TLS negotiation failed to %s:%d - check TLS configuration. Details: %s", host, port,
+								  error);
 	}
 
 	// Server requires encryption but client disabled it
@@ -1079,27 +1084,30 @@ string MSSQLTranslateConnectionError(const string &error, const string &host, ui
 
 	// Certificate validation failures
 	if (lower_error.find("certificate") != string::npos || lower_error.find("cert") != string::npos) {
-		return StringUtil::Format("TLS certificate validation failed - server certificate not trusted");
+		return StringUtil::Format(
+			"TLS certificate validation failed to %s:%d - server certificate not trusted. "
+			"Details: %s",
+			host, port, error);
 	}
 
 	// Connection refused
 	if (lower_error.find("connection refused") != string::npos || lower_error.find("econnrefused") != string::npos) {
 		return StringUtil::Format(
-			"Connection refused to %s:%d - check if SQL Server is running and accepting "
-			"connections",
-			host, port);
+			"Connection refused to %s:%d - check if SQL Server is running and accepting connections. Details: %s", host,
+			port, error);
 	}
 
 	// DNS/hostname resolution
 	if (lower_error.find("resolve") != string::npos || lower_error.find("host") != string::npos ||
 		lower_error.find("enoent") != string::npos || lower_error.find("name or service not known") != string::npos) {
-		return StringUtil::Format("Cannot resolve hostname '%s' - check server name", host);
+		return StringUtil::Format("Cannot resolve hostname '%s' - check server name. Details: %s", host, error);
 	}
 
 	// Timeout
 	if (lower_error.find("timeout") != string::npos || lower_error.find("timed out") != string::npos) {
-		return StringUtil::Format("Connection timed out to %s:%d - check network connectivity and firewall settings",
-								  host, port);
+		return StringUtil::Format(
+			"Connection timed out to %s:%d - check network connectivity and firewall settings. Details: %s", host, port,
+			error);
 	}
 
 	// Generic connection error
@@ -1161,7 +1169,8 @@ void ValidateAzureConnection(ClientContext &context, MSSQLConnectionInfo &info, 
 		string error =
 			MSSQLTranslateConnectionError(conn.GetLastError(), info.host, info.port, info.user, info.database,
 										  conn.GetLastErrorNumber(), conn.GetLastErrorState());
-		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateAzureConnection: Azure AD authentication FAILED - %s", error.c_str());
+		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateAzureConnection: Azure AD authentication FAILED - raw: %s, translated: %s",
+								conn.GetLastError().c_str(), error.c_str());
 		conn.Close();
 		throw InvalidInputException("MSSQL Azure AD connection validation failed: %s", error);
 	}
@@ -1230,7 +1239,8 @@ void ValidateManualTokenConnection(MSSQLConnectionInfo &info, const std::vector<
 		string error =
 			MSSQLTranslateConnectionError(conn.GetLastError(), info.host, info.port, info.user, info.database,
 										  conn.GetLastErrorNumber(), conn.GetLastErrorState());
-		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateManualTokenConnection: FEDAUTH FAILED - %s", error.c_str());
+		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateManualTokenConnection: FEDAUTH FAILED - raw: %s, translated: %s",
+								conn.GetLastError().c_str(), error.c_str());
 		conn.Close();
 		throw InvalidInputException("MSSQL manual token authentication failed: %s", error);
 	}

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1016,8 +1016,8 @@ void MSSQLConnectionInfo::ResolveNamedInstance(ClientContext &context) {
 // -- including Azure 40613, a serverless database resuming -- into "check
 // username and password". The server's number and text are always appended now,
 // so no diagnosis is lost on the way to the user.
-string TranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
-								const string &database, uint32_t server_error, uint8_t server_state) {
+string MSSQLTranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
+									 const string &database, uint32_t server_error, uint8_t server_state) {
 	string lower_error = StringUtil::Lower(error);
 
 	// Server-classified failures. These take precedence over every heuristic
@@ -1155,7 +1155,12 @@ void ValidateAzureConnection(ClientContext &context, MSSQLConnectionInfo &info, 
 	MSSQL_STORAGE_DEBUG_LOG(1, "ValidateAzureConnection: attempting Azure AD authentication...");
 	if (!conn.AuthenticateWithFedAuth(info.database, fedauth_data.token_utf16le, info.use_encrypt,
 									  ResolveAppName(info))) {
-		string error = conn.GetLastError();
+		// Classified, not raw: the Azure-AD path is the one most likely to meet
+		// 40613 on a paused serverless database, which is the case issue #262
+		// was filed about.
+		string error =
+			MSSQLTranslateConnectionError(conn.GetLastError(), info.host, info.port, info.user, info.database,
+										  conn.GetLastErrorNumber(), conn.GetLastErrorState());
 		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateAzureConnection: Azure AD authentication FAILED - %s", error.c_str());
 		conn.Close();
 		throw InvalidInputException("MSSQL Azure AD connection validation failed: %s", error);
@@ -1222,7 +1227,9 @@ void ValidateManualTokenConnection(MSSQLConnectionInfo &info, const std::vector<
 	// Attempt Azure AD authentication (FEDAUTH) with the pre-provided token
 	MSSQL_STORAGE_DEBUG_LOG(1, "ValidateManualTokenConnection: attempting FEDAUTH with manual token...");
 	if (!conn.AuthenticateWithFedAuth(info.database, token_utf16le, info.use_encrypt, ResolveAppName(info))) {
-		string error = conn.GetLastError();
+		string error =
+			MSSQLTranslateConnectionError(conn.GetLastError(), info.host, info.port, info.user, info.database,
+										  conn.GetLastErrorNumber(), conn.GetLastErrorState());
 		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateManualTokenConnection: FEDAUTH FAILED - %s", error.c_str());
 		conn.Close();
 		throw InvalidInputException("MSSQL manual token authentication failed: %s", error);
@@ -1276,7 +1283,7 @@ void ValidateConnection(MSSQLConnectionInfo &info, int timeout_seconds) {
 	MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: attempting TCP connection...");
 	if (!conn.Connect(info.host, info.port, timeout_seconds)) {
 		string error = conn.GetLastError();
-		string translated = TranslateConnectionError(error, info.host, info.port, info.user, info.database);
+		string translated = MSSQLTranslateConnectionError(error, info.host, info.port, info.user, info.database);
 		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: TCP connection FAILED - raw: %s, translated: %s", error.c_str(),
 								translated.c_str());
 		throw IOException("MSSQL connection validation failed: %s", translated);
@@ -1287,8 +1294,8 @@ void ValidateConnection(MSSQLConnectionInfo &info, int timeout_seconds) {
 	MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: attempting authentication...");
 	if (!conn.Authenticate(info.user, info.password, info.database, info.use_encrypt, ResolveAppName(info))) {
 		string error = conn.GetLastError();
-		string translated = TranslateConnectionError(error, info.host, info.port, info.user, info.database,
-													 conn.GetLastErrorNumber(), conn.GetLastErrorState());
+		string translated = MSSQLTranslateConnectionError(error, info.host, info.port, info.user, info.database,
+														  conn.GetLastErrorNumber(), conn.GetLastErrorState());
 		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: authentication FAILED - raw: %s, translated: %s", error.c_str(),
 								translated.c_str());
 		conn.Close();
@@ -1304,7 +1311,8 @@ void ValidateConnection(MSSQLConnectionInfo &info, int timeout_seconds) {
 		try {
 			if (!conn.ExecuteBatch("SELECT 1")) {
 				string error = conn.GetLastError();
-				string translated = TranslateConnectionError(error, info.host, info.port, info.user, info.database);
+				string translated =
+					MSSQLTranslateConnectionError(error, info.host, info.port, info.user, info.database);
 				MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: TLS validation query FAILED - raw: %s, translated: %s",
 										error.c_str(), translated.c_str());
 				conn.Close();
@@ -1323,7 +1331,7 @@ void ValidateConnection(MSSQLConnectionInfo &info, int timeout_seconds) {
 			MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: TLS validation query succeeded");
 		} catch (const std::exception &e) {
 			string error = e.what();
-			string translated = TranslateConnectionError(error, info.host, info.port, info.user, info.database);
+			string translated = MSSQLTranslateConnectionError(error, info.host, info.port, info.user, info.database);
 			MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: TLS validation query FAILED with exception - %s",
 									error.c_str());
 			conn.Close();
@@ -1357,7 +1365,7 @@ void ValidateIntegratedAuthConnection(MSSQLConnectionInfo &info, int timeout_sec
 	conn.SetRequestUtf8Support(info.utf8_support);
 	if (!conn.Connect(info.host, info.port, timeout_seconds)) {
 		string error = conn.GetLastError();
-		string translated = TranslateConnectionError(error, info.host, info.port, "", info.database);
+		string translated = MSSQLTranslateConnectionError(error, info.host, info.port, "", info.database);
 		throw IOException("MSSQL connection validation failed: %s", translated);
 	}
 
@@ -1400,7 +1408,9 @@ void ValidateIntegratedAuthConnection(MSSQLConnectionInfo &info, int timeout_sec
 		// `strategy_error` is the GSSAPI/SSPI cause, which the callable could
 		// not throw across the TDS layer. Reporting only the cause would drop
 		// the routed host; reporting only the driver would drop the reason.
-		string error = conn.GetLastError();
+		string error =
+			MSSQLTranslateConnectionError(conn.GetLastError(), info.host, info.port, info.user, info.database,
+										  conn.GetLastErrorNumber(), conn.GetLastErrorState());
 		if (!strategy_error.empty()) {
 			error += " (" + strategy_error + ")";
 		}

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1002,19 +1002,64 @@ void MSSQLConnectionInfo::ResolveNamedInstance(ClientContext &context) {
 // Connection Validation
 //===----------------------------------------------------------------------===//
 
-// Translate TDS error message to user-friendly message
-static string TranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
-									   const string &database) {
+// Translate TDS error message to user-friendly message.
+//
+// `server_error` / `server_state` are the SERVER's own ERROR-token fields, or 0
+// when the failure produced no ERROR token. When a number is present it decides
+// the classification; the string heuristics below only run for failures that
+// never reached a login (socket, TLS, DNS).
+//
+// Issue #262: the string arms must never be allowed to classify a login
+// failure. Every login failure this extension produces begins "Authentication
+// failed (error N, state S): ...", so a `find("authentication")` test matches
+// our OWN wrapper rather than the server's message, and collapsed every cause
+// -- including Azure 40613, a serverless database resuming -- into "check
+// username and password". The server's number and text are always appended now,
+// so no diagnosis is lost on the way to the user.
+string TranslateConnectionError(const string &error, const string &host, uint16_t port, const string &user,
+								const string &database, uint32_t server_error, uint8_t server_state) {
 	string lower_error = StringUtil::Lower(error);
 
-	// Authentication failures
-	if (lower_error.find("login failed") != string::npos || lower_error.find("authentication") != string::npos ||
-		lower_error.find("18456") != string::npos) {
-		return StringUtil::Format("Authentication failed for user '%s' - check username and password", user);
+	// Server-classified failures. These take precedence over every heuristic
+	// below, because here we know what the server actually said.
+	if (server_error > 0) {
+		switch (server_error) {
+		case 40613:	 // Azure SQL: "Database ... is not currently available"
+		case 40197:	 // Azure SQL: error processing the request, reconfiguration
+		case 40501:	 // Azure SQL: service is busy
+		case 49918:	 // Azure SQL: cannot process request, not enough resources
+			return StringUtil::Format(
+				"Database '%s' on %s:%d is not available yet (server error %d) - a serverless database may be "
+				"resuming, or the service is being reconfigured; retry shortly. Server said: %s",
+				database, host, port, server_error, error);
+		case 18456:	 // Login failed. State is the only field that says WHY (issue #164).
+			return StringUtil::Format(
+				"Authentication failed for user '%s' (server error 18456, state %d) - state 8 is a wrong password, "
+				"state 38/40 an inaccessible initial database, state 1 an unspecified cause the server logs but "
+				"does not disclose. Server said: %s",
+				user, server_state, error);
+		case 4060:	// Cannot open database requested by the login
+			return StringUtil::Format(
+				"Cannot access database '%s' - check database name and permissions (server "
+				"error 4060). Server said: %s",
+				database, error);
+		default:
+			return StringUtil::Format("Login to %s:%d failed with server error %d (state %d): %s", host, port,
+									  server_error, server_state, error);
+		}
+	}
+
+	// A login rejection that carried no usable error number. Matches the
+	// SERVER's phrase ("Login failed for user ...") and deliberately NOT the
+	// word "authentication", which appears in our own wrapper for every login
+	// failure and is what made this arm swallow everything (issue #262).
+	if (lower_error.find("login failed") != string::npos) {
+		return StringUtil::Format("Authentication failed for user '%s' - check username and password. Server said: %s",
+								  user, error);
 	}
 
 	// Database access failures
-	if (lower_error.find("cannot open database") != string::npos || lower_error.find("4060") != string::npos) {
+	if (lower_error.find("cannot open database") != string::npos) {
 		return StringUtil::Format("Cannot access database '%s' - check database name and permissions", database);
 	}
 
@@ -1242,7 +1287,8 @@ void ValidateConnection(MSSQLConnectionInfo &info, int timeout_seconds) {
 	MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: attempting authentication...");
 	if (!conn.Authenticate(info.user, info.password, info.database, info.use_encrypt, ResolveAppName(info))) {
 		string error = conn.GetLastError();
-		string translated = TranslateConnectionError(error, info.host, info.port, info.user, info.database);
+		string translated = TranslateConnectionError(error, info.host, info.port, info.user, info.database,
+													 conn.GetLastErrorNumber(), conn.GetLastErrorState());
 		MSSQL_STORAGE_DEBUG_LOG(1, "ValidateConnection: authentication FAILED - raw: %s, translated: %s", error.c_str(),
 								translated.c_str());
 		conn.Close();

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1078,8 +1078,9 @@ string MSSQLTranslateConnectionError(const string &error, const string &host, ui
 	if (lower_error.find("encrypt_req") != string::npos ||
 		(lower_error.find("encryption") != string::npos && lower_error.find("require") != string::npos)) {
 		return StringUtil::Format(
-			"Server requires encryption (ENCRYPT_REQ) but use_encrypt=false. "
-			"Set use_encrypt=true or Encrypt=yes in connection string.");
+			"Server %s:%d requires encryption (ENCRYPT_REQ) but use_encrypt=false. "
+			"Set use_encrypt=true or Encrypt=yes in connection string. Details: %s",
+			host, port, error);
 	}
 
 	// Certificate validation failures

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -20,7 +20,21 @@
 #include "tds/auth/winsspi_authenticator.hpp"
 #endif
 
+#include <cstring>
 #include <string>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
 
 namespace duckdb {
 namespace tds {
@@ -64,11 +78,58 @@ static std::string DeriveSpn(const MSSQLConnectionInfo &info) {
 		return spn;
 	}
 	// No override: build the canonical "MSSQLSvc/<fqdn>:<port>" form so the
-	// SPN matches what SQL Server registers in AD by default.
-	return std::string("MSSQLSvc/") + info.host + ":" + std::to_string(info.port);
+	// SPN matches what SQL Server registers in AD by default. An IP literal is
+	// reverse-resolved first -- AD registers names, not addresses (issue #259).
+	const std::string spn_host = ResolveHostForSpn(info.host);
+	if (spn_host.empty()) {
+		throw InvalidInputException(
+			"Cannot derive a Kerberos SPN from the IP address '%s': Active Directory registers SQL Server SPNs "
+			"against the host's FQDN, and no reverse DNS record was found for it. Connect by name, add a PTR "
+			"record, or pass the SPN explicitly: service_principal_name=MSSQLSvc/<fqdn>:%d",
+			info.host, info.port);
+	}
+	return std::string("MSSQLSvc/") + spn_host + ":" + std::to_string(info.port);
 }
 
 }  // namespace
+
+std::string ResolveHostForSpn(const std::string &host) {
+	if (host.empty()) {
+		return host;
+	}
+
+	// Only IP literals need resolving. A name is already what AD registers
+	// against, and looking it up would risk turning a working SPN into a
+	// different one (a CNAME resolving to some other canonical name).
+	sockaddr_in v4 = {};
+	sockaddr_in6 v6 = {};
+	const sockaddr *addr = nullptr;
+	socklen_t addr_len = 0;
+	if (inet_pton(AF_INET, host.c_str(), &v4.sin_addr) == 1) {
+		v4.sin_family = AF_INET;
+		addr = reinterpret_cast<const sockaddr *>(&v4);
+		addr_len = sizeof(v4);
+	} else if (inet_pton(AF_INET6, host.c_str(), &v6.sin6_addr) == 1) {
+		v6.sin6_family = AF_INET6;
+		addr = reinterpret_cast<const sockaddr *>(&v6);
+		addr_len = sizeof(v6);
+	} else {
+		return host;  // already a name
+	}
+
+	char fqdn[NI_MAXHOST] = {0};
+	// NI_NAMEREQD: fail rather than hand back the numeric form, which is what
+	// getnameinfo does by default and would silently reproduce the bug.
+	if (getnameinfo(addr, addr_len, fqdn, sizeof(fqdn), nullptr, 0, NI_NAMEREQD) != 0) {
+		return std::string();  // caller reports this; see the header
+	}
+	std::string resolved(fqdn);
+	// A trailing dot is legal in DNS and not wanted in an SPN.
+	if (!resolved.empty() && resolved.back() == '.') {
+		resolved.pop_back();
+	}
+	return resolved;
+}
 
 AuthStrategyPtr AuthStrategyFactory::Create(const MSSQLConnectionInfo &conn_info, ClientContext *context) {
 	// Spec 047 FR-014 / T065: single resolution point for LOGIN7 program_name.

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -111,10 +111,16 @@ std::string ResolveHostForSpn(const std::string &host) {
 #if defined(_WIN32)
 	std::call_once(spn_winsock_once, EnsureWinsockForResolution);
 	if (!spn_winsock_ready) {
-		// Without Winsock we cannot even tell an address from a name, so answer
-		// "unresolvable" rather than guess. Not cached: WSAStartup failing is a
-		// property of the process at this instant, not of the host.
-		return std::string();
+		// Without Winsock we cannot tell an address from a name. Returning
+		// empty would make DeriveDefaultSpn report every host -- including
+		// plain hostnames -- as "an IP address with no reverse DNS record",
+		// which is wrong about the input AND the cause. Pass the host through
+		// instead: a name then behaves exactly as it always has, and an IP gets
+		// the pre-issue-#259 SPN, which is no worse than before and academic
+		// anyway, since nothing can open a socket in this state either. Not
+		// cached -- WSAStartup failing is a property of the process right now,
+		// not of the host.
+		return host;
 	}
 #endif
 
@@ -152,19 +158,17 @@ std::string ResolveHostForSpn(const std::string &host) {
 		addr = reinterpret_cast<const sockaddr *>(&v6);
 		addr_len = sizeof(v6);
 	} else {
-		// Not parseable as an address -- normally that means it IS a name. But
-		// inet_pton can also fail because Winsock never came up, and treating
-		// an IP literal as a name is exactly the unmatchable-SPN bug this path
-		// exists to prevent (issue #259). So: a string made only of hex digits,
-		// dots and colons cannot be a hostname, and is refused rather than
-		// cached as one.
-		const bool looks_like_address =
-			!host.empty() && host.find_first_not_of("0123456789abcdefABCDEF.:") == std::string::npos;
-		if (looks_like_address) {
-			return std::string();  // caller reports it; never cached
-		}
+		// Not parseable as an address, so it is a name.
+		//
+		// There is deliberately NO "does this look like an address anyway"
+		// heuristic here. One was tried, refusing any host made only of hex
+		// digits, dots and colons -- which is every short hostname a Windows
+		// shop uses: db01, dc01, ad01 all match, and integrated auth against
+		// them broke outright. The case it guarded against (inet_pton failing
+		// because Winsock never started) is already handled by the readiness
+		// gate at the top of this function, which returns before we get here.
 		std::lock_guard<std::mutex> guard(cache_mutex);
-		cache[host] = host;	 // already a name; no lookup was performed
+		cache[host] = host;	 // no lookup was performed
 		return host;
 	}
 

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -86,18 +86,38 @@ static std::string DeriveSpn(const MSSQLConnectionInfo &info) {
 
 }  // namespace
 
+#if defined(_WIN32)
+// inet_pton and getnameinfo are Winsock calls and need WSAStartup first.
+// TdsSocket does that inside Connect(), which has NOT run when
+// mssql_winsspi_auth_test() is the first thing a process does -- resolution
+// would then fail with WSANOTINITIALISED, or inet_pton would fail and the
+// address be treated as a name, which is the unmatchable SPN issue #259 is
+// about. So this path initialises Winsock itself.
+static std::once_flag spn_winsock_once;
+static void EnsureWinsockForResolution() {
+	WSADATA wsa_data;
+	if (WSAStartup(MAKEWORD(2, 2), &wsa_data) == 0) {
+		atexit([]() { WSACleanup(); });
+	}
+}
+#endif
+
 std::string ResolveHostForSpn(const std::string &host) {
 	if (host.empty()) {
 		return host;
 	}
+#if defined(_WIN32)
+	std::call_once(spn_winsock_once, EnsureWinsockForResolution);
+#endif
 
 	// Memoized because this sits on the pool-refill path: a fresh strategy is
 	// built per login attempt and again per routing hop, and getnameinfo is a
-	// blocking resolver call. The negative results are the ones that matter --
-	// an IP with no PTR record costs the full resolver timeout every time, and
-	// the answer is always the same. A host's PTR record changing mid-process
-	// therefore needs a restart to be picked up, which is the right trade for a
-	// value that is fixed for the life of an ATTACH.
+	// blocking resolver call. Only DEFINITIVE answers are cached: a successful
+	// resolution, a name that needed no lookup, and EAI_NONAME ("this address
+	// has no PTR record"). A transient failure is retried, because a resolver
+	// that is down says nothing about the host. A PTR record changing
+	// mid-process needs a restart to be picked up, which is the right trade for
+	// a value fixed for the life of an ATTACH.
 	static std::mutex cache_mutex;
 	static std::map<std::string, std::string> cache;
 	{
@@ -132,9 +152,20 @@ std::string ResolveHostForSpn(const std::string &host) {
 	char fqdn[NI_MAXHOST] = {0};
 	// NI_NAMEREQD: fail rather than hand back the numeric form, which is what
 	// getnameinfo does by default and would silently reproduce the bug.
-	if (getnameinfo(addr, addr_len, fqdn, sizeof(fqdn), nullptr, 0, NI_NAMEREQD) != 0) {
-		std::lock_guard<std::mutex> guard(cache_mutex);
-		cache[host] = std::string();
+	const int rc = getnameinfo(addr, addr_len, fqdn, sizeof(fqdn), nullptr, 0, NI_NAMEREQD);
+	if (rc != 0) {
+		// Cache ONLY a definitive "this address has no name". EAI_AGAIN is a
+		// resolver that is unreachable or timing out -- routine while a
+		// container stack is coming up, which is the situation lazy_validation
+		// exists for -- and caching it would keep failing every later ATTACH
+		// and every routing hop until the process restarts, long after DNS
+		// recovered. EAI_FAIL and anything else get the same treatment: retry.
+#if defined(EAI_NONAME)
+		if (rc == EAI_NONAME) {
+			std::lock_guard<std::mutex> guard(cache_mutex);
+			cache[host] = std::string();
+		}
+#endif
 		return std::string();  // caller reports this; see the header
 	}
 	std::string resolved(fqdn);

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -7,6 +7,31 @@
 // Spec 031: Connection & FEDAUTH Refactoring - US7
 //===----------------------------------------------------------------------===//
 
+// Winsock MUST be included before anything that can reach <windows.h>.
+//
+// windows.h pulls in <winsock.h> -- Winsock 1.1 -- unless WIN32_LEAN_AND_MEAN
+// is already defined, and tds/auth/winsspi_authenticator.hpp (included below
+// whenever MSSQL_ENABLE_SSPI is set, i.e. every Windows build) includes
+// windows.h without it. A <winsock2.h> arriving afterwards then redefines
+// sockaddr, fd_set, timeval, WSAData and a dozen more -- around 40 C2011s,
+// which is exactly how this file first broke the MSVC build.
+//
+// Including winsock2.h first also defines _WINSOCKAPI_, so the later
+// windows.h skips winsock.h entirely. Same ordering tds_socket.cpp uses.
+// Fenced because clang-format's SortIncludes would happily undo it.
+// clang-format off
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+// clang-format on
+
 #include "tds/auth/auth_strategy_factory.hpp"
 #include "azure/azure_token.hpp"
 #include "mssql_storage.hpp"
@@ -25,13 +50,7 @@
 #include <mutex>
 #include <string>
 
-#if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#else
+#if !defined(_WIN32)
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -94,9 +94,11 @@ static std::string DeriveSpn(const MSSQLConnectionInfo &info) {
 // address be treated as a name, which is the unmatchable SPN issue #259 is
 // about. So this path initialises Winsock itself.
 static std::once_flag spn_winsock_once;
+static bool spn_winsock_ready = false;
 static void EnsureWinsockForResolution() {
 	WSADATA wsa_data;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa_data) == 0) {
+		spn_winsock_ready = true;
 		atexit([]() { WSACleanup(); });
 	}
 }
@@ -108,6 +110,12 @@ std::string ResolveHostForSpn(const std::string &host) {
 	}
 #if defined(_WIN32)
 	std::call_once(spn_winsock_once, EnsureWinsockForResolution);
+	if (!spn_winsock_ready) {
+		// Without Winsock we cannot even tell an address from a name, so answer
+		// "unresolvable" rather than guess. Not cached: WSAStartup failing is a
+		// property of the process at this instant, not of the host.
+		return std::string();
+	}
 #endif
 
 	// Memoized because this sits on the pool-refill path: a fresh strategy is
@@ -144,6 +152,17 @@ std::string ResolveHostForSpn(const std::string &host) {
 		addr = reinterpret_cast<const sockaddr *>(&v6);
 		addr_len = sizeof(v6);
 	} else {
+		// Not parseable as an address -- normally that means it IS a name. But
+		// inet_pton can also fail because Winsock never came up, and treating
+		// an IP literal as a name is exactly the unmatchable-SPN bug this path
+		// exists to prevent (issue #259). So: a string made only of hex digits,
+		// dots and colons cannot be a hostname, and is refused rather than
+		// cached as one.
+		const bool looks_like_address =
+			!host.empty() && host.find_first_not_of("0123456789abcdefABCDEF.:") == std::string::npos;
+		if (looks_like_address) {
+			return std::string();  // caller reports it; never cached
+		}
 		std::lock_guard<std::mutex> guard(cache_mutex);
 		cache[host] = host;	 // already a name; no lookup was performed
 		return host;
@@ -160,12 +179,29 @@ std::string ResolveHostForSpn(const std::string &host) {
 		// exists for -- and caching it would keep failing every later ATTACH
 		// and every routing hop until the process restarts, long after DNS
 		// recovered. EAI_FAIL and anything else get the same treatment: retry.
-#if defined(EAI_NONAME)
-		if (rc == EAI_NONAME) {
+#if defined(_WIN32)
+		// getnameinfo on Windows documents only "nonzero on failure"; the code
+		// comes from WSAGetLastError. WSANO_DATA is "the name exists but has no
+		// record of this type", which for a PTR query is as definitive as
+		// WSAHOST_NOT_FOUND -- classifying only the latter would mean never
+		// caching a negative on Windows, and paying the full resolver timeout
+		// on every pool refill and every routing hop. Silent, and merely slow.
+		const int wsa_err = WSAGetLastError();
+		const bool definitive = (wsa_err == WSAHOST_NOT_FOUND || wsa_err == WSANO_DATA);
+#elif defined(EAI_NONAME)
+		// EAI_NODATA is deprecated/absent on some libcs, hence the guard.
+#if defined(EAI_NODATA)
+		const bool definitive = (rc == EAI_NONAME || rc == EAI_NODATA);
+#else
+		const bool definitive = (rc == EAI_NONAME);
+#endif
+#else
+		const bool definitive = false;
+#endif
+		if (definitive) {
 			std::lock_guard<std::mutex> guard(cache_mutex);
 			cache[host] = std::string();
 		}
-#endif
 		return std::string();  // caller reports this; see the header
 	}
 	std::string resolved(fqdn);
@@ -193,6 +229,16 @@ std::string DeriveDefaultSpn(const std::string &host, uint16_t port) {
 			host, port);
 	}
 	return std::string("MSSQLSvc/") + spn_host + ":" + std::to_string(port);
+}
+
+bool TryDeriveDefaultSpn(const std::string &host, uint16_t port, std::string &spn, std::string &error) {
+	try {
+		spn = DeriveDefaultSpn(host, port);
+		return true;
+	} catch (const std::exception &e) {
+		error = e.what();
+		return false;
+	}
 }
 
 AuthStrategyPtr AuthStrategyFactory::Create(const MSSQLConnectionInfo &conn_info, ClientContext *context) {

--- a/src/tds/auth/auth_strategy_factory.cpp
+++ b/src/tds/auth/auth_strategy_factory.cpp
@@ -21,6 +21,8 @@
 #endif
 
 #include <cstring>
+#include <map>
+#include <mutex>
 #include <string>
 
 #if defined(_WIN32)
@@ -77,18 +79,9 @@ static std::string DeriveSpn(const MSSQLConnectionInfo &info) {
 		// Hostbased form (@) -- pass through unchanged.
 		return spn;
 	}
-	// No override: build the canonical "MSSQLSvc/<fqdn>:<port>" form so the
-	// SPN matches what SQL Server registers in AD by default. An IP literal is
-	// reverse-resolved first -- AD registers names, not addresses (issue #259).
-	const std::string spn_host = ResolveHostForSpn(info.host);
-	if (spn_host.empty()) {
-		throw InvalidInputException(
-			"Cannot derive a Kerberos SPN from the IP address '%s': Active Directory registers SQL Server SPNs "
-			"against the host's FQDN, and no reverse DNS record was found for it. Connect by name, add a PTR "
-			"record, or pass the SPN explicitly: service_principal_name=MSSQLSvc/<fqdn>:%d",
-			info.host, info.port);
-	}
-	return std::string("MSSQLSvc/") + spn_host + ":" + std::to_string(info.port);
+	// No override: the canonical "MSSQLSvc/<fqdn>:<port>" form, shared with the
+	// diagnostic functions so they cannot disagree about it (issue #259).
+	return DeriveDefaultSpn(info.host, info.port);
 }
 
 }  // namespace
@@ -96,6 +89,23 @@ static std::string DeriveSpn(const MSSQLConnectionInfo &info) {
 std::string ResolveHostForSpn(const std::string &host) {
 	if (host.empty()) {
 		return host;
+	}
+
+	// Memoized because this sits on the pool-refill path: a fresh strategy is
+	// built per login attempt and again per routing hop, and getnameinfo is a
+	// blocking resolver call. The negative results are the ones that matter --
+	// an IP with no PTR record costs the full resolver timeout every time, and
+	// the answer is always the same. A host's PTR record changing mid-process
+	// therefore needs a restart to be picked up, which is the right trade for a
+	// value that is fixed for the life of an ATTACH.
+	static std::mutex cache_mutex;
+	static std::map<std::string, std::string> cache;
+	{
+		std::lock_guard<std::mutex> guard(cache_mutex);
+		auto it = cache.find(host);
+		if (it != cache.end()) {
+			return it->second;
+		}
 	}
 
 	// Only IP literals need resolving. A name is already what AD registers
@@ -114,13 +124,17 @@ std::string ResolveHostForSpn(const std::string &host) {
 		addr = reinterpret_cast<const sockaddr *>(&v6);
 		addr_len = sizeof(v6);
 	} else {
-		return host;  // already a name
+		std::lock_guard<std::mutex> guard(cache_mutex);
+		cache[host] = host;	 // already a name; no lookup was performed
+		return host;
 	}
 
 	char fqdn[NI_MAXHOST] = {0};
 	// NI_NAMEREQD: fail rather than hand back the numeric form, which is what
 	// getnameinfo does by default and would silently reproduce the bug.
 	if (getnameinfo(addr, addr_len, fqdn, sizeof(fqdn), nullptr, 0, NI_NAMEREQD) != 0) {
+		std::lock_guard<std::mutex> guard(cache_mutex);
+		cache[host] = std::string();
 		return std::string();  // caller reports this; see the header
 	}
 	std::string resolved(fqdn);
@@ -128,7 +142,26 @@ std::string ResolveHostForSpn(const std::string &host) {
 	if (!resolved.empty() && resolved.back() == '.') {
 		resolved.pop_back();
 	}
+	{
+		std::lock_guard<std::mutex> guard(cache_mutex);
+		cache[host] = resolved;
+	}
 	return resolved;
+}
+
+std::string DeriveDefaultSpn(const std::string &host, uint16_t port) {
+	const std::string spn_host = ResolveHostForSpn(host);
+	if (spn_host.empty()) {
+		if (host.empty()) {
+			throw InvalidInputException("Cannot derive a Kerberos SPN: no host was supplied.");
+		}
+		throw InvalidInputException(
+			"Cannot derive a Kerberos SPN from the IP address '%s': Active Directory registers SQL Server SPNs "
+			"against the host's FQDN, and no reverse DNS record was found for it. Connect by name, add a PTR "
+			"record, or pass the SPN explicitly: service_principal_name=MSSQLSvc/<fqdn>:%d",
+			host, port);
+	}
+	return std::string("MSSQLSvc/") + spn_host + ":" + std::to_string(port);
 }
 
 AuthStrategyPtr AuthStrategyFactory::Create(const MSSQLConnectionInfo &conn_info, ClientContext *context) {

--- a/src/tds/auth/krb5_test_function.cpp
+++ b/src/tds/auth/krb5_test_function.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "tds/auth/krb5_test_function.hpp"
+#include "tds/auth/auth_strategy_factory.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -109,12 +110,12 @@ static std::string RunKrb5Test(tds::Krb5Config config) {
 }
 
 //===----------------------------------------------------------------------===//
-// DeriveDefaultSpn - same logic as auth_strategy_factory.cpp's DeriveSpn
-// for the (host, port) form. Kept local here to avoid a circular include.
+// SPN derivation comes from auth_strategy_factory.hpp (tds::DeriveDefaultSpn),
+// NOT from a local copy. This function exists to tell a user why a Kerberos
+// login is failing; reporting an SPN the connection path would not actually
+// request is worse than reporting nothing. Issue #259 made them diverge for IP
+// literals -- the real path reverse-resolves, the local copy did not.
 //===----------------------------------------------------------------------===//
-static std::string DeriveDefaultSpn(const std::string &host, uint16_t port) {
-	return "MSSQLSvc/" + host + ":" + std::to_string(port);
-}
 
 //===----------------------------------------------------------------------===//
 // Krb5TestHost - mssql_kerberos_auth_test(host VARCHAR) -> VARCHAR
@@ -124,7 +125,7 @@ static void Krb5TestHost(DataChunk &args, ExpressionState & /*state*/, Vector &r
 	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
 		std::string h = host.GetString();
 		tds::Krb5Config cfg;
-		cfg.spn = DeriveDefaultSpn(h, 1433);
+		cfg.spn = tds::DeriveDefaultSpn(h, 1433);
 		return StringVector::AddString(result, RunKrb5Test(std::move(cfg)));
 	});
 }
@@ -139,7 +140,7 @@ static void Krb5TestHostPort(DataChunk &args, ExpressionState & /*state*/, Vecto
 		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
 			std::string h = host.GetString();
 			tds::Krb5Config cfg;
-			cfg.spn = DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
 			return StringVector::AddString(result, RunKrb5Test(std::move(cfg)));
 		});
 }
@@ -183,7 +184,7 @@ static void Krb5TestSecret(DataChunk &args, ExpressionState &state, Vector &resu
 				cfg.spn = spn;
 			}
 		} else {
-			cfg.spn = DeriveDefaultSpn(info->host, info->port);
+			cfg.spn = tds::DeriveDefaultSpn(info->host, info->port);
 		}
 		cfg.configfile = info->krb5_configfile;
 		cfg.keytabfile = info->krb5_keytabfile;

--- a/src/tds/auth/krb5_test_function.cpp
+++ b/src/tds/auth/krb5_test_function.cpp
@@ -125,7 +125,14 @@ static void Krb5TestHost(DataChunk &args, ExpressionState & /*state*/, Vector &r
 	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
 		std::string h = host.GetString();
 		tds::Krb5Config cfg;
-		cfg.spn = tds::DeriveDefaultSpn(h, 1433);
+		try {
+			cfg.spn = tds::DeriveDefaultSpn(h, 1433);
+		} catch (const std::exception &e) {
+			// These functions report; they do not throw. An unresolvable IP is
+			// precisely what a user runs this to diagnose (issue #259), so the
+			// explanation has to come back as the result string.
+			return StringVector::AddString(result, std::string(e.what()));
+		}
 		return StringVector::AddString(result, RunKrb5Test(std::move(cfg)));
 	});
 }
@@ -140,7 +147,14 @@ static void Krb5TestHostPort(DataChunk &args, ExpressionState & /*state*/, Vecto
 		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
 			std::string h = host.GetString();
 			tds::Krb5Config cfg;
-			cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			try {
+				cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			} catch (const std::exception &e) {
+				// These functions report; they do not throw. An unresolvable IP is
+				// precisely what a user runs this to diagnose (issue #259), so the
+				// explanation has to come back as the result string.
+				return StringVector::AddString(result, std::string(e.what()));
+			}
 			return StringVector::AddString(result, RunKrb5Test(std::move(cfg)));
 		});
 }
@@ -184,7 +198,14 @@ static void Krb5TestSecret(DataChunk &args, ExpressionState &state, Vector &resu
 				cfg.spn = spn;
 			}
 		} else {
-			cfg.spn = tds::DeriveDefaultSpn(info->host, info->port);
+			try {
+				cfg.spn = tds::DeriveDefaultSpn(info->host, info->port);
+			} catch (const std::exception &e) {
+				// These functions report; they do not throw. An unresolvable IP is
+				// precisely what a user runs this to diagnose (issue #259), so the
+				// explanation has to come back as the result string.
+				return StringVector::AddString(result, std::string(e.what()));
+			}
 		}
 		cfg.configfile = info->krb5_configfile;
 		cfg.keytabfile = info->krb5_keytabfile;

--- a/src/tds/auth/krb5_test_function.cpp
+++ b/src/tds/auth/krb5_test_function.cpp
@@ -125,13 +125,9 @@ static void Krb5TestHost(DataChunk &args, ExpressionState & /*state*/, Vector &r
 	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
 		std::string h = host.GetString();
 		tds::Krb5Config cfg;
-		try {
-			cfg.spn = tds::DeriveDefaultSpn(h, 1433);
-		} catch (const std::exception &e) {
-			// These functions report; they do not throw. An unresolvable IP is
-			// precisely what a user runs this to diagnose (issue #259), so the
-			// explanation has to come back as the result string.
-			return StringVector::AddString(result, std::string(e.what()));
+		std::string spn_error;
+		if (!tds::TryDeriveDefaultSpn(h, 1433, cfg.spn, spn_error)) {
+			return StringVector::AddString(result, std::string("MSSQL Kerberos auth test: ") + spn_error);
 		}
 		return StringVector::AddString(result, RunKrb5Test(std::move(cfg)));
 	});
@@ -147,13 +143,9 @@ static void Krb5TestHostPort(DataChunk &args, ExpressionState & /*state*/, Vecto
 		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
 			std::string h = host.GetString();
 			tds::Krb5Config cfg;
-			try {
-				cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
-			} catch (const std::exception &e) {
-				// These functions report; they do not throw. An unresolvable IP is
-				// precisely what a user runs this to diagnose (issue #259), so the
-				// explanation has to come back as the result string.
-				return StringVector::AddString(result, std::string(e.what()));
+			std::string spn_error;
+			if (!tds::TryDeriveDefaultSpn(h, static_cast<uint16_t>(port), cfg.spn, spn_error)) {
+				return StringVector::AddString(result, std::string("MSSQL Kerberos auth test: ") + spn_error);
 			}
 			return StringVector::AddString(result, RunKrb5Test(std::move(cfg)));
 		});
@@ -198,13 +190,9 @@ static void Krb5TestSecret(DataChunk &args, ExpressionState &state, Vector &resu
 				cfg.spn = spn;
 			}
 		} else {
-			try {
-				cfg.spn = tds::DeriveDefaultSpn(info->host, info->port);
-			} catch (const std::exception &e) {
-				// These functions report; they do not throw. An unresolvable IP is
-				// precisely what a user runs this to diagnose (issue #259), so the
-				// explanation has to come back as the result string.
-				return StringVector::AddString(result, std::string(e.what()));
+			std::string spn_error;
+			if (!tds::TryDeriveDefaultSpn(info->host, info->port, cfg.spn, spn_error)) {
+				return StringVector::AddString(result, std::string("MSSQL Kerberos auth test: ") + spn_error);
 			}
 		}
 		cfg.configfile = info->krb5_configfile;

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -130,13 +130,9 @@ static void WinSspiTestHost(DataChunk &args, ExpressionState & /*state*/, Vector
 	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
 		std::string h = host.GetString();
 		tds::WinSspiConfig cfg;
-		try {
-			cfg.spn = tds::DeriveDefaultSpn(h, 1433);
-		} catch (const std::exception &e) {
-			// These functions report; they do not throw. An unresolvable IP is
-			// precisely what a user runs this to diagnose (issue #259), so the
-			// explanation has to come back as the result string.
-			return StringVector::AddString(result, std::string(e.what()));
+		std::string spn_error;
+		if (!tds::TryDeriveDefaultSpn(h, 1433, cfg.spn, spn_error)) {
+			return StringVector::AddString(result, std::string("MSSQL SSPI auth test: ") + spn_error);
 		}
 		return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
 	});
@@ -152,13 +148,9 @@ static void WinSspiTestHostPort(DataChunk &args, ExpressionState & /*state*/, Ve
 		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
 			std::string h = host.GetString();
 			tds::WinSspiConfig cfg;
-			try {
-				cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
-			} catch (const std::exception &e) {
-				// These functions report; they do not throw. An unresolvable IP is
-				// precisely what a user runs this to diagnose (issue #259), so the
-				// explanation has to come back as the result string.
-				return StringVector::AddString(result, std::string(e.what()));
+			std::string spn_error;
+			if (!tds::TryDeriveDefaultSpn(h, static_cast<uint16_t>(port), cfg.spn, spn_error)) {
+				return StringVector::AddString(result, std::string("MSSQL SSPI auth test: ") + spn_error);
 			}
 			return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
 		});

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -130,7 +130,14 @@ static void WinSspiTestHost(DataChunk &args, ExpressionState & /*state*/, Vector
 	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
 		std::string h = host.GetString();
 		tds::WinSspiConfig cfg;
-		cfg.spn = tds::DeriveDefaultSpn(h, 1433);
+		try {
+			cfg.spn = tds::DeriveDefaultSpn(h, 1433);
+		} catch (const std::exception &e) {
+			// These functions report; they do not throw. An unresolvable IP is
+			// precisely what a user runs this to diagnose (issue #259), so the
+			// explanation has to come back as the result string.
+			return StringVector::AddString(result, std::string(e.what()));
+		}
 		return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
 	});
 }
@@ -145,7 +152,14 @@ static void WinSspiTestHostPort(DataChunk &args, ExpressionState & /*state*/, Ve
 		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
 			std::string h = host.GetString();
 			tds::WinSspiConfig cfg;
-			cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			try {
+				cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			} catch (const std::exception &e) {
+				// These functions report; they do not throw. An unresolvable IP is
+				// precisely what a user runs this to diagnose (issue #259), so the
+				// explanation has to come back as the result string.
+				return StringVector::AddString(result, std::string(e.what()));
+			}
 			return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
 		});
 }

--- a/src/tds/auth/winsspi_test_function.cpp
+++ b/src/tds/auth/winsspi_test_function.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "tds/auth/winsspi_test_function.hpp"
+#include "tds/auth/auth_strategy_factory.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
@@ -114,11 +115,12 @@ static std::string RunWinSspiTest(tds::WinSspiConfig config) {
 }
 
 //===----------------------------------------------------------------------===//
-// DeriveDefaultSpn - canonical "MSSQLSvc/<host>:<port>" form
+// SPN derivation comes from auth_strategy_factory.hpp (tds::DeriveDefaultSpn),
+// NOT from a local copy. This function exists to tell a user why a Kerberos
+// login is failing; reporting an SPN the connection path would not actually
+// request is worse than reporting nothing. Issue #259 made them diverge for IP
+// literals -- the real path reverse-resolves, the local copy did not.
 //===----------------------------------------------------------------------===//
-static std::string DeriveDefaultSpn(const std::string &host, uint16_t port) {
-	return "MSSQLSvc/" + host + ":" + std::to_string(port);
-}
 
 //===----------------------------------------------------------------------===//
 // WinSspiTestHost - mssql_winsspi_auth_test(host VARCHAR) -> VARCHAR
@@ -128,7 +130,7 @@ static void WinSspiTestHost(DataChunk &args, ExpressionState & /*state*/, Vector
 	UnaryExecutor::Execute<string_t, string_t>(host_vec, result, args.size(), [&](string_t host) {
 		std::string h = host.GetString();
 		tds::WinSspiConfig cfg;
-		cfg.spn = DeriveDefaultSpn(h, 1433);
+		cfg.spn = tds::DeriveDefaultSpn(h, 1433);
 		return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
 	});
 }
@@ -143,7 +145,7 @@ static void WinSspiTestHostPort(DataChunk &args, ExpressionState & /*state*/, Ve
 		host_vec, port_vec, result, args.size(), [&](string_t host, int32_t port) {
 			std::string h = host.GetString();
 			tds::WinSspiConfig cfg;
-			cfg.spn = DeriveDefaultSpn(h, static_cast<uint16_t>(port));
+			cfg.spn = tds::DeriveDefaultSpn(h, static_cast<uint16_t>(port));
 			return StringVector::AddString(result, RunWinSspiTest(std::move(cfg)));
 		});
 }

--- a/src/tds/tds_connection.cpp
+++ b/src/tds/tds_connection.cpp
@@ -352,6 +352,8 @@ bool TdsConnection::RunWithRoutingHops(const std::function<LoginAttemptOutcome()
 		has_routing_ = false;
 		routed_server_.clear();
 		routed_port_ = 0;
+		last_error_number_ = 0;
+		last_error_state_ = 0;
 		next_packet_id_ = 1;
 		tls_enabled_ = false;
 		fedauth_echo_ = false;
@@ -709,6 +711,8 @@ LoginAttemptOutcome TdsConnection::DoLogin7WithFedAuth(const std::string &databa
 
 	// Check for success
 	if (!login_response.success) {
+		last_error_number_ = login_response.error_number;
+		last_error_state_ = login_response.error_state;
 		if (login_response.error_number > 0) {
 			last_error_ = "Azure AD authentication failed (error " + std::to_string(login_response.error_number) +
 						  "): " + login_response.error_message;
@@ -894,6 +898,8 @@ bool TdsConnection::AuthenticateIntegrated(const std::string &database, Authenti
 
 			if (!login_response.has_sspi_token) {
 				// No continuation requested and no LOGINACK -- server rejected the auth.
+				last_error_number_ = login_response.error_number;
+				last_error_state_ = login_response.error_state;
 				if (login_response.error_number > 0) {
 					last_error_ = "MSSQL Kerberos auth rejected by server (error " +
 								  std::to_string(login_response.error_number) + "): " + login_response.error_message;
@@ -1031,6 +1037,8 @@ LoginAttemptOutcome TdsConnection::DoLogin7(const std::string &username, const s
 	}
 
 	if (!login_response.success) {
+		last_error_number_ = login_response.error_number;
+		last_error_state_ = login_response.error_state;
 		if (login_response.error_number > 0) {
 			// Include the ERROR-token State byte: for 18456 it is the only field
 			// that distinguishes a bad password from an inaccessible default/initial

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -149,6 +149,62 @@ void TestServerPhraseWithoutNumber() {
 	std::cout << "  [ok] the server's phrase hints at credentials; our own wrapper's word does not" << std::endl;
 }
 
+// The heuristic branches (no server error number) used to return a canned
+// sentence and DISCARD the original text. These are the three messages
+// AuthenticateWithFedAuth actually sets, and the reason it mattered: two of
+// them describe a failure BEFORE any handshake, so "TLS handshake failed" was
+// not merely lossy but wrong.
+//
+// Note the shape of the old assertion this replaces: checking for "TLS
+// handshake failed" passed both before and after the fix, because the canned
+// string contained it. These assert on the part that was being thrown away.
+void TestPreHandshakeAzureFailuresKeepTheirText() {
+	const string not_sup = MSSQLTranslateConnectionError(
+		"TLS required for Azure AD but server does not support encryption", "az.database.windows.net", 1433, "", "db");
+	CHECK(Contains(not_sup, "does not support encryption"));
+
+	const string declined = MSSQLTranslateConnectionError("TLS required for Azure AD but server declined encryption",
+														  "az.database.windows.net", 1433, "", "db");
+	CHECK(Contains(declined, "declined encryption"));
+
+	// A real handshake failure must keep the OpenSSL reason, which is the only
+	// part that says what to change.
+	const string handshake = MSSQLTranslateConnectionError("TLS handshake failed: sslv3 alert handshake failure",
+														   "az.database.windows.net", 1433, "", "db");
+	CHECK(Contains(handshake, "sslv3 alert handshake failure"));
+
+	std::cout << "  [ok] pre-handshake and handshake failures keep the server/OpenSSL text" << std::endl;
+}
+
+// Every other heuristic branch had the same defect.
+void TestOtherHeuristicBranchesKeepTheirText() {
+	CHECK(Contains(MSSQLTranslateConnectionError("connect: connection refused", "s", 1433, "u", "db"),
+				   "connection refused"));
+	CHECK(Contains(MSSQLTranslateConnectionError("cannot resolve host: no such host", "nope", 1433, "u", "db"),
+				   "no such host"));
+	CHECK(Contains(MSSQLTranslateConnectionError("connect timed out after 30s", "s", 1433, "u", "db"), "after 30s"));
+	CHECK(Contains(MSSQLTranslateConnectionError("certificate verify failed: self signed", "s", 1433, "u", "db"),
+				   "self signed"));
+	std::cout << "  [ok] refused / DNS / timeout / certificate branches keep the original text" << std::endl;
+}
+
+// On the token-authenticated paths the identity comes from the token, so
+// info.user is empty and "for user ''" is less informative than nothing.
+void TestEmptyUserOmitsTheClause() {
+	const string out = MSSQLTranslateConnectionError(
+		"Authentication failed (error 18456, state 1): Login failed for user '<token-identified principal>'.",
+		"az.database.windows.net", 1433, /*user=*/"", "db", 18456, 1);
+
+	CHECK(!Contains(out, "for user ''"));
+	CHECK(Contains(out, "state 1"));					 // the byte still surfaces
+	CHECK(Contains(out, "token-identified principal"));	 // and the server's own text
+	// A named user still gets the clause.
+	const string named = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 8): Login failed.",
+													   "s", 1433, "app_user", "db", 18456, 8);
+	CHECK(Contains(named, "for user 'app_user'"));
+	std::cout << "  [ok] the \"for user\" clause is omitted when the identity came from a token" << std::endl;
+}
+
 }  // namespace
 
 int main() {
@@ -162,6 +218,9 @@ int main() {
 	TestUnknownServerErrorSurfacesVerbatim();
 	TestNonLoginFailuresStillClassified();
 	TestServerPhraseWithoutNumber();
+	TestPreHandshakeAzureFailuresKeepTheirText();
+	TestOtherHeuristicBranchesKeepTheirText();
+	TestEmptyUserOmitsTheClause();
 
 	std::cout << "All " << g_checks << " checks passed." << std::endl;
 	return 0;

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -43,9 +43,10 @@ bool Contains(const string &haystack, const string &needle) {
 // failed (error ...)" prefix, which is exactly why the old substring test
 // misfired. Classification must come from the number.
 void TestResumingAzureDatabaseIsNotACredentialProblem() {
-	const string raw =
-		"Authentication failed (error 40613, state 1): Database 'sales' on server "
-		"'x.database.windows.net' is not currently available. Please retry the connection later.";
+	// Raw carrying neither the number nor the database name: this arm echoes the
+	// raw after "Server said: ", so a raw containing them satisfies the
+	// assertions below even with the interpolations deleted.
+	const string raw = "Database is not currently available. Please retry the connection later.";
 	const string out = MSSQLTranslateConnectionError(raw, "x.database.windows.net", 1433, "azure_sql_admin", "sales",
 													 /*server_error=*/40613, /*server_state=*/1);
 
@@ -73,7 +74,8 @@ void TestOtherTransientAzureErrorsAreRetryable() {
 // 18456 IS a credential-family failure, and the State byte must survive to the
 // user -- that is the whole point of issue #164, and the old code threw it away.
 void TestLoginFailedKeepsStateByte() {
-	const string raw = "Authentication failed (error 18456, state 40): Login failed for user 'app_user'.";
+	// Same trap: no number in the raw, so "18456" can only come from the format.
+	const string raw = "Login failed for user 'app_user'.";
 	const string out = MSSQLTranslateConnectionError(raw, "sql1", 1433, "app_user", "reporting", 18456, 40);
 
 	CHECK(Contains(out, "app_user"));
@@ -215,6 +217,10 @@ void TestOtherHeuristicBranchesKeepTheirText() {
 	// of it is satisfied by the static text alone. Only the "Details: " marker
 	// followed by the echo proves the raw error survived.
 	CHECK(Contains(enc, "Details: Server requires encryption"));
+	// Disjoint from the above: the raw says use_encrypt=FALSE, so this needle
+	// comes only from the branch's remediation clause -- it catches that clause
+	// being deleted, which the join assertion does not.
+	CHECK(Contains(enc, "Set use_encrypt=true"));
 	std::cout << "  [ok] refused / DNS / timeout / certificate / ENCRYPT_REQ branches keep the original text"
 			  << std::endl;
 }

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -1,0 +1,168 @@
+// test/cpp/test_connection_error_translation.cpp
+// Unit tests for TranslateConnectionError (issue #262).
+//
+// The bug this pins: the translator used to decide "this is a credential
+// problem" by looking for the substring "authentication" in the error text --
+// but the text it was handed is OUR OWN wrapper, and every login failure this
+// extension produces begins "Authentication failed (error N, state S): ...".
+// So the arm matched unconditionally and every login-time server error, of any
+// cause, was reported as "check username and password". A paused Azure
+// serverless database resuming (error 40613) told the user to go check a
+// password that was never wrong, and the State byte that issue #164 added to
+// disambiguate 18456 was discarded on the way.
+//
+// These cases run without a server: they call the classifier directly.
+//
+// Build + run: make test-cpp (this file is in STANDALONE_TEST_SOURCES).
+
+#include <iostream>
+#include <string>
+
+#include "mssql_storage.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+int g_checks = 0;
+
+#define CHECK(cond)                                                                                             \
+	do {                                                                                                        \
+		g_checks++;                                                                                             \
+		if (!(cond)) {                                                                                          \
+			std::cerr << "ASSERT FAILED: " << #cond << " (" << __FILE__ << ":" << __LINE__ << ")" << std::endl; \
+			std::exit(1);                                                                                       \
+		}                                                                                                       \
+	} while (0)
+
+bool Contains(const string &haystack, const string &needle) {
+	return haystack.find(needle) != string::npos;
+}
+
+// The reported case. Azure SQL 40613 arrives wrapped in our own "Authentication
+// failed (error ...)" prefix, which is exactly why the old substring test
+// misfired. Classification must come from the number.
+void TestResumingAzureDatabaseIsNotACredentialProblem() {
+	const string raw =
+		"Authentication failed (error 40613, state 1): Database 'sales' on server "
+		"'x.database.windows.net' is not currently available. Please retry the connection later.";
+	const string out = TranslateConnectionError(raw, "x.database.windows.net", 1433, "azure_sql_admin", "sales",
+												/*server_error=*/40613, /*server_state=*/1);
+
+	CHECK(!Contains(out, "check username and password"));  // the whole point
+	CHECK(Contains(out, "not available yet"));
+	CHECK(Contains(out, "40613"));
+	CHECK(Contains(out, "retry"));
+	CHECK(Contains(out, "sales"));
+	CHECK(Contains(out, "not currently available"));  // the server's own words survive
+	std::cout << "  [ok] 40613 (database resuming) is reported as retryable, not as bad credentials" << std::endl;
+}
+
+// 40197 / 40501 / 49918 are the same family: transient Azure conditions.
+void TestOtherTransientAzureErrorsAreRetryable() {
+	for (uint32_t code : {40197u, 40501u, 49918u}) {
+		const string out =
+			TranslateConnectionError("Authentication failed (error " + std::to_string(code) + ", state 1): transient",
+									 "h", 1433, "u", "db", code, 1);
+		CHECK(!Contains(out, "check username and password"));
+		CHECK(Contains(out, "retry"));
+	}
+	std::cout << "  [ok] 40197 / 40501 / 49918 also classified as retryable" << std::endl;
+}
+
+// 18456 IS a credential-family failure, and the State byte must survive to the
+// user -- that is the whole point of issue #164, and the old code threw it away.
+void TestLoginFailedKeepsStateByte() {
+	const string raw = "Authentication failed (error 18456, state 40): Login failed for user 'app_user'.";
+	const string out = TranslateConnectionError(raw, "sql1", 1433, "app_user", "reporting", 18456, 40);
+
+	CHECK(Contains(out, "app_user"));
+	CHECK(Contains(out, "18456"));
+	CHECK(Contains(out, "state 40"));		   // issue #164's byte, preserved
+	CHECK(Contains(out, "initial database"));  // and explained
+	CHECK(Contains(out, "Login failed for user"));
+	std::cout << "  [ok] 18456 keeps the State byte and explains what it means (issue #164)" << std::endl;
+}
+
+// A wrong password is state 8 -- same number, different cause, and the message
+// must not read identically to the state-40 case above.
+void TestWrongPasswordAndInaccessibleDatabaseDiffer() {
+	const string a = TranslateConnectionError("Authentication failed (error 18456, state 8): Login failed.", "s", 1433,
+											  "u", "db", 18456, 8);
+	const string b = TranslateConnectionError("Authentication failed (error 18456, state 40): Login failed.", "s", 1433,
+											  "u", "db", 18456, 40);
+	CHECK(a != b);
+	CHECK(Contains(a, "state 8"));
+	CHECK(Contains(b, "state 40"));
+	std::cout << "  [ok] state 8 and state 40 produce different messages" << std::endl;
+}
+
+// 4060 is a database-access failure, not a credential one.
+void TestCannotOpenDatabase() {
+	const string out = TranslateConnectionError("Authentication failed (error 4060, state 1): Cannot open database",
+												"s", 1433, "u", "missing_db", 4060, 1);
+	CHECK(Contains(out, "missing_db"));
+	CHECK(Contains(out, "check database name and permissions"));
+	CHECK(!Contains(out, "check username and password"));
+	std::cout << "  [ok] 4060 points at the database, not the password" << std::endl;
+}
+
+// An unrecognised server error must still surface its number, state and text
+// rather than being flattened into a guess.
+void TestUnknownServerErrorSurfacesVerbatim() {
+	const string out = TranslateConnectionError("Authentication failed (error 12345, state 7): something specific", "s",
+												1433, "u", "db", 12345, 7);
+	CHECK(Contains(out, "12345"));
+	CHECK(Contains(out, "7"));
+	CHECK(Contains(out, "something specific"));
+	CHECK(!Contains(out, "check username and password"));
+	std::cout << "  [ok] an unknown server error keeps its number, state and text" << std::endl;
+}
+
+// Failures that never reached a login carry no number, and the string
+// heuristics still have to work.
+void TestNonLoginFailuresStillClassified() {
+	const string refused = TranslateConnectionError("connect: connection refused", "s", 1433, "u", "db");
+	CHECK(Contains(refused, "Connection refused"));
+
+	const string tls = TranslateConnectionError("TLS handshake failed: bad record", "s", 1433, "u", "db");
+	CHECK(Contains(tls, "TLS handshake failed"));
+
+	const string timeout = TranslateConnectionError("connect timed out", "s", 1433, "u", "db");
+	CHECK(Contains(timeout, "timed out"));
+	std::cout << "  [ok] socket / TLS / timeout failures still classified without a server number" << std::endl;
+}
+
+// The server's own "Login failed for user" phrase, with no number available,
+// should still give the credential hint -- but the word "authentication" alone
+// must never trigger it, since our own wrapper always contains it.
+void TestServerPhraseWithoutNumber() {
+	const string out = TranslateConnectionError("Login failed for user 'sa'.", "s", 1433, "sa", "db");
+	CHECK(Contains(out, "check username and password"));
+
+	// This is the shape that used to swallow everything: our wrapper's word,
+	// no server number. It must NOT be called a credential problem.
+	const string wrapper_only =
+		TranslateConnectionError("Azure AD authentication failed: token audience rejected", "s", 1433, "u", "db");
+	CHECK(!Contains(wrapper_only, "check username and password"));
+	CHECK(Contains(wrapper_only, "token audience rejected"));
+	std::cout << "  [ok] the server's phrase hints at credentials; our own wrapper's word does not" << std::endl;
+}
+
+}  // namespace
+
+int main() {
+	std::cout << "test_connection_error_translation (issue #262)" << std::endl;
+
+	TestResumingAzureDatabaseIsNotACredentialProblem();
+	TestOtherTransientAzureErrorsAreRetryable();
+	TestLoginFailedKeepsStateByte();
+	TestWrongPasswordAndInaccessibleDatabaseDiffer();
+	TestCannotOpenDatabase();
+	TestUnknownServerErrorSurfacesVerbatim();
+	TestNonLoginFailuresStillClassified();
+	TestServerPhraseWithoutNumber();
+
+	std::cout << "All " << g_checks << " checks passed." << std::endl;
+	return 0;
+}

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -46,8 +46,8 @@ void TestResumingAzureDatabaseIsNotACredentialProblem() {
 	const string raw =
 		"Authentication failed (error 40613, state 1): Database 'sales' on server "
 		"'x.database.windows.net' is not currently available. Please retry the connection later.";
-	const string out = TranslateConnectionError(raw, "x.database.windows.net", 1433, "azure_sql_admin", "sales",
-												/*server_error=*/40613, /*server_state=*/1);
+	const string out = MSSQLTranslateConnectionError(raw, "x.database.windows.net", 1433, "azure_sql_admin", "sales",
+													 /*server_error=*/40613, /*server_state=*/1);
 
 	CHECK(!Contains(out, "check username and password"));  // the whole point
 	CHECK(Contains(out, "not available yet"));
@@ -61,9 +61,9 @@ void TestResumingAzureDatabaseIsNotACredentialProblem() {
 // 40197 / 40501 / 49918 are the same family: transient Azure conditions.
 void TestOtherTransientAzureErrorsAreRetryable() {
 	for (uint32_t code : {40197u, 40501u, 49918u}) {
-		const string out =
-			TranslateConnectionError("Authentication failed (error " + std::to_string(code) + ", state 1): transient",
-									 "h", 1433, "u", "db", code, 1);
+		const string out = MSSQLTranslateConnectionError(
+			"Authentication failed (error " + std::to_string(code) + ", state 1): transient", "h", 1433, "u", "db",
+			code, 1);
 		CHECK(!Contains(out, "check username and password"));
 		CHECK(Contains(out, "retry"));
 	}
@@ -74,7 +74,7 @@ void TestOtherTransientAzureErrorsAreRetryable() {
 // user -- that is the whole point of issue #164, and the old code threw it away.
 void TestLoginFailedKeepsStateByte() {
 	const string raw = "Authentication failed (error 18456, state 40): Login failed for user 'app_user'.";
-	const string out = TranslateConnectionError(raw, "sql1", 1433, "app_user", "reporting", 18456, 40);
+	const string out = MSSQLTranslateConnectionError(raw, "sql1", 1433, "app_user", "reporting", 18456, 40);
 
 	CHECK(Contains(out, "app_user"));
 	CHECK(Contains(out, "18456"));
@@ -87,10 +87,10 @@ void TestLoginFailedKeepsStateByte() {
 // A wrong password is state 8 -- same number, different cause, and the message
 // must not read identically to the state-40 case above.
 void TestWrongPasswordAndInaccessibleDatabaseDiffer() {
-	const string a = TranslateConnectionError("Authentication failed (error 18456, state 8): Login failed.", "s", 1433,
-											  "u", "db", 18456, 8);
-	const string b = TranslateConnectionError("Authentication failed (error 18456, state 40): Login failed.", "s", 1433,
-											  "u", "db", 18456, 40);
+	const string a = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 8): Login failed.", "s",
+												   1433, "u", "db", 18456, 8);
+	const string b = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 40): Login failed.", "s",
+												   1433, "u", "db", 18456, 40);
 	CHECK(a != b);
 	CHECK(Contains(a, "state 8"));
 	CHECK(Contains(b, "state 40"));
@@ -99,8 +99,8 @@ void TestWrongPasswordAndInaccessibleDatabaseDiffer() {
 
 // 4060 is a database-access failure, not a credential one.
 void TestCannotOpenDatabase() {
-	const string out = TranslateConnectionError("Authentication failed (error 4060, state 1): Cannot open database",
-												"s", 1433, "u", "missing_db", 4060, 1);
+	const string out = MSSQLTranslateConnectionError(
+		"Authentication failed (error 4060, state 1): Cannot open database", "s", 1433, "u", "missing_db", 4060, 1);
 	CHECK(Contains(out, "missing_db"));
 	CHECK(Contains(out, "check database name and permissions"));
 	CHECK(!Contains(out, "check username and password"));
@@ -110,8 +110,8 @@ void TestCannotOpenDatabase() {
 // An unrecognised server error must still surface its number, state and text
 // rather than being flattened into a guess.
 void TestUnknownServerErrorSurfacesVerbatim() {
-	const string out = TranslateConnectionError("Authentication failed (error 12345, state 7): something specific", "s",
-												1433, "u", "db", 12345, 7);
+	const string out = MSSQLTranslateConnectionError("Authentication failed (error 12345, state 7): something specific",
+													 "s", 1433, "u", "db", 12345, 7);
 	CHECK(Contains(out, "12345"));
 	CHECK(Contains(out, "7"));
 	CHECK(Contains(out, "something specific"));
@@ -122,13 +122,13 @@ void TestUnknownServerErrorSurfacesVerbatim() {
 // Failures that never reached a login carry no number, and the string
 // heuristics still have to work.
 void TestNonLoginFailuresStillClassified() {
-	const string refused = TranslateConnectionError("connect: connection refused", "s", 1433, "u", "db");
+	const string refused = MSSQLTranslateConnectionError("connect: connection refused", "s", 1433, "u", "db");
 	CHECK(Contains(refused, "Connection refused"));
 
-	const string tls = TranslateConnectionError("TLS handshake failed: bad record", "s", 1433, "u", "db");
+	const string tls = MSSQLTranslateConnectionError("TLS handshake failed: bad record", "s", 1433, "u", "db");
 	CHECK(Contains(tls, "TLS handshake failed"));
 
-	const string timeout = TranslateConnectionError("connect timed out", "s", 1433, "u", "db");
+	const string timeout = MSSQLTranslateConnectionError("connect timed out", "s", 1433, "u", "db");
 	CHECK(Contains(timeout, "timed out"));
 	std::cout << "  [ok] socket / TLS / timeout failures still classified without a server number" << std::endl;
 }
@@ -137,13 +137,13 @@ void TestNonLoginFailuresStillClassified() {
 // should still give the credential hint -- but the word "authentication" alone
 // must never trigger it, since our own wrapper always contains it.
 void TestServerPhraseWithoutNumber() {
-	const string out = TranslateConnectionError("Login failed for user 'sa'.", "s", 1433, "sa", "db");
+	const string out = MSSQLTranslateConnectionError("Login failed for user 'sa'.", "s", 1433, "sa", "db");
 	CHECK(Contains(out, "check username and password"));
 
 	// This is the shape that used to swallow everything: our wrapper's word,
 	// no server number. It must NOT be called a credential problem.
 	const string wrapper_only =
-		TranslateConnectionError("Azure AD authentication failed: token audience rejected", "s", 1433, "u", "db");
+		MSSQLTranslateConnectionError("Azure AD authentication failed: token audience rejected", "s", 1433, "u", "db");
 	CHECK(!Contains(wrapper_only, "check username and password"));
 	CHECK(Contains(wrapper_only, "token audience rejected"));
 	std::cout << "  [ok] the server's phrase hints at credentials; our own wrapper's word does not" << std::endl;

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -92,8 +92,16 @@ void TestWrongPasswordAndInaccessibleDatabaseDiffer() {
 	const string b = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 40): Login failed.", "s",
 												   1433, "u", "db", 18456, 40);
 	CHECK(a != b);
-	CHECK(Contains(a, "state 8"));
-	CHECK(Contains(b, "state 40"));
+	// "state 8" and "state 38/40" both occur in the branch's own static
+	// explanation, so asserting on them cannot fail even if server_state were
+	// dropped from the format. Assert on states the static text never names.
+	const string c = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 5): x", "s", 1433, "u",
+												   "db", 18456, 5);
+	const string d = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 11): x", "s", 1433, "u",
+												   "db", 18456, 11);
+	CHECK(Contains(c, "state 5"));
+	CHECK(Contains(d, "state 11"));
+	CHECK(c != d);
 	std::cout << "  [ok] state 8 and state 40 produce different messages" << std::endl;
 }
 

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -95,14 +95,17 @@ void TestWrongPasswordAndInaccessibleDatabaseDiffer() {
 	// "state 8" and "state 38/40" both occur in the branch's own static
 	// explanation, so asserting on them cannot fail even if server_state were
 	// dropped from the format. Assert on states the static text never names.
-	const string c = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 5): x", "s", 1433, "u",
-												   "db", 18456, 5);
-	const string d = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 11): x", "s", 1433, "u",
-												   "db", 18456, 11);
+	// The raw error deliberately does NOT mention a state: the 18456 branch
+	// echoes the raw text back ("Server said: %s"), so an assertion on a state
+	// that appears in the input is satisfied by the echo alone and cannot fail
+	// however the format string changes. Same trap as asserting on the branch's
+	// static explanation, one layer along.
+	const string c = MSSQLTranslateConnectionError("Login failed for user 'u'.", "s", 1433, "u", "db", 18456, 5);
+	const string d = MSSQLTranslateConnectionError("Login failed for user 'u'.", "s", 1433, "u", "db", 18456, 11);
 	CHECK(Contains(c, "state 5"));
 	CHECK(Contains(d, "state 11"));
 	CHECK(c != d);
-	std::cout << "  [ok] state 8 and state 40 produce different messages" << std::endl;
+	std::cout << "  [ok] the State byte reaches the message and distinguishes causes" << std::endl;
 }
 
 // 4060 is a database-access failure, not a credential one.
@@ -193,18 +196,27 @@ void TestOtherHeuristicBranchesKeepTheirText() {
 	CHECK(Contains(MSSQLTranslateConnectionError("connect timed out after 30s", "s", 1433, "u", "db"), "after 30s"));
 	CHECK(Contains(MSSQLTranslateConnectionError("certificate verify failed: self signed", "s", 1433, "u", "db"),
 				   "self signed"));
+
+	// The ENCRYPT_REQ arm. Its text carries no tls/ssl/handshake substring, so
+	// it correctly misses the TLS branch above and lands in its own -- which
+	// used to name neither the server nor the cause. With several ATTACHes in
+	// flight, "server requires encryption" without a host is unactionable.
+	const string enc = MSSQLTranslateConnectionError("Server requires encryption (ENCRYPT_REQ) but use_encrypt=false",
+													 "sql1", 1433, "u", "db");
+	CHECK(Contains(enc, "sql1:1433"));
+	CHECK(Contains(enc, "ENCRYPT_REQ"));
+	CHECK(Contains(enc, "use_encrypt=true"));  // the actionable half
 	std::cout << "  [ok] refused / DNS / timeout / certificate branches keep the original text" << std::endl;
 }
 
 // On the token-authenticated paths the identity comes from the token, so
 // info.user is empty and "for user ''" is less informative than nothing.
 void TestEmptyUserOmitsTheClause() {
-	const string out = MSSQLTranslateConnectionError(
-		"Authentication failed (error 18456, state 1): Login failed for user '<token-identified principal>'.",
-		"az.database.windows.net", 1433, /*user=*/"", "db", 18456, 1);
+	const string out = MSSQLTranslateConnectionError("Login failed for user '<token-identified principal>'.",
+													 "az.database.windows.net", 1433, /*user=*/"", "db", 18456, 5);
 
 	CHECK(!Contains(out, "for user ''"));
-	CHECK(Contains(out, "state 1"));					 // the byte still surfaces
+	CHECK(Contains(out, "state 5"));					 // the byte still surfaces
 	CHECK(Contains(out, "token-identified principal"));	 // and the server's own text
 	// A named user still gets the clause.
 	const string named = MSSQLTranslateConnectionError("Authentication failed (error 18456, state 8): Login failed.",

--- a/test/cpp/test_connection_error_translation.cpp
+++ b/test/cpp/test_connection_error_translation.cpp
@@ -121,10 +121,12 @@ void TestCannotOpenDatabase() {
 // An unrecognised server error must still surface its number, state and text
 // rather than being flattened into a guess.
 void TestUnknownServerErrorSurfacesVerbatim() {
-	const string out = MSSQLTranslateConnectionError("Authentication failed (error 12345, state 7): something specific",
-													 "s", 1433, "u", "db", 12345, 7);
+	// Raw text carrying neither the number nor the state: the default arm
+	// echoes the raw verbatim, so feeding it "error 12345 ... state 7" would
+	// satisfy these checks even with server_error/server_state dropped.
+	const string out = MSSQLTranslateConnectionError("something specific", "s", 1433, "u", "db", 12345, 7);
 	CHECK(Contains(out, "12345"));
-	CHECK(Contains(out, "7"));
+	CHECK(Contains(out, "state 7"));
 	CHECK(Contains(out, "something specific"));
 	CHECK(!Contains(out, "check username and password"));
 	std::cout << "  [ok] an unknown server error keeps its number, state and text" << std::endl;
@@ -137,10 +139,14 @@ void TestNonLoginFailuresStillClassified() {
 	CHECK(Contains(refused, "Connection refused"));
 
 	const string tls = MSSQLTranslateConnectionError("TLS handshake failed: bad record", "s", 1433, "u", "db");
-	CHECK(Contains(tls, "TLS handshake failed"));
+	// "TLS negotiation failed" is this branch's own wording -- the raw input says
+	// "handshake", so asserting on that would pass from the echo alone even if
+	// classification fell through to the generic arm.
+	CHECK(Contains(tls, "TLS negotiation failed"));
 
 	const string timeout = MSSQLTranslateConnectionError("connect timed out", "s", 1433, "u", "db");
-	CHECK(Contains(timeout, "timed out"));
+	// Same: "timed out" is in the raw. This fragment is only in the branch.
+	CHECK(Contains(timeout, "check network connectivity"));
 	std::cout << "  [ok] socket / TLS / timeout failures still classified without a server number" << std::endl;
 }
 
@@ -203,10 +209,14 @@ void TestOtherHeuristicBranchesKeepTheirText() {
 	// flight, "server requires encryption" without a host is unactionable.
 	const string enc = MSSQLTranslateConnectionError("Server requires encryption (ENCRYPT_REQ) but use_encrypt=false",
 													 "sql1", 1433, "u", "db");
-	CHECK(Contains(enc, "sql1:1433"));
-	CHECK(Contains(enc, "ENCRYPT_REQ"));
-	CHECK(Contains(enc, "use_encrypt=true"));  // the actionable half
-	std::cout << "  [ok] refused / DNS / timeout / certificate branches keep the original text" << std::endl;
+	CHECK(Contains(enc, "sql1:1433"));	// which server
+	// Assert on the JOIN, not on either side of it: the raw producer string is
+	// word-for-word a subset of this branch's own sentence, so every fragment
+	// of it is satisfied by the static text alone. Only the "Details: " marker
+	// followed by the echo proves the raw error survived.
+	CHECK(Contains(enc, "Details: Server requires encryption"));
+	std::cout << "  [ok] refused / DNS / timeout / certificate / ENCRYPT_REQ branches keep the original text"
+			  << std::endl;
 }
 
 // On the token-authenticated paths the identity comes from the token, so

--- a/test/cpp/test_spn_host_resolution.cpp
+++ b/test/cpp/test_spn_host_resolution.cpp
@@ -7,9 +7,12 @@
 // and the resulting KDC failure ("server not found in Kerberos database") says
 // nothing about the address form being the cause.
 //
-// These cases are offline: 127.0.0.1 reverse-resolves from the local hosts
-// database, and 192.0.2.x is TEST-NET-1 (RFC 5737), reserved for documentation
-// and never given a PTR record. Neither needs a nameserver.
+// On resolver dependence, precisely: the pass-through cases touch nothing.
+// 127.0.0.1 resolves from the local hosts database. The documentation-range
+// addresses DO issue a PTR query to whatever resolver the machine has, so they
+// assert only what no resolver may do -- hand back the address as if it were a
+// name -- rather than asserting a specific answer. A network with wildcard PTR
+// synthesises a name for any address, and that is a legitimate answer here.
 //
 // Build + run: make test-cpp (this file is in STANDALONE_TEST_SOURCES).
 
@@ -59,9 +62,15 @@ void TestIPv4LiteralIsReverseResolved() {
 // An IP with no PTR record returns empty, so the caller can say what to do
 // about it rather than building an SPN that cannot match.
 void TestUnresolvableIPReturnsEmpty() {
-	// TEST-NET-1, reserved by RFC 5737 and never assigned a PTR record.
-	CHECK(ResolveHostForSpn("192.0.2.111").empty());
-	std::cout << "  [ok] an IP with no PTR record returns empty rather than an unmatchable SPN" << std::endl;
+	// TEST-NET-1 (RFC 5737). Normally no PTR record exists, so this returns
+	// empty and DeriveDefaultSpn turns that into an actionable error. A resolver
+	// that synthesises names for every address returns one instead -- also fine.
+	// What must never happen is the address coming back as though it were a
+	// name, because that is the unmatchable SPN issue #259 is about.
+	const std::string resolved = ResolveHostForSpn("192.0.2.111");
+	CHECK(resolved != "192.0.2.111");
+	std::cout << "  [ok] an IP with no PTR record never comes back as an address (got "
+			  << (resolved.empty() ? "<empty>" : resolved) << ")" << std::endl;
 }
 
 // IPv6 literals take the same path -- the connection string may carry one, and
@@ -71,8 +80,9 @@ void TestIPv6LiteralIsRecognised() {
 	// Either it resolves to a name, or it has no PTR and returns empty. What it
 	// must NOT do is hand back "::1" as though it were a hostname.
 	CHECK(loopback != "::1");
-	// Documentation range 2001:db8::/32 (RFC 3849) has no PTR.
-	CHECK(ResolveHostForSpn("2001:db8::1").empty());
+	// Documentation range 2001:db8::/32 (RFC 3849). Same reasoning as the IPv4
+	// case above: assert it is not passed through, not that it is empty.
+	CHECK(ResolveHostForSpn("2001:db8::1") != "2001:db8::1");
 	std::cout << "  [ok] IPv6 literals are recognised as addresses, not passed through as names" << std::endl;
 }
 

--- a/test/cpp/test_spn_host_resolution.cpp
+++ b/test/cpp/test_spn_host_resolution.cpp
@@ -1,0 +1,97 @@
+// test/cpp/test_spn_host_resolution.cpp
+// Unit tests for ResolveHostForSpn (issue #259).
+//
+// Active Directory registers SQL Server SPNs against the host's FQDN. Building
+// the SPN by pasting the connection string's host into "MSSQLSvc/<host>:<port>"
+// therefore produces something unmatchable the moment a user connects by IP --
+// and the resulting KDC failure ("server not found in Kerberos database") says
+// nothing about the address form being the cause.
+//
+// These cases are offline: 127.0.0.1 reverse-resolves from the local hosts
+// database, and 192.0.2.x is TEST-NET-1 (RFC 5737), reserved for documentation
+// and never given a PTR record. Neither needs a nameserver.
+//
+// Build + run: make test-cpp (this file is in STANDALONE_TEST_SOURCES).
+
+#include <iostream>
+#include <string>
+
+#include "tds/auth/auth_strategy_factory.hpp"
+
+using namespace duckdb;
+using namespace duckdb::tds;
+
+namespace {
+
+int g_checks = 0;
+
+#define CHECK(cond)                                                                                             \
+	do {                                                                                                        \
+		g_checks++;                                                                                             \
+		if (!(cond)) {                                                                                          \
+			std::cerr << "ASSERT FAILED: " << #cond << " (" << __FILE__ << ":" << __LINE__ << ")" << std::endl; \
+			std::exit(1);                                                                                       \
+		}                                                                                                       \
+	} while (0)
+
+// A hostname is what AD registers against, so it must pass through untouched --
+// and, importantly, without a lookup: resolving a name could follow a CNAME to
+// a different canonical name and change an SPN that was already correct.
+void TestHostnamePassesThroughUnchanged() {
+	CHECK(ResolveHostForSpn("sqlhost.corp.example.com") == "sqlhost.corp.example.com");
+	CHECK(ResolveHostForSpn("sqlhost") == "sqlhost");
+	CHECK(ResolveHostForSpn("SQLHOST.CORP.EXAMPLE.COM") == "SQLHOST.CORP.EXAMPLE.COM");
+	std::cout << "  [ok] a hostname passes through unchanged, unresolved" << std::endl;
+}
+
+// The reported case: an IPv4 literal must be turned into a name. 127.0.0.1
+// resolves from the local hosts database on every platform CI runs on.
+void TestIPv4LiteralIsReverseResolved() {
+	const std::string resolved = ResolveHostForSpn("127.0.0.1");
+	CHECK(!resolved.empty());
+	CHECK(resolved != "127.0.0.1");	 // the whole point: no longer an address
+	CHECK(resolved.find('.') == std::string::npos || resolved.find("localhost") != std::string::npos ||
+		  !resolved.empty());		// whatever the box calls loopback
+	CHECK(resolved.back() != '.');	// trailing DNS dot stripped
+	std::cout << "  [ok] 127.0.0.1 reverse-resolves to '" << resolved << "' instead of staying an address" << std::endl;
+}
+
+// An IP with no PTR record returns empty, so the caller can say what to do
+// about it rather than building an SPN that cannot match.
+void TestUnresolvableIPReturnsEmpty() {
+	// TEST-NET-1, reserved by RFC 5737 and never assigned a PTR record.
+	CHECK(ResolveHostForSpn("192.0.2.111").empty());
+	std::cout << "  [ok] an IP with no PTR record returns empty rather than an unmatchable SPN" << std::endl;
+}
+
+// IPv6 literals take the same path -- the connection string may carry one, and
+// silently treating it as a name would put brackets and colons in an SPN.
+void TestIPv6LiteralIsRecognised() {
+	const std::string loopback = ResolveHostForSpn("::1");
+	// Either it resolves to a name, or it has no PTR and returns empty. What it
+	// must NOT do is hand back "::1" as though it were a hostname.
+	CHECK(loopback != "::1");
+	// Documentation range 2001:db8::/32 (RFC 3849) has no PTR.
+	CHECK(ResolveHostForSpn("2001:db8::1").empty());
+	std::cout << "  [ok] IPv6 literals are recognised as addresses, not passed through as names" << std::endl;
+}
+
+void TestEmptyHostIsNotTouched() {
+	CHECK(ResolveHostForSpn("").empty());
+	std::cout << "  [ok] an empty host stays empty" << std::endl;
+}
+
+}  // namespace
+
+int main() {
+	std::cout << "test_spn_host_resolution (issue #259)" << std::endl;
+
+	TestHostnamePassesThroughUnchanged();
+	TestIPv4LiteralIsReverseResolved();
+	TestUnresolvableIPReturnsEmpty();
+	TestIPv6LiteralIsRecognised();
+	TestEmptyHostIsNotTouched();
+
+	std::cout << "All " << g_checks << " checks passed." << std::endl;
+	return 0;
+}

--- a/test/cpp/test_spn_host_resolution.cpp
+++ b/test/cpp/test_spn_host_resolution.cpp
@@ -47,6 +47,22 @@ void TestHostnamePassesThroughUnchanged() {
 	std::cout << "  [ok] a hostname passes through unchanged, unresolved" << std::endl;
 }
 
+// Short single-label hostnames -- the NetBIOS-style names a Windows shop
+// actually uses, and the deployment integrated auth exists for.
+//
+// These are here because a "does this look like an address?" heuristic was
+// briefly added to this function that refused any host made only of hex
+// digits, dots and colons. db01, dc01, ad01 and cafe all match that, so
+// ATTACH 'Server=db01;Trusted_Connection=yes' failed with "Cannot derive a
+// Kerberos SPN from the IP address 'db01'" -- wrong about the input and the
+// cause. Nothing else in the suite used a hex-only name, so nothing caught it.
+void TestShortHexLookingHostnamesArePassedThrough() {
+	for (const char *name : {"db01", "dc01", "ad01", "cafe", "abe", "db", "feed", "0"}) {
+		CHECK(ResolveHostForSpn(name) == name);
+	}
+	std::cout << "  [ok] short hex-looking hostnames (db01, dc01, ad01, ...) pass through as names" << std::endl;
+}
+
 // The reported case: an IPv4 literal must be turned into a name. 127.0.0.1
 // resolves from the local hosts database on every platform CI runs on.
 void TestIPv4LiteralIsReverseResolved() {
@@ -98,6 +114,7 @@ int main() {
 	std::cout << "test_spn_host_resolution (issue #259)" << std::endl;
 
 	TestHostnamePassesThroughUnchanged();
+	TestShortHexLookingHostnamesArePassedThrough();
 	TestIPv4LiteralIsReverseResolved();
 	TestUnresolvableIPReturnsEmpty();
 	TestIPv6LiteralIsRecognised();

--- a/test/cpp/test_spn_host_resolution.cpp
+++ b/test/cpp/test_spn_host_resolution.cpp
@@ -52,10 +52,11 @@ void TestHostnamePassesThroughUnchanged() {
 void TestIPv4LiteralIsReverseResolved() {
 	const std::string resolved = ResolveHostForSpn("127.0.0.1");
 	CHECK(!resolved.empty());
-	CHECK(resolved != "127.0.0.1");	 // the whole point: no longer an address
-	CHECK(resolved.find('.') == std::string::npos || resolved.find("localhost") != std::string::npos ||
-		  !resolved.empty());		// whatever the box calls loopback
-	CHECK(resolved.back() != '.');	// trailing DNS dot stripped
+	CHECK(resolved != "127.0.0.1");					 // the whole point: no longer an address
+	CHECK(resolved.find('/') == std::string::npos);	 // characters that would be
+	CHECK(resolved.find(':') == std::string::npos);	 // invalid inside the derived
+	CHECK(resolved.find('@') == std::string::npos);	 // "MSSQLSvc/<host>:<port>" SPN
+	CHECK(resolved.back() != '.');					 // trailing DNS dot stripped
 	std::cout << "  [ok] 127.0.0.1 reverse-resolves to '" << resolved << "' instead of staying an address" << std::endl;
 }
 

--- a/test/cpp/test_winsspi_context.cpp
+++ b/test/cpp/test_winsspi_context.cpp
@@ -1,0 +1,132 @@
+// test/cpp/test_winsspi_context.cpp
+// Unit tests for Windows SSPI context creation (issue #260).
+//
+// WHY THIS EXISTS. Spec 042 Phase 4 shipped WinSspiAuthenticator, and the only
+// test for it -- test/sql/integrated_auth/winsspi_basic.test -- is gated behind
+// MSSQL_WINSSPI_TEST, which sits on the opt-in allowlist in
+// scripts/ci/check_require_env.sh and is therefore never set. Its stated reason
+// is that CI runners are not domain-joined. True, and stronger than it needs to
+// be: acquiring a Negotiate credential handle and producing the first SPNEGO
+// token needs the LOCAL logon session, not a domain and not a SQL Server. So
+// the whole path from "construct the authenticator" to "we have bytes to put in
+// LOGIN7" is testable on a bare windows-latest runner, which is where the
+// platform-specific bugs live.
+//
+// Microsoft's own Rust TDS driver does exactly this in
+// mssql-tds/tests/test_windows_sspi.rs (test_windows_sspi_context_creation /
+// test_windows_sspi_generate_initial_token).
+//
+// On non-Windows this compiles to a no-op so the file can live in the normal
+// test set without a platform fence around every build recipe.
+//
+// Build + run (Windows): part of the MSVC build job in .github/workflows/ci.yml.
+
+#include <iostream>
+#include <string>
+
+#if defined(_WIN32)
+
+#include <vector>
+
+#include "tds/auth/winsspi_authenticator.hpp"
+
+using namespace duckdb;
+using namespace duckdb::tds;
+
+namespace {
+
+int g_checks = 0;
+
+#define CHECK(cond)                                                                                             \
+	do {                                                                                                        \
+		g_checks++;                                                                                             \
+		if (!(cond)) {                                                                                          \
+			std::cerr << "ASSERT FAILED: " << #cond << " (" << __FILE__ << ":" << __LINE__ << ")" << std::endl; \
+			std::exit(1);                                                                                       \
+		}                                                                                                       \
+	} while (0)
+
+// The SPN the caller asked for must be the SPN the authenticator holds -- no
+// rewriting, no defaulting. This is the value that decides which ticket the
+// KDC is asked for, and a routing hop rebuilds the authenticator precisely to
+// change it (spec 068 D3).
+void TestSpnIsHeldVerbatim() {
+	WinSspiConfig config;
+	config.spn = "MSSQLSvc/localhost:1433";
+	WinSspiAuthenticator auth(config);
+	CHECK(auth.GetSpn() == "MSSQLSvc/localhost:1433");
+	std::cout << "  [ok] the configured SPN is held verbatim" << std::endl;
+}
+
+// An empty SPN is a configuration error and must be rejected at construction,
+// before any TDS traffic -- otherwise it surfaces mid-login as an opaque SSPI
+// status.
+void TestEmptySpnRejectedAtConstruction() {
+	WinSspiConfig config;
+	config.spn = "";
+	bool threw = false;
+	try {
+		WinSspiAuthenticator auth(config);
+	} catch (const std::exception &) {
+		threw = true;
+	}
+	CHECK(threw);
+	std::cout << "  [ok] an empty SPN is rejected at construction" << std::endl;
+}
+
+// The real one: acquire a Negotiate credential from the local logon session and
+// produce the first token. No domain, no SQL Server, no network. A token that
+// comes back empty, or that is not a GSS-API framed blob, means the SSPI wiring
+// is broken however well the code compiles.
+void TestInitialTokenIsAGssApiBlob() {
+	WinSspiConfig config;
+	// localhost is deliberate: the SPN need not exist for InitializeSecurityContext
+	// to produce an initial NTLM/SPNEGO token. Only the server would reject it.
+	config.spn = "MSSQLSvc/localhost:1433";
+	WinSspiAuthenticator auth(config);
+
+	std::vector<uint8_t> token;
+	try {
+		token = auth.InitialBytes();
+	} catch (const std::exception &e) {
+		std::cerr << "InitialBytes() threw: " << e.what() << std::endl;
+		std::exit(1);
+	}
+
+	CHECK(!token.empty());
+	// SPNEGO/NTLM tokens are DER: 0x60 is the ASN.1 APPLICATION 0 tag that wraps
+	// a GSS-API token. Raw NTLM ("NTLMSSP\0") is also legitimate when Negotiate
+	// picks NTLM directly on an undomained box, so accept either -- but not
+	// arbitrary bytes. (The 0x60 check is the one mssql-rs makes.)
+	const bool gssapi_framed = token[0] == 0x60;
+	const bool raw_ntlm =
+		token.size() >= 8 && std::string(reinterpret_cast<const char *>(token.data()), 7) == "NTLMSSP";
+	CHECK(gssapi_framed || raw_ntlm);
+
+	auth.Free();
+	auth.Free();  // Free() is documented idempotent; calling twice must not crash
+	std::cout << "  [ok] initial token is " << token.size() << " bytes, "
+			  << (gssapi_framed ? "GSS-API framed (0x60)" : "raw NTLMSSP") << std::endl;
+}
+
+}  // namespace
+
+int main() {
+	std::cout << "test_winsspi_context (issue #260)" << std::endl;
+
+	TestSpnIsHeldVerbatim();
+	TestEmptySpnRejectedAtConstruction();
+	TestInitialTokenIsAGssApiBlob();
+
+	std::cout << "All " << g_checks << " checks passed." << std::endl;
+	return 0;
+}
+
+#else  // !_WIN32
+
+int main() {
+	std::cout << "test_winsspi_context: skipped (Windows-only; SSPI is not present on this platform)" << std::endl;
+	return 0;
+}
+
+#endif

--- a/test/cpp/test_winsspi_context.cpp
+++ b/test/cpp/test_winsspi_context.cpp
@@ -19,7 +19,10 @@
 // On non-Windows this compiles to a no-op so the file can live in the normal
 // test set without a platform fence around every build recipe.
 //
-// Build + run (Windows): part of the MSVC build job in .github/workflows/ci.yml.
+// Build + run: the `windows-sspi-test` job in .github/workflows/ci.yml, which
+// is UNGATED -- it runs on every PR. That is the property worth having: the
+// dispatch-gated Windows build job would only run it when somebody ticks a box,
+// which is barely better than the never-set env var this replaces.
 
 #include <iostream>
 #include <string>

--- a/test/kerberos/docker-compose.yml
+++ b/test/kerberos/docker-compose.yml
@@ -87,9 +87,13 @@ services:
       start_period: 30s
 
   # Issue #261 / spec 068: answers any login with a ROUTING redirect to `sql`,
-  # so the stack can exercise a Kerberos hop. Plaintext (ENCRYPT_NOT_SUP), so
-  # the hop test connects with Encrypt=no; the real login on the routed server
-  # is unaffected and still negotiates TLS as the other tests do.
+  # so the stack can exercise a Kerberos hop. The gateway is plaintext
+  # (ENCRYPT_NOT_SUP), so the hop test connects with Encrypt=no -- and that
+  # setting PROPAGATES across the hop: the routed login to sql.example.com is
+  # plaintext too, because the hop reuses the same connection info and changes
+  # only host and port. That diverges from step 4, which uses
+  # Encrypt=yes;TrustServerCertificate=yes; worth knowing before debugging a
+  # step-6 failure as though it were a TLS problem.
   gateway:
     build: ./gateway
     container_name: mssql-kerb-gateway

--- a/test/kerberos/docker-compose.yml
+++ b/test/kerberos/docker-compose.yml
@@ -4,6 +4,7 @@
 #
 #   kdc         MIT Kerberos KDC, realm EXAMPLE.COM
 #   sql         SQL Server 2022, joined-equivalent via a service keytab
+#   gateway     TDS server that answers every login with ROUTING -> sql (#261)
 #   test-client Ubuntu + krb5-user + the built mssql.duckdb_extension
 #
 # Usage (from this directory):
@@ -85,6 +86,28 @@ services:
       retries: 40
       start_period: 30s
 
+  # Issue #261 / spec 068: answers any login with a ROUTING redirect to `sql`,
+  # so the stack can exercise a Kerberos hop. Plaintext (ENCRYPT_NOT_SUP), so
+  # the hop test connects with Encrypt=no; the real login on the routed server
+  # is unaffected and still negotiates TLS as the other tests do.
+  gateway:
+    build: ./gateway
+    container_name: mssql-kerb-gateway
+    hostname: gateway.example.com
+    networks:
+      kerb_net:
+        aliases:
+          - gateway.example.com
+    environment:
+      ROUTE_TO_HOST: sql.example.com
+      ROUTE_TO_PORT: "1433"
+      LISTEN_PORT: "1433"
+    expose:
+      - "1433/tcp"
+    depends_on:
+      sql:
+        condition: service_healthy
+
   test-client:
     # CI pre-builds this tag with buildx + GHA cache, then `docker compose up`
     # (no --build) reuses it. Local users keep the original behaviour because
@@ -106,6 +129,8 @@ services:
     depends_on:
       sql:
         condition: service_healthy
+      gateway:
+        condition: service_started
     # Keep alive so the user can `docker compose exec` into it.
     command: ["sleep", "infinity"]
 

--- a/test/kerberos/gateway/Dockerfile
+++ b/test/kerberos/gateway/Dockerfile
@@ -1,0 +1,17 @@
+# Issue #261 / spec 068: a TDS server whose only job is to answer a login with
+# a ROUTING redirect, so the Kerberos stack can exercise a hop.
+#
+# python3 stdlib only -- no pip install, no build step, nothing to break on a
+# base-image bump. The gateway never validates the SPNEGO blob it receives; it
+# only has to be something the client asks the KDC for a ticket to reach.
+FROM python:3.12-slim
+
+COPY gateway.py /gateway.py
+
+ENV ROUTE_TO_HOST=sql.example.com \
+    ROUTE_TO_PORT=1433 \
+    LISTEN_PORT=1433
+
+EXPOSE 1433/tcp
+
+CMD ["python3", "-u", "/gateway.py"]

--- a/test/kerberos/gateway/gateway.py
+++ b/test/kerberos/gateway/gateway.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""A TDS server that does exactly one thing: tell the client to log in elsewhere.
+
+Issue #261 / spec 068. The extension follows a login-time ROUTING redirect
+(ENVCHANGE type 20) on every auth path, and for integrated auth it must acquire
+a *fresh* Kerberos service ticket for the ROUTED host's SPN -- the gateway's
+ticket cannot validate on another server. That design was shipped verified only
+against a stub authenticator; nothing proved a real KDC would issue the second
+ticket, because no environment in the test surface both spoke Kerberos and
+routed.
+
+This is the missing half. It speaks just enough TDS to be routed *through*:
+
+    PRELOGIN  -> version + ENCRYPT_NOT_SUP (so the client stays in plaintext)
+    LOGIN7    -> ROUTING to $ROUTE_TO_HOST:$ROUTE_TO_PORT, then DONE
+
+It never validates the SPNEGO blob the client sends -- it does not need to. The
+client had to obtain a ticket for MSSQLSvc/gateway.example.com:1433 from the KDC
+*before* it could send that blob, so the ticket request has already happened by
+the time we answer. What the test then checks is that a SECOND ticket, for the
+routed host, appears in the ccache.
+
+Deliberately dependency-free: python3 stdlib only, so the container is small and
+there is no build step to break.
+"""
+
+import os
+import socket
+import socketserver
+import struct
+import sys
+
+ROUTE_TO_HOST = os.environ.get("ROUTE_TO_HOST", "sql.example.com")
+ROUTE_TO_PORT = int(os.environ.get("ROUTE_TO_PORT", "1433"))
+LISTEN_PORT = int(os.environ.get("LISTEN_PORT", "1433"))
+
+TDS_HEADER_LEN = 8
+PKT_TABULAR_RESULT = 0x04
+STATUS_EOM = 0x01
+
+TOKEN_ENVCHANGE = 0xE3
+TOKEN_DONE = 0xFD
+ENVCHANGE_ROUTING = 20
+ENCRYPT_NOT_SUP = 0x02
+
+
+def log(msg):
+    print("[gateway] %s" % msg, flush=True)
+
+
+def frame(payload):
+    """Wrap a payload in one TDS packet with EOM set."""
+    return struct.pack(">BBHHBB", PKT_TABULAR_RESULT, STATUS_EOM, len(payload) + TDS_HEADER_LEN, 0, 1, 0) + payload
+
+
+def read_message(conn):
+    """Read one complete TDS message (packets until the EOM status bit).
+
+    Returns (type, payload) or (None, None) if the peer went away. LOGIN7 with a
+    Kerberos blob is routinely fragmented (issue #138), so reassembly is not
+    optional here.
+    """
+    payload = b""
+    pkt_type = None
+    while True:
+        header = b""
+        while len(header) < TDS_HEADER_LEN:
+            chunk = conn.recv(TDS_HEADER_LEN - len(header))
+            if not chunk:
+                return (None, None)
+            header += chunk
+        pkt_type, status, length = struct.unpack(">BBH", header[:4])
+        remaining = length - TDS_HEADER_LEN
+        while remaining > 0:
+            chunk = conn.recv(remaining)
+            if not chunk:
+                return (None, None)
+            payload += chunk
+            remaining -= len(chunk)
+        if status & STATUS_EOM:
+            return (pkt_type, payload)
+
+
+def prelogin_response():
+    """VERSION + ENCRYPTION(NOT_SUP) + TERMINATOR.
+
+    Offsets in a PRELOGIN response are big-endian and relative to the start of
+    the payload. Three option headers of 5, 5 and 1 bytes precede the data.
+    """
+    header_len = 5 + 5 + 1
+    out = b""
+    out += struct.pack(">BHH", 0x00, header_len, 6)      # VERSION at header_len, 6 bytes
+    out += struct.pack(">BHH", 0x01, header_len + 6, 1)  # ENCRYPTION after it, 1 byte
+    out += b"\xff"                                       # TERMINATOR
+    out += struct.pack(">BBHH", 16, 0, 1000, 0)          # version 16.0.1000.0
+    out += bytes([ENCRYPT_NOT_SUP])
+    return out
+
+
+def routing_response(host, port):
+    """ENVCHANGE type 20 + a final DONE.
+
+    Layout per [MS-TDS] 2.2.7.13: Type(1) NewValueLen(2 LE) Protocol(1, 0=TCP)
+    Port(2 LE) AltServerLen(2 LE, in CHARACTERS) AltServer(UTF-16LE)
+    OldValue(2). The length is in characters, not bytes -- getting that wrong is
+    the classic way to write a ROUTING token nobody can parse.
+    """
+    server_utf16 = host.encode("utf-16-le")
+    routing = struct.pack("<BHH", 0x00, port, len(host)) + server_utf16
+
+    body = struct.pack("<B", ENVCHANGE_ROUTING) + struct.pack("<H", len(routing)) + routing
+    body += struct.pack("<H", 0)  # OldValue length
+
+    out = struct.pack("<B", TOKEN_ENVCHANGE) + struct.pack("<H", len(body)) + body
+    # Final DONE, TDS 7.2+ layout: Status(2) CurCmd(2) RowCount(8).
+    out += struct.pack("<BHHQ", TOKEN_DONE, 0x0000, 0x0000, 0)
+    return out
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        peer = "%s:%d" % self.client_address[:2]
+        log("connection from %s" % peer)
+        try:
+            pkt_type, _ = read_message(self.request)
+            if pkt_type is None:
+                return
+            log("  <- PRELOGIN (type 0x%02x)" % pkt_type)
+            self.request.sendall(frame(prelogin_response()))
+
+            pkt_type, payload = read_message(self.request)
+            if pkt_type is None:
+                return
+            # The client only gets here after asking the KDC for a ticket for
+            # OUR SPN -- that request is the first half of what this test proves.
+            log("  <- LOGIN7 (type 0x%02x, %d bytes payload)" % (pkt_type, len(payload)))
+            log("  -> ROUTING to %s:%d" % (ROUTE_TO_HOST, ROUTE_TO_PORT))
+            self.request.sendall(frame(routing_response(ROUTE_TO_HOST, ROUTE_TO_PORT)))
+        except (ConnectionResetError, BrokenPipeError) as exc:
+            log("  peer went away: %s" % exc)
+
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+    address_family = socket.AF_INET
+
+
+if __name__ == "__main__":
+    log("listening on 0.0.0.0:%d, routing every login to %s:%d" % (LISTEN_PORT, ROUTE_TO_HOST, ROUTE_TO_PORT))
+    try:
+        with Server(("0.0.0.0", LISTEN_PORT), Handler) as server:
+            server.serve_forever()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/test/kerberos/kdc/init-kdc.sh
+++ b/test/kerberos/kdc/init-kdc.sh
@@ -22,6 +22,28 @@ KEYTAB_OUT="${KEYTAB_OUT:-/export/mssql.keytab}"
 
 mkdir -p /var/log /var/lib/krb5kdc /export
 
+# Issue #261: the routing gateway's SPN. Idempotent and called from BOTH the
+# fresh-realm and existing-realm branches -- a stack brought up before this
+# commit and restarted without `down -v` keeps its KDC database, and a missing
+# gateway principal there makes the hop test fail with "the first login never
+# asked the KDC", which points at the client when the cause is the KDC.
+ensure_gateway_principal() {
+    [[ -n "${GATEWAY_PRINCIPAL}" ]] || return 0
+    local p
+    for p in "${GATEWAY_PRINCIPAL}" "${GATEWAY_PRINCIPAL%:*}"; do
+        [[ -n "${p}" ]] || continue
+        if kadmin.local -q "getprinc ${p}@${REALM}" 2>/dev/null | grep -q "Principal:"; then
+            echo "[init-kdc] gateway principal ${p}@${REALM} already present"
+        else
+            echo "[init-kdc] creating routing-gateway principal ${p}@${REALM} (issue #261)"
+            kadmin.local -q "addprinc -randkey ${p}@${REALM}"
+        fi
+        # The port-less hostbased variant equals the principal when there is no
+        # ":port" suffix; don't create it twice.
+        [[ "${GATEWAY_PRINCIPAL%:*}" != "${GATEWAY_PRINCIPAL}" ]] || break
+    done
+}
+
 if [[ ! -f /var/lib/krb5kdc/principal ]]; then
     echo "[init-kdc] creating realm ${REALM}"
     # -s = stash the master key on disk so we can autostart krb5kdc later
@@ -43,15 +65,6 @@ if [[ ! -f /var/lib/krb5kdc/principal ]]; then
     # clients using the principal-name form land on the port-suffixed variant.
     # Registering both makes the test KDC robust against both client paths.
     # spec 042 ultrareview bug_015.
-    if [[ -n "${GATEWAY_PRINCIPAL}" ]]; then
-        echo "[init-kdc] creating routing-gateway principal ${GATEWAY_PRINCIPAL}@${REALM} (issue #261)"
-        kadmin.local -q "addprinc -randkey ${GATEWAY_PRINCIPAL}@${REALM}"
-        GATEWAY_PRINCIPAL_HOSTBASED="${GATEWAY_PRINCIPAL%:*}"
-        if [[ "${GATEWAY_PRINCIPAL_HOSTBASED}" != "${GATEWAY_PRINCIPAL}" ]]; then
-            kadmin.local -q "addprinc -randkey ${GATEWAY_PRINCIPAL_HOSTBASED}@${REALM}"
-        fi
-    fi
-
     SERVICE_PRINCIPAL_HOSTBASED="${SERVICE_PRINCIPAL%:*}"  # strip ":1433"
     if [[ "${SERVICE_PRINCIPAL_HOSTBASED}" != "${SERVICE_PRINCIPAL}" ]]; then
         echo "[init-kdc] also creating hostbased variant ${SERVICE_PRINCIPAL_HOSTBASED}@${REALM}"
@@ -67,6 +80,8 @@ if [[ ! -f /var/lib/krb5kdc/principal ]]; then
         kadmin.local -q "ktadd -k ${KEYTAB_OUT} ${SERVICE_PRINCIPAL_HOSTBASED}@${REALM}"
     fi
     chmod 644 "${KEYTAB_OUT}"
+
+    ensure_gateway_principal
 else
     echo "[init-kdc] realm already exists at /var/lib/krb5kdc; skipping create"
     # Re-export keytab in case the keytabs volume was wiped between runs but
@@ -80,6 +95,9 @@ else
         fi
         chmod 644 "${KEYTAB_OUT}"
     fi
+
+    # A KDC database created before issue #261 has no gateway principal.
+    ensure_gateway_principal
 fi
 
 echo "[init-kdc] starting krb5kdc and kadmind"

--- a/test/kerberos/kdc/init-kdc.sh
+++ b/test/kerberos/kdc/init-kdc.sh
@@ -13,6 +13,11 @@ ADMIN_PASSWORD="${ADMIN_PASSWORD:-adminpw}"
 USER_PRINCIPAL="${USER_PRINCIPAL:-testuser}"
 USER_PASSWORD="${USER_PASSWORD:-testpass}"
 SERVICE_PRINCIPAL="${SERVICE_PRINCIPAL:-MSSQLSvc/sql.example.com:1433}"
+# Issue #261: the routing gateway's own SPN. The client must be able to get a
+# ticket for the gateway BEFORE it can send a LOGIN7 there and be redirected --
+# that first ticket request is half of what the hop test proves. No keytab is
+# exported for it: the gateway never validates the blob, it only redirects.
+GATEWAY_PRINCIPAL="${GATEWAY_PRINCIPAL:-MSSQLSvc/gateway.example.com:1433}"
 KEYTAB_OUT="${KEYTAB_OUT:-/export/mssql.keytab}"
 
 mkdir -p /var/log /var/lib/krb5kdc /export
@@ -38,6 +43,15 @@ if [[ ! -f /var/lib/krb5kdc/principal ]]; then
     # clients using the principal-name form land on the port-suffixed variant.
     # Registering both makes the test KDC robust against both client paths.
     # spec 042 ultrareview bug_015.
+    if [[ -n "${GATEWAY_PRINCIPAL}" ]]; then
+        echo "[init-kdc] creating routing-gateway principal ${GATEWAY_PRINCIPAL}@${REALM} (issue #261)"
+        kadmin.local -q "addprinc -randkey ${GATEWAY_PRINCIPAL}@${REALM}"
+        GATEWAY_PRINCIPAL_HOSTBASED="${GATEWAY_PRINCIPAL%:*}"
+        if [[ "${GATEWAY_PRINCIPAL_HOSTBASED}" != "${GATEWAY_PRINCIPAL}" ]]; then
+            kadmin.local -q "addprinc -randkey ${GATEWAY_PRINCIPAL_HOSTBASED}@${REALM}"
+        fi
+    fi
+
     SERVICE_PRINCIPAL_HOSTBASED="${SERVICE_PRINCIPAL%:*}"  # strip ":1433"
     if [[ "${SERVICE_PRINCIPAL_HOSTBASED}" != "${SERVICE_PRINCIPAL}" ]]; then
         echo "[init-kdc] also creating hostbased variant ${SERVICE_PRINCIPAL_HOSTBASED}@${REALM}"

--- a/test/kerberos/test-client/run-tests.sh
+++ b/test/kerberos/test-client/run-tests.sh
@@ -27,6 +27,8 @@ PRINCIPAL="${PRINCIPAL:-testuser@EXAMPLE.COM}"
 PASSWORD="${PASSWORD:-testpass}"
 SQL_HOST="${SQL_HOST:-sql.example.com}"
 SQL_PORT="${SQL_PORT:-1433}"
+GATEWAY_HOST="${GATEWAY_HOST:-gateway.example.com}"
+GATEWAY_PORT="${GATEWAY_PORT:-1433}"
 
 echo "[run-tests] step 0: extension sanity check"
 if [[ ! -f "${EXT}" ]]; then
@@ -107,5 +109,59 @@ if echo "${negative}" | grep -q "^OK:"; then
     echo "[run-tests] ERROR: auth_test reported OK with no ccache -- this should have failed." >&2
     exit 4
 fi
+
+# --------------------------------------------------------------------------
+# step 6: a Kerberos login that is ROUTED (issue #261, spec 068 D3).
+#
+# The design under test: when a server answers LOGIN7 with ENVCHANGE 20, the
+# client must acquire a FRESH service ticket for the ROUTED host's SPN. The
+# gateway's ticket is bound to the gateway's SPN and cannot validate anywhere
+# else. Unit tests cover the mechanics with a stub authenticator; what they
+# cannot cover is whether a real KDC issues that second ticket, which is the
+# part spec 068 shipped as its acknowledged risk.
+#
+# The gateway container answers every login with ROUTING -> sql.example.com. So
+# a single ATTACH against the gateway should make the client:
+#   1. ask the KDC for MSSQLSvc/gateway.example.com:1433, send LOGIN7 there;
+#   2. receive ROUTING, reconnect to sql.example.com;
+#   3. ask the KDC for MSSQLSvc/sql.example.com:1433 -- a DIFFERENT ticket;
+#   4. send a second LOGIN7 there.
+#
+# The assertion is on the ticket cache, not on the final login: as in step 4,
+# SQL Server on Linux cannot map the AD principal without SSSD/realmd, so the
+# login itself is expected to be rejected. Two service tickets in the ccache is
+# the proof, and it is exactly what would NOT appear if the hop reused the
+# gateway's authenticator.
+echo "[run-tests] step 6: routed Kerberos login (issue #261)"
+kdestroy 2>/dev/null || true
+echo -n "${PASSWORD}" | kinit "${PRINCIPAL}"
+
+cat > /tmp/route.sql <<EOF
+LOAD '${EXT}';
+ATTACH 'Server=${GATEWAY_HOST},${GATEWAY_PORT};Database=TestDB;Trusted_Connection=yes;Encrypt=no' AS kroute (TYPE mssql);
+DETACH kroute;
+EOF
+set +e
+route_out=$(MSSQL_DEBUG=1 duckdb --unsigned -f /tmp/route.sql 2>&1)
+set -e
+echo "${route_out}"
+
+if ! echo "${route_out}" | grep -q "ROUTING requested to ${SQL_HOST}"; then
+    echo "[run-tests] ERROR: the gateway's ROUTING was not followed -- no hop logged" >&2
+    exit 5
+fi
+
+tickets=$(klist)
+echo "${tickets}"
+if ! echo "${tickets}" | grep -q "MSSQLSvc/${GATEWAY_HOST}"; then
+    echo "[run-tests] ERROR: no service ticket for the gateway -- the first login never asked the KDC" >&2
+    exit 5
+fi
+if ! echo "${tickets}" | grep -q "MSSQLSvc/${SQL_HOST}"; then
+    echo "[run-tests] ERROR: no service ticket for the ROUTED host. The hop reused the gateway's" >&2
+    echo "[run-tests]        credential instead of acquiring one for ${SQL_HOST} -- spec 068 D3 is wrong." >&2
+    exit 5
+fi
+echo "[run-tests] step 6: OK -- the hop acquired a separate ticket for ${SQL_HOST} (spec 068 D3 verified)"
 
 echo "[run-tests] all integration steps completed"


### PR DESCRIPTION
Closes #259. Closes #260. Closes #261. Closes #262.

**Stacked on #258** (base is `task/spec-068-4f420d`, not `main`) because #261's hop test only means anything with spec 068's routing code present. Retarget to `main` once #258 lands.

All four were found while verifying spec 068; none is caused by it.

## #262 — every login-time server error read as "check username and password"

`TranslateConnectionError` decided "credential problem" from the substring `"authentication"` — but the string it inspects is **our own wrapper**: `DoLogin7` formats every rejection as `Authentication failed (error N, state S): …`. The arm matched unconditionally, and the number, the state and the server's own words were discarded.

Consequences seen in this repo's CI twice today: Azure **40613** (a paused serverless database resuming, which `azure_lazy_loading.test` warns about in its own header) told the reader to rotate a secret that was never wrong. It also silently undid **#164**, which added the State byte precisely because 18456 has several distinct causes.

Classification now comes from `LoginResponse::error_number`, plumbed out via `GetLastErrorNumber()`/`GetLastErrorState()`. 40613/40197/40501/49918 are named retryable; 18456 explains what its state means; the server's text is always appended. The one surviving string arm matches the **server's** phrase (`"login failed"`), never our own word.

## #259 — an SPN built from an IP can never match

AD registers SPNs against the FQDN, so `Server=10.1.2.3,1433` produced `MSSQLSvc/10.1.2.3:1433` and a KDC failure that says nothing about the address form being the cause. IP literals (v4 and v6) are now reverse-resolved. Names pass through **untouched and unresolved** — looking them up could follow a CNAME and change an SPN that was already correct. An IP with no PTR record raises an error naming the fix rather than building something unmatchable.

## #260 — Windows SSPI had no automated coverage

Its only test assumes a domain-joined host and sits on the never-set allowlist in `check_require_env.sh`. But acquiring a Negotiate credential and producing the first token needs the **local logon session**, not a domain and not a SQL Server — so that now runs on a bare Windows runner in the MSVC job. Accepts a GSS-API-framed (`0x60`) or raw `NTLMSSP` token, since Negotiate legitimately picks NTLM on an undomained box.

## #261 — `test/kerberos` can now exercise a hop

Spec 068 D3 (a fresh ticket for the **routed** host's SPN) was verified only against a stub authenticator; nothing proved a real KDC would issue the second ticket. A `gateway` container now answers every login with `ROUTING -> sql.example.com`, and the KDC registers `MSSQLSvc/gateway.example.com:1433` so the client must obtain a ticket to reach it at all.

The assertion is on the **ccache**: two service tickets, the gateway's and the routed host's. One ticket means the hop reused the gateway's credential and the design is wrong. The final login is still expected to be rejected — SQL Server on Linux cannot map the principal without SSSD — exactly as the existing step 4 documents.

## Verified here

- 33 new checks (error translation) + 11 (SPN resolution), both in `make test-cpp`, whole suite green
- 79 routing checks, full unit suite (**5086 assertions / 158 cases**)
- **The Python gateway driven end-to-end by a real `TdsConnection`** on loopback: it routed the client to a second listener, which completed the login. The wire format — the error-prone half of #261 — is proven, not assumed
- `docker compose config` accepts the new service; `bash -n` on both scripts

## NOT verified here

- The SSPI test has never run: no Windows available. It will first execute on the next Windows dispatch
- The Kerberos hop's ticket assertions need the docker stack, which builds the extension inside Linux and takes far longer than one session. The protocol half is proven above; the Kerberos half is not

🤖 Generated with [Claude Code](https://claude.com/claude-code)