### PR TITLE
azure-test: keep the build out of the secret scope, ask the binary for the version dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1282,7 +1282,27 @@ jobs:
           # A `v*` glob matches nothing here and the step dies before running a
           # single test. It appeared to work locally only because a shallow
           # submodule clone stamps v0.0.1, which is release-shaped by accident.
-          extdir=$(ls -d "$scratch"/.duckdb/extensions/*/*/ 2>/dev/null | head -1 || true)
+          # $scratch is created fresh in this step, so exactly one directory is
+          # expected; assert that rather than silently taking the first of
+          # several. (The Makefile derives the name from the binary instead,
+          # because build/release/repository is NOT cleaned between builds and
+          # can hold a stale entry. Here the directory is new, so counting is
+          # enough.)
+          #
+          # `dirs=$(...) || dirs=""`, not a pipeline into wc: under
+          # `set -euo pipefail` an unmatched glob makes ls exit 2, pipefail
+          # propagates it through wc/tr, and the assignment then aborts the step
+          # via set -e -- before the diagnostic below could print, in exactly
+          # the case it was written for. That is also why the extdir line has
+          # its `|| true`.
+          dirs=$(ls -d "$scratch"/.duckdb/extensions/*/*/ 2>/dev/null) || dirs=""
+          found=$(printf '%s' "$dirs" | grep -c . || true)
+          if [ "$found" -gt 1 ]; then
+            echo "::error::expected one extension directory under $scratch, found $found:" >&2
+            printf '%s\n' "$dirs" >&2
+            exit 1
+          fi
+          extdir=$(printf '%s' "$dirs" | head -1)
           if [ -z "$extdir" ]; then
             echo "::error::INSTALL azure reported success but wrote no extension directory under $scratch/.duckdb/extensions" >&2
             ./cli/duckdb -c "PRAGMA version;" >&2 || true

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,15 @@ AZURE_ENV_VARS := AZURE_APP_ID AZURE_DIRECTORY_ID AZURE_APP_SECRET \
 # into the environment of `make release` (cmake, ninja, vcpkg -- which writes
 # build logs), `make docker-up` (the docker CLI), and everything else. The
 # tag-based exclusion below contains the test-SELECTION risk; it does nothing
-# about secrets in unrelated child processes. This does.
+# about secrets in unrelated child processes.
+#
+# The gate is per-INVOCATION, not per-recipe, so it only helps if nothing else
+# is built in the same command line. `azure-test: release` defeated it
+# completely: `make azure-test` on an unbuilt tree satisfies the gate and then
+# runs cmake/ninja/vcpkg inside it, which is the one invocation the gate exists
+# for. So `release` is NOT a prerequisite -- build separately
+# (`make release && make azure-test`) and the recipe's own guard says so when
+# the build is missing.
 ifneq ($(filter azure-test,$(MAKECMDGOALS)),)
 # Strip ONE layer of surrounding quotes first. `-include .env` reads the file
 # with make's syntax, not the shell's: for the shell `VAR='x'` means x, for
@@ -262,29 +270,49 @@ $(foreach v,$(AZURE_ENV_VARS),$(if $($(v)),$(eval $(v) := $(call unquote,$($(v))
 $(foreach v,$(AZURE_ENV_VARS),$(if $($(v)),$(eval export $(v))))
 endif
 
-azure-test: release
+azure-test:
 	@echo "Running Azure / Fabric tests..."
-	@echo "NOTE: needs real Azure credentials in .env (see .env.example) and the"
-	@echo "      azure extension installed locally: duckdb -c 'INSTALL azure;'"
+	@echo "NOTE: needs real Azure credentials in .env (see .env.example), a built"
+	@echo "      tree ('make release'), and the azure extension installed locally"
+	@echo "      for THIS build: ./build/release/duckdb -c 'INSTALL azure;'"
 	@echo "Variables supplied: $(foreach v,$(AZURE_ENV_VARS),$(if $($(v)),$(v)))"
 	@echo ""
-# '*/*/', not 'v*/*/': the version directory is the release tag only for a
-# RELEASE build. GetVersionDirectoryName() returns DuckDB::SourceID() -- a
-# commit hash, never 'v'-prefixed -- for anything carrying '-dev', which is
-# every build of the 'main'-branch submodule that is not exactly on a tag.
-# A shallow clone stamps v0.0.1 and hides this; a full one does not.
+# The version directory is the release tag only for a RELEASE build.
+# GetVersionDirectoryName() returns DuckDB::SourceID() -- a commit hash, never
+# 'v'-prefixed -- for anything carrying '-dev', which is every build of the
+# 'main'-branch submodule that is not exactly on a tag. A shallow clone stamps
+# v0.0.1 and hides this; a full one does not.
+#
+# So ASK THE BINARY rather than globbing. `ls */*/ | head -1` takes the
+# lexicographically first of however many directories exist, and
+# build/release/repository is never cleaned between builds -- after a submodule
+# bump it holds the old and the new, and the stale one can win. The failure was
+# loud but named a version this binary does not use, which reads as "install
+# azure" rather than "stale repository directory".
+#
 # (Make comment, NOT tab-@#-in-a-continuation: a comment line spliced into the
 # 'set -e; \' continuation reaches the shell with its '@#' intact and its
 # backticks LIVE -- `*/*/` executed as command substitution and the recipe
 # died with '@#: command not found' before running a single test.)
 	@set -e; \
-	repo_dir=$$(ls -d $(AZURE_EXT_REPO)/*/*/ 2>/dev/null | head -1); \
-	if [ -z "$$repo_dir" ]; then \
-		echo "azure-test: no local extension repository under $(AZURE_EXT_REPO)." >&2; \
+	if [ ! -x build/release/duckdb ]; then \
+		echo "azure-test: build/release/duckdb missing - run 'make release' first." >&2; \
+		exit 1; \
+	fi; \
+	lib_ver=$$(build/release/duckdb -noheader -list -c "SELECT library_version FROM pragma_version();"); \
+	src_id=$$(build/release/duckdb -noheader -list -c "SELECT source_id FROM pragma_version();"); \
+	case "$$lib_ver" in \
+		*-dev*) ver="$$src_id" ;; \
+		*)      ver="$$lib_ver" ;; \
+	esac; \
+	plat=$$(build/release/duckdb -noheader -list -c "PRAGMA platform;"); \
+	echo "azure-test: extension directory for this build: $$ver/$$plat"; \
+	repo_dir="$(AZURE_EXT_REPO)/$$ver/$$plat"; \
+	if [ ! -d "$$repo_dir" ]; then \
+		echo "azure-test: no local extension repository at $$repo_dir." >&2; \
 		echo "  Run 'make release' first." >&2; exit 1; \
 	fi; \
-	rel=$${repo_dir#$(AZURE_EXT_REPO)/}; \
-	src="$$HOME/.duckdb/extensions/$${rel%/}/azure.duckdb_extension"; \
+	src="$$HOME/.duckdb/extensions/$$ver/$$plat/azure.duckdb_extension"; \
 	if [ ! -f "$$src" ]; then \
 		echo "azure-test: $$src not found." >&2; \
 		echo "  Install the azure extension for this DuckDB version first:" >&2; \
@@ -1019,7 +1047,7 @@ help:
 	@echo "Custom targets:"
 	@echo "  make vcpkg-setup          - Bootstrap vcpkg (required for TLS support)"
 	@echo "  make integration-test     - Run integration tests (requires SQL Server)"
-	@echo "  make azure-test           - Run Azure/Fabric tests (requires cloud credentials + azure ext)"
+	@echo "  make azure-test           - Run Azure/Fabric tests (build first; needs cloud creds + azure ext)"
 	@echo "  make counters-test        - Run the SQL suite with MSSQL_COUNTERS=1 (exercises the counter path)"
 	@echo "  make test-all             - Run all tests"
 	@echo "  make test-debug           - Run tests with debug build"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -953,9 +953,12 @@ DROP SECRET azure_sp;
 3. **Test token acquisition only** - `mssql_azure_auth_test()` validates tokens without SQL Server
 4. **Keep tests in `test/sql/azure/`** - the directory *is* the `[azure]` tag; see the note under
    [Test Groups](#test-groups) — the `# group:` header selects nothing
-5. **Run them with `make azure-test`** - it provisions the azure extension into the local extension
-   repository (without which `require azure` is unsatisfiable and every file skips silently), passes
-   only the non-empty `AZURE_*` variables, and fails if fewer than `AZURE_MIN_ASSERTIONS` ran
+5. **Run them with `make release && make azure-test`** - it provisions the azure extension into the
+   local extension repository (without which `require azure` is unsatisfiable and every file skips
+   silently), passes only the non-empty `AZURE_*` variables, and fails if fewer than
+   `AZURE_MIN_ASSERTIONS` ran. Build as a **separate invocation**: `release` is deliberately not a
+   prerequisite of `azure-test`, because the `AZURE_*` values are exported for the whole invocation
+   and would otherwise reach cmake/ninja/vcpkg
 
 **Azure AD Authentication Methods:**
 


### PR DESCRIPTION
Follow-up to #264, taking the two Low findings @VGSML confirmed [there](https://github.com/hugr-lab/mssql-extension/pull/264#issuecomment-5309468223). Neither is a regression in the merged work — both are limits on how far the fixes in it actually reached. Three files, no `src/` or `test/sql` changes.

## 1. The `MAKECMDGOALS` gate did not cover the build it exists for

The gate narrows the `AZURE_*` export to invocations whose goal list contains `azure-test`, so a populated `.env` cannot hand `AZURE_APP_SECRET`, `AZURE_CLIENT_SECRET`, `AZURE_ACCESS_TOKEN` and the DSN password to unrelated child processes.

But `azure-test: release` put the build **inside** that invocation. So `make azure-test` on an unbuilt tree still handed them to cmake, ninja and vcpkg — the "vcpkg, which writes build logs" case named in the comment directly above the gate. What the gate actually secured was standalone `make release`.

`release` is no longer a prerequisite. The recipe already guarded on a missing build; it now checks `build/release/duckdb` explicitly and says to run `make release` first, so the failure stays actionable. `make help` and `docs/TESTING.md` say `make release && make azure-test`.

The alternative — sourcing `.env` inside the recipe — was rejected per the discussion: it trades make's parser for the shell's, which breaks on the first unquoted value containing a space.

## 2. The version directory is derived, not globbed

`ls -d $(AZURE_EXT_REPO)/*/*/ | head -1` takes the lexicographically first of however many directories exist, and `build/release/repository` is never cleaned between builds — so after a duckdb submodule bump it holds both the old and the new, and the stale one can win. The failure was loud but named a version the binary does not use, which reads as "install azure" rather than "stale repository directory".

The recipe now replicates `ExtensionHelper::GetVersionDirectoryName()` against the binary that will actually load the extension:

```make
case "$$lib_ver" in \
    *-dev*) ver="$$src_id" ;; \
    *)      ver="$$lib_ver" ;; \
esac; \
plat=$$(build/release/duckdb -noheader -list -c "PRAGMA platform;"); \
```

The `-dev` branch is load-bearing: `source_id` alone is wrong for a release build, where the directory is the tag.

## 3. The ci.yml count assert, written pipefail-safe

@VGSML asked for the same one-directory check in the workflow, where `$scratch` is created fresh in the step. The obvious form is a trap, and I walked into it first: under `set -euo pipefail` an unmatched glob makes `ls` exit 2, pipefail carries that through `wc`/`tr`, and the assignment aborts the step via `set -e` — **before the diagnostic it guards can print**, in exactly the case that diagnostic exists for.

Verified both ways against an empty directory:

| form | result |
|---|---|
| `found=$(ls -d … 2>/dev/null \| wc -l \| tr -d ' ')` | aborts, exit 1, diagnostic never runs |
| `dirs=$(ls -d … 2>/dev/null) \|\| dirs=""` | reaches the block, `found=0` |

That is also why the pre-existing `extdir=` line carries its `|| true`.

## Verification

- `make azure-test` derives `v0.0.1/osx_arm64`, reaches its intended guard and exits 1 as designed — with **no build triggered** (zero cmake/ninja commands in the recipe)
- integration subset **666 assertions / 23 cases PASSED**
- `check_require_env.sh` green; `ci.yml` valid YAML with the provisioning step shell-clean
- `integration-test` command line unchanged

**Not verifiable here:** the azure lane itself. This build stamps `v0.0.1` from a shallow submodule clone, so `INSTALL azure` 404s locally — same constraint as on #264. Given the lane now has a working dispatch path, this wants the live-dispatch treatment on the branch before merge, as agreed.
