### PR TITLE
test: sweep deprecated sqllogictest substitution forms to 2.0 syntax (spec 070 W3)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -368,7 +368,7 @@ require-env MSSQL_TEST_DSN
 
 # Setup
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS testdb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS testdb (TYPE mssql);
 
 # Test with expected result
 query II
@@ -394,6 +394,12 @@ does not exist
 statement ok
 DETACH testdb;
 ```
+
+**Environment-variable substitution.** Write `{MSSQL_TEST_DSN}` (braces only).
+The runner substitutes a variable only if the same file `require-env`s it; an
+undeclared name comes through literally. The older `${VAR}` form still
+substitutes but the DuckDB 2.0 sqllogictest runner prints a deprecation warning
+for every occurrence — use the brace-only form in new tests.
 
 ### Query Result Type Codes
 
@@ -466,7 +472,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mydb (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mydb (TYPE mssql);
 
 # Your tests here...
 
@@ -542,7 +548,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Use unique context name to avoid conflicts
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_upd_mytest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_upd_mytest (TYPE mssql);
 
 # Create test table with PRIMARY KEY (required for rowid-based UPDATE/DELETE)
 # Use mssql_exec for CREATE TABLE with constraints
@@ -623,7 +629,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txdb (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txdb (TYPE mssql);
 
 # Test COMMIT: changes persist
 statement ok
@@ -686,7 +692,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS copydb (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS copydb (TYPE mssql);
 
 # Create local source data
 statement ok
@@ -773,7 +779,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ctas_mytest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ctas_mytest (TYPE mssql);
 
 # Clean up target if exists
 statement ok
@@ -861,7 +867,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 statement ok
 BEGIN TRANSACTION;
@@ -928,9 +934,9 @@ statement ok
 CREATE SECRET azure_sp (
     TYPE azure,
     provider 'service_principal',
-    tenant_id '${AZURE_TENANT_ID}',
-    client_id '${AZURE_APP_ID}',
-    client_secret '${AZURE_CLIENT_SECRET}'
+    tenant_id '{AZURE_TENANT_ID}',
+    client_id '{AZURE_APP_ID}',
+    client_secret '{AZURE_CLIENT_SECRET}'
 );
 
 # Test token acquisition (no SQL Server connection needed)

--- a/specs/070-duckdb-v2-followups/spec.md
+++ b/specs/070-duckdb-v2-followups/spec.md
@@ -130,6 +130,16 @@ still substituting. Mechanical sweep:
 Do this LAST among the three — it touches every .test file and would sit
 noisily inside any other PR's diff.
 
+**Result.** `${VAR}` → `{VAR}` across 159 `.test` files (334 occurrences).
+The zero-"Replacing deprecated" assertion caught a *second* deprecated form the
+title did not name: `__TEST_DIR__`, which the 2.0 runner deprecates in favour of
+`{TEST_DIR}` and which surfaced the identical warning line. One occurrence pair
+in `copy/vector_encodings_bcp.test` swept the same way — the assertion is on the
+suite log, not on `${`, so both had to go for it to hold. `docs/TESTING.md` and
+`test/README.md` examples converted, with an authoring note added naming the
+brace-only form as canonical. `test/TLS_TESTING.md` left untouched: its `${VAR}`
+are real shell variables in `bash`/`curl` examples, not runner substitutions.
+
 ---
 
 ## Out of scope (all three workstreams)

--- a/test/README.md
+++ b/test/README.md
@@ -220,7 +220,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS testdb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS testdb (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('testdb', 'SELECT 1 AS val');

--- a/test/sql/attach/application_name.test
+++ b/test/sql/attach/application_name.test
@@ -21,7 +21,7 @@ require-env MSSQL_TEST_PASS
 # Verifies the value reaches SQL Server's APP_NAME() / program_name.
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS};Application Name=AppV1' AS appn_adonet1 (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS};Application Name=AppV1' AS appn_adonet1 (TYPE mssql);
 
 query I
 SELECT app FROM mssql_scan('appn_adonet1', 'SELECT APP_NAME() AS app');
@@ -33,7 +33,7 @@ DETACH appn_adonet1;
 
 # Spaceless ADO.NET alias `ApplicationName=...`.
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS};ApplicationName=AppV2' AS appn_adonet2 (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS};ApplicationName=AppV2' AS appn_adonet2 (TYPE mssql);
 
 query I
 SELECT app FROM mssql_scan('appn_adonet2', 'SELECT APP_NAME() AS app');
@@ -45,7 +45,7 @@ DETACH appn_adonet2;
 
 # Underscore form `application_name=...` (matches the secret convention).
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS};application_name=AppV3' AS appn_adonet3 (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS};application_name=AppV3' AS appn_adonet3 (TYPE mssql);
 
 query I
 SELECT app FROM mssql_scan('appn_adonet3', 'SELECT APP_NAME() AS app');
@@ -59,7 +59,7 @@ DETACH appn_adonet3;
 # Group 2 — URI `?applicationname=...` (spaceless form per URI convention).
 #
 statement ok
-ATTACH 'mssql://${MSSQL_TEST_USER}:${MSSQL_TEST_PASS}@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/master?applicationname=UriAppName' AS appn_uri (TYPE mssql);
+ATTACH 'mssql://{MSSQL_TEST_USER}:{MSSQL_TEST_PASS}@{MSSQL_TEST_HOST}:{MSSQL_TEST_PORT}/master?applicationname=UriAppName' AS appn_uri (TYPE mssql);
 
 query I
 SELECT app FROM mssql_scan('appn_uri', 'SELECT APP_NAME() AS app');
@@ -74,7 +74,7 @@ DETACH appn_uri;
 # extension default string is what SQL Server should see.
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS}' AS appn_default (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS}' AS appn_default (TYPE mssql);
 
 query I
 SELECT app FROM mssql_scan('appn_default', 'SELECT APP_NAME() AS app');
@@ -92,7 +92,7 @@ DETACH appn_default;
 # and an APP_NAME()-based audit assertion would surprise the user.
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS};Application Name=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' AS appn_clamp (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS};Application Name=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' AS appn_clamp (TYPE mssql);
 
 query I
 SELECT app_len FROM mssql_scan('appn_clamp', 'SELECT LEN(APP_NAME()) AS app_len');
@@ -109,10 +109,10 @@ DETACH appn_clamp;
 # captures its own resolved value (spec 047 per-catalog pool ownership).
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS};Application Name=AppA' AS appn_a (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS};Application Name=AppA' AS appn_a (TYPE mssql);
 
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS};Application Name=AppB' AS appn_b (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS};Application Name=AppB' AS appn_b (TYPE mssql);
 
 query I
 SELECT app FROM mssql_scan('appn_a', 'SELECT APP_NAME() AS app');
@@ -138,11 +138,11 @@ DETACH appn_b;
 statement ok
 CREATE SECRET appn_secret_canonical (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'master',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     application_name 'SecretApp'
 );
 
@@ -166,11 +166,11 @@ DROP SECRET appn_secret_canonical;
 statement ok
 CREATE SECRET appn_secret_fallback (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'master',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     applicationname 'SecretAppFallback'
 );
 

--- a/test/sql/attach/attach_uri_password.test
+++ b/test/sql/attach/attach_uri_password.test
@@ -15,7 +15,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_URI}' AS uri_std (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_URI}' AS uri_std (TYPE mssql);
 
 # `>= 0` here asserted nothing at all -- COUNT(*) over an empty result is 0, so
 # it passed whether or not the ATTACH had produced a database. Same shape as the

--- a/test/sql/attach/attach_validates_credentials.test
+++ b/test/sql/attach/attach_validates_credentials.test
@@ -37,7 +37,7 @@ require-env MSSQL_TEST_PASS
 # wraps the translated message — never the raw connection string.
 #
 statement error
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=WRONG_PASSWORD_SENTINEL_xyz123' AS att_bad_pw (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password=WRONG_PASSWORD_SENTINEL_xyz123' AS att_bad_pw (TYPE mssql);
 ----
 Authentication failed for user
 
@@ -102,7 +102,7 @@ RESET mssql_attach_validation_timeout;
 # user; the subsequent query succeeds the same way it always did.
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS}' AS att_ok (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS}' AS att_ok (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('att_ok', 'SELECT 1');

--- a/test/sql/azure/azure_access_token.test
+++ b/test/sql/azure/azure_access_token.test
@@ -23,9 +23,9 @@ require-env AZURE_ACCESS_TOKEN
 #===----------------------------------------------------------------------===#
 
 statement ok
-ATTACH 'Server=${AZURE_SQL_DB_HOST};Database=${AZURE_SQL_DB}' AS token_db (
+ATTACH 'Server={AZURE_SQL_DB_HOST};Database={AZURE_SQL_DB}' AS token_db (
     TYPE mssql,
-    ACCESS_TOKEN '${AZURE_ACCESS_TOKEN}'
+    ACCESS_TOKEN '{AZURE_ACCESS_TOKEN}'
 );
 
 # Basic connectivity test
@@ -45,9 +45,9 @@ DETACH token_db;
 statement ok
 CREATE OR REPLACE SECRET mssql_token_secret (
     TYPE mssql,
-    HOST '${AZURE_SQL_DB_HOST}',
-    DATABASE '${AZURE_SQL_DB}',
-    ACCESS_TOKEN '${AZURE_ACCESS_TOKEN}'
+    HOST '{AZURE_SQL_DB_HOST}',
+    DATABASE '{AZURE_SQL_DB}',
+    ACCESS_TOKEN '{AZURE_ACCESS_TOKEN}'
 );
 
 statement ok
@@ -77,7 +77,7 @@ DROP SECRET IF EXISTS mssql_token_secret;
 #===----------------------------------------------------------------------===#
 
 statement error
-ATTACH 'Server=${AZURE_SQL_DB_HOST};Database=${AZURE_SQL_DB}' AS bad_token_db (
+ATTACH 'Server={AZURE_SQL_DB_HOST};Database={AZURE_SQL_DB}' AS bad_token_db (
     TYPE mssql,
     ACCESS_TOKEN 'not_a_valid_jwt'
 );
@@ -92,7 +92,7 @@ Invalid access token format: unable to parse JWT
 # This is a JWT with correct audience but expired (exp: 2020-01-01)
 # Header: {"alg":"none","typ":"JWT"} Payload: {"exp":1577836800,"aud":"https://database.windows.net/"}
 statement error
-ATTACH 'Server=${AZURE_SQL_DB_HOST};Database=${AZURE_SQL_DB}' AS expired_db (
+ATTACH 'Server={AZURE_SQL_DB_HOST};Database={AZURE_SQL_DB}' AS expired_db (
     TYPE mssql,
     ACCESS_TOKEN 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJleHAiOjE1Nzc4MzY4MDAsImF1ZCI6Imh0dHBzOi8vZGF0YWJhc2Uud2luZG93cy5uZXQvIn0.sig'
 );

--- a/test/sql/azure/azure_auth_test_function_with_credentials.test
+++ b/test/sql/azure/azure_auth_test_function_with_credentials.test
@@ -20,9 +20,9 @@ statement ok
 CREATE OR REPLACE SECRET test_azure_sp (
     TYPE azure,
     PROVIDER service_principal,
-    TENANT_ID '${AZURE_DIRECTORY_ID}',
-    CLIENT_ID '${AZURE_APP_ID}',
-    CLIENT_SECRET '${AZURE_APP_SECRET}'
+    TENANT_ID '{AZURE_DIRECTORY_ID}',
+    CLIENT_ID '{AZURE_APP_ID}',
+    CLIENT_SECRET '{AZURE_APP_SECRET}'
 );
 
 # Test: Valid service principal credentials return truncated token

--- a/test/sql/azure/azure_env_provider.test
+++ b/test/sql/azure/azure_env_provider.test
@@ -47,7 +47,7 @@ CREATE OR REPLACE SECRET azure_env_secret (
 
 # ATTACH using the env-based Azure secret
 statement ok
-ATTACH 'Server=${AZURE_SQL_DB_HOST};Database=${AZURE_SQL_DB}' AS env_db (
+ATTACH 'Server={AZURE_SQL_DB_HOST};Database={AZURE_SQL_DB}' AS env_db (
     TYPE mssql,
     AZURE_SECRET 'azure_env_secret'
 );
@@ -83,7 +83,7 @@ CREATE OR REPLACE SECRET azure_env_cli_secret (
 );
 
 statement ok
-ATTACH 'Server=${AZURE_SQL_DB_HOST};Database=${AZURE_SQL_DB}' AS env_cli_db (
+ATTACH 'Server={AZURE_SQL_DB_HOST};Database={AZURE_SQL_DB}' AS env_cli_db (
     TYPE mssql,
     AZURE_SECRET 'azure_env_cli_secret'
 );

--- a/test/sql/azure/azure_lazy_loading.test
+++ b/test/sql/azure/azure_lazy_loading.test
@@ -39,7 +39,7 @@ statement ok
 SET mssql_attach_validation_timeout = 120;
 
 statement ok
-ATTACH '${AZURE_SQL_TEST_DSN}' AS azure_test (TYPE mssql);
+ATTACH '{AZURE_SQL_TEST_DSN}' AS azure_test (TYPE mssql);
 
 # =============================================================================
 # Test 1: Lazy loading - schema discovery on demand

--- a/test/sql/azure/azure_secret_validation_with_credentials.test
+++ b/test/sql/azure/azure_secret_validation_with_credentials.test
@@ -21,9 +21,9 @@ statement ok
 CREATE OR REPLACE SECRET valid_azure_secret (
     TYPE azure,
     PROVIDER service_principal,
-    TENANT_ID '${AZURE_DIRECTORY_ID}',
-    CLIENT_ID '${AZURE_APP_ID}',
-    CLIENT_SECRET '${AZURE_APP_SECRET}'
+    TENANT_ID '{AZURE_DIRECTORY_ID}',
+    CLIENT_ID '{AZURE_APP_ID}',
+    CLIENT_SECRET '{AZURE_APP_SECRET}'
 );
 
 # Test: MSSQL secret with valid azure_secret succeeds (no user/password required)

--- a/test/sql/azure/azure_service_principal.test
+++ b/test/sql/azure/azure_service_principal.test
@@ -46,18 +46,18 @@ statement ok
 CREATE OR REPLACE SECRET azure_sp_secret (
     TYPE azure,
     PROVIDER service_principal,
-    TENANT_ID '${AZURE_DIRECTORY_ID}',
-    CLIENT_ID '${AZURE_APP_ID}',
-    CLIENT_SECRET '${AZURE_APP_SECRET}'
+    TENANT_ID '{AZURE_DIRECTORY_ID}',
+    CLIENT_ID '{AZURE_APP_ID}',
+    CLIENT_SECRET '{AZURE_APP_SECRET}'
 );
 
 # Create MSSQL secret that uses Azure authentication
 statement ok
 CREATE OR REPLACE SECRET azure_sql_secret (
     TYPE mssql,
-    HOST '${AZURE_SQL_DB_HOST}',
+    HOST '{AZURE_SQL_DB_HOST}',
     PORT 1433,
-    DATABASE '${AZURE_SQL_DB}',
+    DATABASE '{AZURE_SQL_DB}',
     azure_secret 'azure_sp_secret'
 );
 

--- a/test/sql/catalog/catalog_filter.test
+++ b/test/sql/catalog/catalog_filter.test
@@ -14,7 +14,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filter_setup (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS filter_setup (TYPE mssql);
 
 # Create test schema
 statement ok
@@ -56,7 +56,7 @@ DETACH filter_setup;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filt1 (TYPE mssql, table_filter '^filter_orders$');
+ATTACH '{MSSQL_TESTDB_DSN}' AS filt1 (TYPE mssql, table_filter '^filter_orders$');
 
 # Matching table should be queryable
 query IR
@@ -78,7 +78,7 @@ DETACH filt1;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filt2 (TYPE mssql, schema_filter '^dbo$');
+ATTACH '{MSSQL_TESTDB_DSN}' AS filt2 (TYPE mssql, schema_filter '^dbo$');
 
 # dbo tables should be visible
 query IR
@@ -100,7 +100,7 @@ DETACH filt2;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filt3 (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS filt3 (TYPE mssql);
 
 query IR
 SELECT id, total FROM filt3.dbo.filter_orders;
@@ -125,7 +125,7 @@ DETACH filt3;
 # =============================================================================
 
 statement error
-ATTACH '${MSSQL_TESTDB_DSN}' AS filt_bad (TYPE mssql, table_filter '[invalid');
+ATTACH '{MSSQL_TESTDB_DSN}' AS filt_bad (TYPE mssql, table_filter '[invalid');
 ----
 Invalid regex
 
@@ -134,7 +134,7 @@ Invalid regex
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filt5 (TYPE mssql, table_filter 'filter_');
+ATTACH '{MSSQL_TESTDB_DSN}' AS filt5 (TYPE mssql, table_filter 'filter_');
 
 # Both filter_ tables should match (partial match)
 query IR
@@ -155,7 +155,7 @@ DETACH filt5;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filt6 (TYPE mssql, table_filter '^FILTER_ORDERS$');
+ATTACH '{MSSQL_TESTDB_DSN}' AS filt6 (TYPE mssql, table_filter '^FILTER_ORDERS$');
 
 query IR
 SELECT id, total FROM filt6.dbo.filter_orders;
@@ -170,7 +170,7 @@ DETACH filt6;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filter_cleanup (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS filter_cleanup (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('filter_cleanup', 'DROP TABLE dbo.filter_orders');

--- a/test/sql/catalog/catalog_filter_sources.test
+++ b/test/sql/catalog/catalog_filter_sources.test
@@ -26,7 +26,7 @@ require-env MSSQL_TEST_PASS
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cfs_setup (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cfs_setup (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('cfs_setup', 'IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = ''cfs_other'') EXEC(''CREATE SCHEMA cfs_other'')');
@@ -66,7 +66,7 @@ DETACH cfs_setup;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN};Table_Filter=^cfs_orders$' AS ado_tf (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN};Table_Filter=^cfs_orders$' AS ado_tf (TYPE mssql);
 
 # Matching table should be queryable
 query IR
@@ -88,7 +88,7 @@ DETACH ado_tf;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN};Schema_Filter=^dbo$' AS ado_sf (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN};Schema_Filter=^dbo$' AS ado_sf (TYPE mssql);
 
 # dbo tables should be visible
 query IR
@@ -110,7 +110,7 @@ DETACH ado_sf;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN};Schema_Filter=^dbo$;Table_Filter=^cfs_orders$' AS ado_both (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN};Schema_Filter=^dbo$;Table_Filter=^cfs_orders$' AS ado_both (TYPE mssql);
 
 query IR
 SELECT id, total FROM ado_both.dbo.cfs_orders;
@@ -131,7 +131,7 @@ DETACH ado_both;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN};SchemaFilter=^dbo$;TableFilter=^cfs_orders$' AS ado_alt (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN};SchemaFilter=^dbo$;TableFilter=^cfs_orders$' AS ado_alt (TYPE mssql);
 
 query IR
 SELECT id, total FROM ado_alt.dbo.cfs_orders;
@@ -151,7 +151,7 @@ DETACH ado_alt;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_URI}?table_filter=^cfs_orders$' AS uri_tf (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_URI}?table_filter=^cfs_orders$' AS uri_tf (TYPE mssql);
 
 query IR
 SELECT id, total FROM uri_tf.dbo.cfs_orders;
@@ -171,7 +171,7 @@ DETACH uri_tf;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_URI}?schema_filter=^dbo$' AS uri_sf (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_URI}?schema_filter=^dbo$' AS uri_sf (TYPE mssql);
 
 query IR
 SELECT id, total FROM uri_sf.dbo.cfs_orders;
@@ -191,7 +191,7 @@ DETACH uri_sf;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_URI}?schema_filter=^dbo$&table_filter=^cfs_orders$' AS uri_both (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_URI}?schema_filter=^dbo$&table_filter=^cfs_orders$' AS uri_both (TYPE mssql);
 
 query IR
 SELECT id, total FROM uri_both.dbo.cfs_orders;
@@ -213,11 +213,11 @@ DETACH uri_both;
 statement ok
 CREATE SECRET cfs_secret_tf (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     table_filter '^cfs_orders$'
 );
 
@@ -247,11 +247,11 @@ DROP SECRET cfs_secret_tf;
 statement ok
 CREATE SECRET cfs_secret_sf (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     schema_filter '^dbo$'
 );
 
@@ -281,11 +281,11 @@ DROP SECRET cfs_secret_sf;
 statement ok
 CREATE SECRET cfs_secret_both (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     schema_filter '^dbo$',
     table_filter '^cfs_orders$'
 );
@@ -315,7 +315,7 @@ DROP SECRET cfs_secret_both;
 
 # Connection string has table_filter=^cfs_orders$, but ATTACH overrides to ^cfs_products$
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN};Table_Filter=^cfs_orders$' AS override_test (TYPE mssql, table_filter '^cfs_products$');
+ATTACH '{MSSQL_TESTDB_DSN};Table_Filter=^cfs_orders$' AS override_test (TYPE mssql, table_filter '^cfs_products$');
 
 # cfs_products should be visible (ATTACH override wins)
 query IT
@@ -339,11 +339,11 @@ DETACH override_test;
 statement ok
 CREATE SECRET cfs_secret_override (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     table_filter '^cfs_orders$'
 );
 
@@ -373,7 +373,7 @@ DROP SECRET cfs_secret_override;
 
 # Should match cfs_orders and cfs_products but not cfs_items
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS alt_test (TYPE mssql, table_filter '^(cfs_orders|cfs_products)$');
+ATTACH '{MSSQL_TESTDB_DSN}' AS alt_test (TYPE mssql, table_filter '^(cfs_orders|cfs_products)$');
 
 query IR
 SELECT id, total FROM alt_test.dbo.cfs_orders;
@@ -399,7 +399,7 @@ DETACH alt_test;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS alt_schema (TYPE mssql, schema_filter '^(dbo|cfs_other)$');
+ATTACH '{MSSQL_TESTDB_DSN}' AS alt_schema (TYPE mssql, schema_filter '^(dbo|cfs_other)$');
 
 query IR
 SELECT id, total FROM alt_schema.dbo.cfs_orders;
@@ -419,7 +419,7 @@ DETACH alt_schema;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN};Table_Filter=^(cfs_orders|cfs_products)$' AS ado_alt (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN};Table_Filter=^(cfs_orders|cfs_products)$' AS ado_alt (TYPE mssql);
 
 query IR
 SELECT id, total FROM ado_alt.dbo.cfs_orders;
@@ -439,7 +439,7 @@ DETACH ado_alt;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_URI}?table_filter=^(cfs_orders|cfs_products)$' AS uri_alt (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_URI}?table_filter=^(cfs_orders|cfs_products)$' AS uri_alt (TYPE mssql);
 
 query IR
 SELECT id, total FROM uri_alt.dbo.cfs_orders;
@@ -461,11 +461,11 @@ DETACH uri_alt;
 statement ok
 CREATE SECRET cfs_secret_alt (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}',
     table_filter '^(cfs_orders|cfs_products)$'
 );
 
@@ -493,7 +493,7 @@ DROP SECRET cfs_secret_alt;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cfs_cleanup (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cfs_cleanup (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('cfs_cleanup', 'DROP TABLE dbo.cfs_orders');

--- a/test/sql/catalog/catalog_parsing.test
+++ b/test/sql/catalog/catalog_parsing.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_catalog (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_catalog (TYPE mssql);
 
 # =============================================================================
 # Schema Tests

--- a/test/sql/catalog/collation_filter.test
+++ b/test/sql/catalog/collation_filter.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_coll (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_coll (TYPE mssql);
 
 # =============================================================================
 # Case-Insensitive Collation Filter Tests (SQL_Latin1_General_CP1_CI_AS)

--- a/test/sql/catalog/data_types.test
+++ b/test/sql/catalog/data_types.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_types (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_types (TYPE mssql);
 
 # =============================================================================
 # Tests using TestSimplePK table (simple types)

--- a/test/sql/catalog/datetimeoffset.test
+++ b/test/sql/catalog/datetimeoffset.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_dto (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_dto (TYPE mssql);
 
 # =============================================================================
 # Basic DATETIMEOFFSET Select Tests

--- a/test/sql/catalog/datetimeoffset_nbc.test
+++ b/test/sql/catalog/datetimeoffset_nbc.test
@@ -13,7 +13,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS nbc_dto (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS nbc_dto (TYPE mssql);
 
 # =============================================================================
 # Setup: Create table with many nullable columns to force NBCROW encoding

--- a/test/sql/catalog/ddl_if_not_exists.test
+++ b/test/sql/catalog/ddl_if_not_exists.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_CONNECTION_STRING
 
 statement ok
-ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # Clean up any existing test tables
 statement ok

--- a/test/sql/catalog/ddl_timestamp_precision.test
+++ b/test/sql/catalog/ddl_timestamp_precision.test
@@ -9,7 +9,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db_tspre (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db_tspre (TYPE mssql);
 
 statement ok
 DROP TABLE IF EXISTS db_tspre.dbo.ts_precision_create;

--- a/test/sql/catalog/deferred_columns.test
+++ b/test/sql/catalog/deferred_columns.test
@@ -14,7 +14,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS defer_test (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS defer_test (TYPE mssql);
 
 # Create several test tables to verify only queried tables load columns
 statement ok

--- a/test/sql/catalog/exec_ddl_cache_invalidation.test
+++ b/test/sql/catalog/exec_ddl_cache_invalidation.test
@@ -16,7 +16,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # Opt in to auto-invalidation (the default is false).
 statement ok

--- a/test/sql/catalog/exec_invalidate_cache_setting.test
+++ b/test/sql/catalog/exec_invalidate_cache_setting.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # =============================================================================
 # mssql_invalidate_cache() returns true at each granularity

--- a/test/sql/catalog/filter_client_net.test
+++ b/test/sql/catalog/filter_client_net.test
@@ -33,7 +33,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cfnet (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cfnet (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/catalog/filter_pushdown.test
+++ b/test/sql/catalog/filter_pushdown.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_filter (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_filter (TYPE mssql);
 
 # =============================================================================
 # Simple Equality Filter Tests

--- a/test/sql/catalog/filter_pushdown_hugeint.test
+++ b/test/sql/catalog/filter_pushdown_hugeint.test
@@ -26,7 +26,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS hugeint_filter (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS hugeint_filter (TYPE mssql);
 
 # Create + populate a DECIMAL(38,0) column via direct T-SQL. DuckDB's catalog
 # scan exposes it as HUGEINT, so the filter constant in WHERE clauses below is

--- a/test/sql/catalog/geometry_scan.test
+++ b/test/sql/catalog/geometry_scan.test
@@ -17,7 +17,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS geo (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS geo (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('geo', 'IF OBJECT_ID(N''dbo.geo_test'', N''U'') IS NOT NULL DROP TABLE dbo.geo_test;');

--- a/test/sql/catalog/incremental_ttl.test
+++ b/test/sql/catalog/incremental_ttl.test
@@ -18,7 +18,7 @@ statement ok
 SET mssql_catalog_cache_ttl = 2;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ttl_test (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ttl_test (TYPE mssql);
 
 # =============================================================================
 # Test 1: Cache loads on first access

--- a/test/sql/catalog/lazy_loading.test
+++ b/test/sql/catalog/lazy_loading.test
@@ -14,7 +14,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS lazy_test (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS lazy_test (TYPE mssql);
 
 # =============================================================================
 # Test 1: Lazy loading - schema discovery on demand

--- a/test/sql/catalog/legacy_lob_scan.test
+++ b/test/sql/catalog/legacy_lob_scan.test
@@ -25,7 +25,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS lob (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS lob (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('lob', 'DROP TABLE IF EXISTS dbo.LegacyLobScan');

--- a/test/sql/catalog/native_types.test
+++ b/test/sql/catalog/native_types.test
@@ -21,7 +21,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS nt (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS nt (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('nt', $$

--- a/test/sql/catalog/order_pushdown.test
+++ b/test/sql/catalog/order_pushdown.test
@@ -14,7 +14,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd_setup (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd_setup (TYPE mssql);
 
 # Clean up any previous test table
 statement ok
@@ -51,7 +51,7 @@ DETACH opd_setup;
 
 # Default: pushdown disabled
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd1 (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd1 (TYPE mssql);
 
 # Should work normally (ORDER BY done by DuckDB)
 query IT
@@ -77,7 +77,7 @@ statement ok
 SET mssql_order_pushdown = true;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd2 (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd2 (TYPE mssql);
 
 # With pushdown enabled, ORDER BY should be pushed to SQL Server
 query IT
@@ -104,7 +104,7 @@ SET mssql_order_pushdown = false;
 
 # Global setting disabled, but ATTACH option enables it
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd3 (TYPE mssql, order_pushdown true);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd3 (TYPE mssql, order_pushdown true);
 
 query IT
 SELECT id, name FROM opd3.dbo.order_pushdown_test ORDER BY id ASC;
@@ -126,7 +126,7 @@ statement ok
 SET mssql_order_pushdown = true;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd3b (TYPE mssql, order_pushdown false);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd3b (TYPE mssql, order_pushdown false);
 
 query IT
 SELECT id, name FROM opd3b.dbo.order_pushdown_test ORDER BY id ASC;
@@ -151,7 +151,7 @@ SET mssql_order_pushdown = false;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd4 (TYPE mssql, order_pushdown true);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd4 (TYPE mssql, order_pushdown true);
 
 query IT
 SELECT id, name FROM opd4.dbo.order_pushdown_test ORDER BY name ASC;
@@ -308,7 +308,7 @@ DETACH opd4;
 
 # Create table with NOT NULL column
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd_nn (TYPE mssql, order_pushdown true);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd_nn (TYPE mssql, order_pushdown true);
 
 statement ok
 DROP TABLE IF EXISTS opd_nn.dbo.order_pushdown_nn;
@@ -350,7 +350,7 @@ DETACH opd_nn;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd_prune (TYPE mssql, order_pushdown true);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd_prune (TYPE mssql, order_pushdown true);
 
 # score is used only for ORDER BY, not in output — should be pruned after pushdown
 query IT
@@ -414,7 +414,7 @@ DETACH opd_prune;
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd_join (TYPE mssql, order_pushdown true);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd_join (TYPE mssql, order_pushdown true);
 
 # Create a local DuckDB table to join against
 statement ok
@@ -485,7 +485,7 @@ DETACH opd_join;
 
 # Final cleanup: drop test table
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS opd_cleanup (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS opd_cleanup (TYPE mssql);
 
 statement ok
 DROP TABLE IF EXISTS opd_cleanup.dbo.order_pushdown_test;

--- a/test/sql/catalog/partitioned_table.test
+++ b/test/sql/catalog/partitioned_table.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS part_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS part_db (TYPE mssql);
 
 # =============================================================================
 # Setup: a table spread over 4 partitions by a clustered index

--- a/test/sql/catalog/preload_catalog.test
+++ b/test/sql/catalog/preload_catalog.test
@@ -14,7 +14,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS preload_test (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS preload_test (TYPE mssql);
 
 # Create some tables for preloading
 statement ok

--- a/test/sql/catalog/scan_wide_varchar_length.test
+++ b/test/sql/catalog/scan_wide_varchar_length.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.scan_wide_varchar_test');

--- a/test/sql/catalog/select_queries.test
+++ b/test/sql/catalog/select_queries.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_select (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_select (TYPE mssql);
 
 # =============================================================================
 # Basic SELECT Tests - Standard tables

--- a/test/sql/catalog/table_options.test
+++ b/test/sql/catalog/table_options.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS topt (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS topt (TYPE mssql);
 
 # =============================================================================
 # Defaults first: with nothing set, a created table is a HEAP with nvarchar(max)

--- a/test/sql/catalog/udt_type_alias.test
+++ b/test/sql/catalog/udt_type_alias.test
@@ -16,7 +16,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_udt (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_udt (TYPE mssql);
 
 # =============================================================================
 # Setup: Create UDT aliases and a test table using them

--- a/test/sql/catalog/unsupported_type_cast.test
+++ b/test/sql/catalog/unsupported_type_cast.test
@@ -16,7 +16,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_cast (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_cast (TYPE mssql);
 
 # =============================================================================
 # Setup: Create table with unsupported types

--- a/test/sql/catalog/varchar_encoding.test
+++ b/test/sql/catalog/varchar_encoding.test
@@ -14,7 +14,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_enc (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_enc (TYPE mssql);
 
 # =============================================================================
 # Setup: Create test table with non-UTF8 collation

--- a/test/sql/catalog/view_cast_type_mismatch.test
+++ b/test/sql/catalog/view_cast_type_mismatch.test
@@ -16,7 +16,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS view_cast (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS view_cast (TYPE mssql);
 
 # Build a base table whose columns reproduce the issue #89 schema shape:
 #   - A numeric-looking column declared as NVARCHAR (issue #89's "Convenience Fee")

--- a/test/sql/catalog_discovery.test
+++ b/test/sql/catalog_discovery.test
@@ -10,7 +10,7 @@ require-env MSSQL_TEST_DSN
 # Test 1: Attach and browse schemas
 #
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS mssql_catalog (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS mssql_catalog (TYPE mssql);
 
 # Ensure test data is in a known state (restore if modified by previous test runs)
 statement ok

--- a/test/sql/copy/bcp_identity_column.test
+++ b/test/sql/copy/bcp_identity_column.test
@@ -18,7 +18,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # =============================================================================
 # Scenario A: source OMITS the identity column -> server auto-generates it

--- a/test/sql/copy/both_paths_agree.test
+++ b/test/sql/copy/both_paths_agree.test
@@ -55,7 +55,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS bp (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS bp (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/columnar_encode_all_families.test
+++ b/test/sql/copy/columnar_encode_all_families.test
@@ -47,7 +47,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ce (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ce (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/columnar_width_and_sign.test
+++ b/test/sql/copy/columnar_width_and_sign.test
@@ -19,7 +19,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ws (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ws (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/columnstore_batch_threshold.test
+++ b/test/sql/copy/columnstore_batch_threshold.test
@@ -33,7 +33,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cs (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cs (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/compatible_type_conversion.test
+++ b/test/sql/copy/compatible_type_conversion.test
@@ -36,7 +36,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cv (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cv (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/copy_auto_tablock.test
+++ b/test/sql/copy/copy_auto_tablock.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_CONNECTION_STRING
 
 statement ok
-ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # Clean up any existing test tables
 statement ok

--- a/test/sql/copy/copy_basic.test
+++ b/test/sql/copy/copy_basic.test
@@ -8,7 +8,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach to SQL Server
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # Create a local table with test data
 statement ok

--- a/test/sql/copy/copy_column_mapping.test
+++ b/test/sql/copy/copy_column_mapping.test
@@ -8,7 +8,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach to SQL Server
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # ===========================================================================
 # Test 1: Exact column match (backward compatibility)

--- a/test/sql/copy/copy_connection_leak.test
+++ b/test/sql/copy/copy_connection_leak.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_SERVER
 
 statement ok
-ATTACH '${MSSQL_TEST_SERVER}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TEST_SERVER}' AS db (TYPE mssql);
 
 # This file counts connections, so it has to pin the number a COPY is allowed to
 # open. Spec 057 step 7 let a successful COPY take one bulk-load session per
@@ -138,7 +138,7 @@ loop i 0 10
 
 # Try to COPY to non-existent table with CREATE_TABLE=false
 statement error
-COPY test_data TO 'db.dbo.nonexistent_table_${i}' (FORMAT 'bcp', CREATE_TABLE false);
+COPY test_data TO 'db.dbo.nonexistent_table_{i}' (FORMAT 'bcp', CREATE_TABLE false);
 ----
 does not exist
 

--- a/test/sql/copy/copy_empty_schema.test
+++ b/test/sql/copy/copy_empty_schema.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_SERVER
 
 statement ok
-ATTACH '${MSSQL_TEST_SERVER}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TEST_SERVER}' AS db (TYPE mssql);
 
 # Create test data
 statement ok

--- a/test/sql/copy/copy_errors.test
+++ b/test/sql/copy/copy_errors.test
@@ -7,7 +7,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 statement ok
 CREATE TABLE test_data AS SELECT 1::BIGINT AS id, 'test'::VARCHAR AS name;

--- a/test/sql/copy/copy_existing_temp.test
+++ b/test/sql/copy/copy_existing_temp.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_SERVER
 
 statement ok
-ATTACH '${MSSQL_TEST_SERVER}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TEST_SERVER}' AS db (TYPE mssql);
 
 # Test 1: Copy to existing temp table with BIGINT column
 statement ok

--- a/test/sql/copy/copy_failed_bcp_releases_connection.test
+++ b/test/sql/copy/copy_failed_bcp_releases_connection.test
@@ -12,7 +12,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_fail_release_test');

--- a/test/sql/copy/copy_hugeint_bcp.test
+++ b/test/sql/copy/copy_hugeint_bcp.test
@@ -7,7 +7,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # SUM() over BIGINT returns HUGEINT — the exact repro from issue #177.
 statement ok

--- a/test/sql/copy/copy_large.test
+++ b/test/sql/copy/copy_large.test
@@ -7,7 +7,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # Test with 10K rows
 statement ok

--- a/test/sql/copy/copy_nvarchar_length_validation.test
+++ b/test/sql/copy/copy_nvarchar_length_validation.test
@@ -32,7 +32,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # Pre-test cleanup: drop any leftover tables from a previous failed run.
 statement ok

--- a/test/sql/copy/copy_overwrite.test
+++ b/test/sql/copy/copy_overwrite.test
@@ -7,7 +7,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # Test 1: OVERWRITE replaces existing table with new schema
 statement ok

--- a/test/sql/copy/copy_temp.test
+++ b/test/sql/copy/copy_temp.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS copytemp (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS copytemp (TYPE mssql);
 
 # =============================================================================
 # Test 1: COPY to temp table within transaction (keeps temp table accessible)

--- a/test/sql/copy/copy_to_nvarchar_unicode.test
+++ b/test/sql/copy/copy_to_nvarchar_unicode.test
@@ -7,7 +7,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # Source data covers the four payload classes the codec consolidation
 # spec (044) cares about: ASCII fast path, BMP Cyrillic / accented

--- a/test/sql/copy/copy_transaction.test
+++ b/test/sql/copy/copy_transaction.test
@@ -11,7 +11,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS copytx (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS copytx (TYPE mssql);
 
 # =============================================================================
 # Test 1: COPY within transaction - COMMIT persists data

--- a/test/sql/copy/copy_type_mismatch.test
+++ b/test/sql/copy/copy_type_mismatch.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_SERVER
 
 statement ok
-ATTACH '${MSSQL_TEST_SERVER}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TEST_SERVER}' AS db (TYPE mssql);
 
 #
 # T021: Test VARCHAR to INT mismatch detection

--- a/test/sql/copy/copy_types.test
+++ b/test/sql/copy/copy_types.test
@@ -7,7 +7,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 # Test integer types
 statement ok

--- a/test/sql/copy/copy_varchar_collation.test
+++ b/test/sql/copy/copy_varchar_collation.test
@@ -27,7 +27,7 @@ require-env MSSQL_TEST_PASS
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cvc (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cvc (TYPE mssql);
 
 # -----------------------------------------------------------------------------
 # 1. The session setting. CTAS honoured it and COPY did not: COPY only looked
@@ -78,7 +78,7 @@ IF DB_ID('CvcUtf8Db') IS NULL CREATE DATABASE CvcUtf8Db COLLATE Latin1_General_1
 $$);
 
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=CvcUtf8Db;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS}' AS cvc8 (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=CvcUtf8Db;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS}' AS cvc8 (TYPE mssql);
 
 statement ok
 BEGIN TRANSACTION;

--- a/test/sql/copy/copy_varchar_length.test
+++ b/test/sql/copy/copy_varchar_length.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('db', 'DROP TABLE IF EXISTS dbo.copy_varchar_len_test');

--- a/test/sql/copy/decimal_scale_mismatch.test
+++ b/test/sql/copy/decimal_scale_mismatch.test
@@ -26,7 +26,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ds (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ds (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/geometry_wkb.test
+++ b/test/sql/copy/geometry_wkb.test
@@ -22,7 +22,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS geo (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS geo (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/money_columnar.test
+++ b/test/sql/copy/money_columnar.test
@@ -31,7 +31,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mn (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mn (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/null_only_columns.test
+++ b/test/sql/copy/null_only_columns.test
@@ -32,7 +32,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS no (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS no (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/parallel_writers.test
+++ b/test/sql/copy/parallel_writers.test
@@ -34,7 +34,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS pw (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS pw (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/string_bound_truncation.test
+++ b/test/sql/copy/string_bound_truncation.test
@@ -39,7 +39,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS tr (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS tr (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/tablock_by_target_shape.test
+++ b/test/sql/copy/tablock_by_target_shape.test
@@ -26,7 +26,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS tl (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS tl (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/copy/vector_encodings_bcp.test
+++ b/test/sql/copy/vector_encodings_bcp.test
@@ -32,7 +32,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ve_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ve_db (TYPE mssql);
 
 statement ok
 CREATE TABLE ve_src AS
@@ -47,12 +47,12 @@ SELECT i,
 FROM range(400000) t(i);
 
 statement ok
-COPY ve_src TO '__TEST_DIR__/ve_dict.parquet';
+COPY ve_src TO '{TEST_DIR}/ve_dict.parquet';
 
 # --- parquet source: dictionary vectors from the parquet reader ---
 
 statement ok
-COPY (FROM read_parquet('__TEST_DIR__/ve_dict.parquet')) TO 've_db.dbo.VecEnc' (FORMAT bcp, CREATE_TABLE true, REPLACE true);
+COPY (FROM read_parquet('{TEST_DIR}/ve_dict.parquet')) TO 've_db.dbo.VecEnc' (FORMAT bcp, CREATE_TABLE true, REPLACE true);
 
 query I
 SELECT count(*) FROM ve_db.dbo.VecEnc

--- a/test/sql/ctas/ctas_auto_tablock.test
+++ b/test/sql/ctas/ctas_auto_tablock.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_CONNECTION_STRING
 
 statement ok
-ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # This test mixes raw mssql_exec() DDL (DROP) with catalog DDL, so enable
 # auto-invalidation (mssql_exec_invalidate_cache defaults to false).

--- a/test/sql/ctas/ctas_basic.test
+++ b/test/sql/ctas/ctas_basic.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database with READ_WRITE mode (required for CTAS)
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ctas_basic (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ctas_basic (TYPE mssql);
 
 # Test 2: Cleanup any leftover test tables
 statement ok

--- a/test/sql/ctas/ctas_bcp.test
+++ b/test/sql/ctas/ctas_bcp.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ctas_bcp (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ctas_bcp (TYPE mssql);
 
 # Cleanup
 statement ok

--- a/test/sql/ctas/ctas_failure.test
+++ b/test/sql/ctas/ctas_failure.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_fail (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_fail (TYPE mssql);
 
 # Cleanup any leftover test tables
 statement ok

--- a/test/sql/ctas/ctas_if_not_exists.test
+++ b/test/sql/ctas/ctas_if_not_exists.test
@@ -8,7 +8,7 @@ require mssql
 require-env MSSQL_TEST_CONNECTION_STRING
 
 statement ok
-ATTACH '${MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TEST_CONNECTION_STRING}' AS mssql (TYPE mssql);
 
 # This test mixes raw mssql_exec() DDL (DROP) with catalog DDL, so enable
 # auto-invalidation (mssql_exec_invalidate_cache defaults to false).

--- a/test/sql/ctas/ctas_insert_mode.test
+++ b/test/sql/ctas/ctas_insert_mode.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ctas_insert (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ctas_insert (TYPE mssql);
 
 # Cleanup
 statement ok

--- a/test/sql/ctas/ctas_large.test
+++ b/test/sql/ctas/ctas_large.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ctas_large (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ctas_large (TYPE mssql);
 
 # Cleanup any leftover test tables
 statement ok

--- a/test/sql/ctas/ctas_or_replace.test
+++ b/test/sql/ctas/ctas_or_replace.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_or_replace (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_or_replace (TYPE mssql);
 
 # Cleanup any leftover test tables
 statement ok

--- a/test/sql/ctas/ctas_parallel_writers.test
+++ b/test/sql/ctas/ctas_parallel_writers.test
@@ -33,7 +33,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS cpw (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS cpw (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/ctas/ctas_transaction.test
+++ b/test/sql/ctas/ctas_transaction.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_tx (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_tx (TYPE mssql);
 
 # Cleanup any leftover test tables
 statement ok

--- a/test/sql/ctas/ctas_types.test
+++ b/test/sql/ctas/ctas_types.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ctas_types (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ctas_types (TYPE mssql);
 
 # Cleanup any leftover test tables
 statement ok

--- a/test/sql/ctas/ctas_varchar_collation.test
+++ b/test/sql/ctas/ctas_varchar_collation.test
@@ -23,7 +23,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ctas_col (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ctas_col (TYPE mssql);
 
 statement ok
 SET mssql_ctas_text_type = 'VARCHAR';

--- a/test/sql/dml/delete_bulk.test
+++ b/test/sql/dml/delete_bulk.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_del_bulk (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_del_bulk (TYPE mssql);
 
 # Test 2: Create test table with primary key
 statement ok

--- a/test/sql/dml/delete_composite_pk.test
+++ b/test/sql/dml/delete_composite_pk.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # Test 2: Create test table with composite primary key (2 columns)
 statement ok

--- a/test/sql/dml/delete_scalar_pk.test
+++ b/test/sql/dml/delete_scalar_pk.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database with READ_WRITE mode (required for DELETE)
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # Test 2: Create test table with primary key
 statement ok

--- a/test/sql/dml/no_pk_update_delete.test
+++ b/test/sql/dml/no_pk_update_delete.test
@@ -17,7 +17,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # Create a table WITHOUT a primary key
 statement ok

--- a/test/sql/dml/update_bulk.test
+++ b/test/sql/dml/update_bulk.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_upd_bulk (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_upd_bulk (TYPE mssql);
 
 # Test 2: Create test table with primary key
 statement ok

--- a/test/sql/dml/update_composite_pk.test
+++ b/test/sql/dml/update_composite_pk.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_upd_comp (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_upd_comp (TYPE mssql);
 
 # Test 2: Create test table with composite primary key (2 columns)
 statement ok

--- a/test/sql/dml/update_scalar_pk.test
+++ b/test/sql/dml/update_scalar_pk.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database with READ_WRITE mode (required for UPDATE)
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_upd_scalar (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_upd_scalar (TYPE mssql);
 
 # Test 2: Create test table with primary key
 statement ok

--- a/test/sql/fabric/fabric_types.test
+++ b/test/sql/fabric/fabric_types.test
@@ -25,9 +25,9 @@ require-env AZURE_WH_NAME
 require-env AZURE_WH_TOKEN
 
 statement ok
-ATTACH 'Server=${AZURE_WH_HOST};Database=${AZURE_WH_NAME}' AS wh (
+ATTACH 'Server={AZURE_WH_HOST};Database={AZURE_WH_NAME}' AS wh (
     TYPE mssql,
-    ACCESS_TOKEN '${AZURE_WH_TOKEN}'
+    ACCESS_TOKEN '{AZURE_WH_TOKEN}'
 );
 
 # =============================================================================

--- a/test/sql/insert/insert_basic.test
+++ b/test/sql/insert/insert_basic.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database with READ_WRITE mode (required for INSERT)
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_insert_basic (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_insert_basic (TYPE mssql);
 
 # Test 2: Create test table using standard DDL
 statement ok

--- a/test/sql/insert/insert_bulk.test
+++ b/test/sql/insert/insert_bulk.test
@@ -13,7 +13,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_insert_bulk (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_insert_bulk (TYPE mssql);
 
 # Test 2: Create test table (use mssql_exec for PRIMARY KEY constraint)
 statement ok

--- a/test/sql/insert/insert_errors.test
+++ b/test/sql/insert/insert_errors.test
@@ -16,7 +16,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: READ_ONLY mode blocks INSERT
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_insert_err_ro (TYPE mssql, READ_ONLY);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_insert_err_ro (TYPE mssql, READ_ONLY);
 
 # Try to INSERT into any table - should fail with read-only error
 statement error
@@ -29,7 +29,7 @@ DETACH mssql_insert_err_ro;
 
 # Test 2: Attach with READ_WRITE for constraint tests
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_insert_errors (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_insert_errors (TYPE mssql);
 
 # Test 3: Primary key violation (use mssql_exec for PRIMARY KEY constraint)
 statement ok

--- a/test/sql/insert/insert_returning.test
+++ b/test/sql/insert/insert_returning.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database with READ_WRITE mode
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_insert_returning (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_insert_returning (TYPE mssql);
 
 # Test 2: Create table with IDENTITY column (use mssql_exec for IDENTITY syntax)
 statement ok

--- a/test/sql/insert/insert_server_defaults.test
+++ b/test/sql/insert/insert_server_defaults.test
@@ -18,7 +18,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS defdb (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS defdb (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('defdb', 'IF OBJECT_ID(''dbo.SrvDefaults'') IS NOT NULL DROP TABLE dbo.SrvDefaults;

--- a/test/sql/insert/insert_types.test
+++ b/test/sql/insert/insert_types.test
@@ -21,7 +21,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Test 1: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ins_types (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ins_types (TYPE mssql);
 
 # Test 2: Create table with all supported types (ensure clean state via mssql_exec)
 statement ok

--- a/test/sql/integrated_auth/winsspi_basic.test
+++ b/test/sql/integrated_auth/winsspi_basic.test
@@ -19,7 +19,7 @@ require-env MSSQL_TEST_DB
 #         Resolves to authenticator=winsspi on Windows.
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=${MSSQL_TEST_DB};Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes' AS wsspi (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database={MSSQL_TEST_DB};Trusted_Connection=yes;Encrypt=yes;TrustServerCertificate=yes' AS wsspi (TYPE mssql);
 
 #
 # Test 2: Basic SELECT through the catalog.
@@ -44,7 +44,7 @@ DETACH wsspi;
 # Test 4: ATTACH via explicit authenticator=winsspi (go-mssqldb form).
 #
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=${MSSQL_TEST_DB};authenticator=winsspi;Encrypt=yes;TrustServerCertificate=yes' AS wsspi2 (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database={MSSQL_TEST_DB};authenticator=winsspi;Encrypt=yes;TrustServerCertificate=yes' AS wsspi2 (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('wsspi2', 'SELECT @@VERSION AS v');

--- a/test/sql/integration/basic_queries.test
+++ b/test/sql/integration/basic_queries.test
@@ -11,7 +11,7 @@ require-env MSSQL_TEST_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS basic_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS basic_db (TYPE mssql);
 
 # Test 1: Simple SELECT
 query I

--- a/test/sql/integration/connection_pool.test
+++ b/test/sql/integration/connection_pool.test
@@ -11,7 +11,7 @@ require-env MSSQL_TEST_DSN
 
 # Test 1: ATTACH creates a connection pool
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS pool_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS pool_db (TYPE mssql);
 
 # Test 2: Pool statistics should be available for attached database
 query IIIIIIII
@@ -61,7 +61,7 @@ SELECT count(*) FROM mssql_pool_stats('pool_db');
 
 # Test 8: Re-attach with connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS pool_db2 (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS pool_db2 (TYPE mssql);
 
 # Pool should be created for connection string attachment too
 query I

--- a/test/sql/integration/datetime2_scale.test
+++ b/test/sql/integration/datetime2_scale.test
@@ -10,7 +10,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS dt2test (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS dt2test (TYPE mssql);
 
 # Create test table with datetime2 columns of various scales
 statement ok

--- a/test/sql/integration/datetime_nbc_scales.test
+++ b/test/sql/integration/datetime_nbc_scales.test
@@ -13,7 +13,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS nbc_scales (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS nbc_scales (TYPE mssql);
 
 # =============================================================================
 # Test 1: TIME at all scales via NBCROW

--- a/test/sql/integration/datetimeoffset_scales.test
+++ b/test/sql/integration/datetimeoffset_scales.test
@@ -10,7 +10,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS dto_scale (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS dto_scale (TYPE mssql);
 
 # Create test table with DATETIMEOFFSET columns of various scales
 statement ok

--- a/test/sql/integration/ddl_ansi_settings.test
+++ b/test/sql/integration/ddl_ansi_settings.test
@@ -16,7 +16,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ansi_test_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ansi_test_db (TYPE mssql);
 
 # Test 1: Verify CONCAT_NULL_YIELDS_NULL behavior is ON
 # With CONCAT_NULL_YIELDS_NULL ON, 'test' + NULL = NULL

--- a/test/sql/integration/diagnostic_functions.test
+++ b/test/sql/integration/diagnostic_functions.test
@@ -12,7 +12,7 @@ require-env MSSQL_TEST_DSN
 # Test 1: mssql_open with connection string - should succeed and return a connection handle
 # Store handle in temp table for use in subsequent tests
 statement ok
-CREATE TEMP TABLE test_handle AS SELECT mssql_open('${MSSQL_TEST_DSN}') AS handle;
+CREATE TEMP TABLE test_handle AS SELECT mssql_open('{MSSQL_TEST_DSN}') AS handle;
 
 query I
 SELECT handle >= 1 FROM test_handle;

--- a/test/sql/integration/filter_pushdown.test
+++ b/test/sql/integration/filter_pushdown.test
@@ -16,7 +16,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS filter_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS filter_db (TYPE mssql);
 
 # =============================================================================
 # SCENARIO 1: All Filters Pushed Down

--- a/test/sql/integration/issue178_concurrent_same_table.test
+++ b/test/sql/integration/issue178_concurrent_same_table.test
@@ -13,7 +13,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS mss (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS mss (TYPE mssql);
 
 # Big enough that LIMIT 10 abandons the TDS stream mid-flight (as in the report).
 # The table is DELIBERATELY persistent (IF OBJECT_ID guard, no DROP): populating

--- a/test/sql/integration/large_data.test
+++ b/test/sql/integration/large_data.test
@@ -11,7 +11,7 @@ require-env MSSQL_TEST_DSN
 
 # Setup using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS largedb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS largedb (TYPE mssql);
 
 # Test 1: Result set with GENERATE_SERIES
 query I

--- a/test/sql/integration/max_types.test
+++ b/test/sql/integration/max_types.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database using connection string
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS maxtype_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS maxtype_db (TYPE mssql);
 
 # ===========================================================================
 # Test MAX types using catalog (attached database)

--- a/test/sql/integration/nbc_all_types.test
+++ b/test/sql/integration/nbc_all_types.test
@@ -10,7 +10,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS nbc_all (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS nbc_all (TYPE mssql);
 
 # =============================================================================
 # Setup: Create table with ALL supported types, all nullable + padding for NBCROW

--- a/test/sql/integration/non_ascii_connection_formats.test
+++ b/test/sql/integration/non_ascii_connection_formats.test
@@ -8,7 +8,7 @@
 # REQUIRES: SQL Server running (via `make docker-up`)
 # Connection parameters come from MSSQL_TEST_* env vars exported by the
 # project Makefile. No hardcoded host/port — the URI / ADO.NET strings
-# are constructed from ${MSSQL_TEST_HOST} and ${MSSQL_TEST_PORT}.
+# are constructed from {MSSQL_TEST_HOST} and {MSSQL_TEST_PORT}.
 
 require mssql
 
@@ -27,7 +27,7 @@ require-env MSSQL_TEST_PASS
 # ============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS bootstrap_admin (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS bootstrap_admin (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('bootstrap_admin', '
@@ -80,7 +80,7 @@ DETACH bootstrap_admin;
 # ============================================================================
 
 statement ok
-ATTACH 'mssql://spec043_user_ru:%D0%A2%D0%B5%D1%81%D1%82123%21@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/TestDB?encrypt=true&trustservercertificate=true' AS mssql_uri_tls (TYPE mssql);
+ATTACH 'mssql://spec043_user_ru:%D0%A2%D0%B5%D1%81%D1%82123%21@{MSSQL_TEST_HOST}:{MSSQL_TEST_PORT}/TestDB?encrypt=true&trustservercertificate=true' AS mssql_uri_tls (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mssql_uri_tls', 'SELECT 1 AS one');
@@ -91,7 +91,7 @@ statement ok
 DETACH mssql_uri_tls;
 
 statement ok
-ATTACH 'mssql://spec043_user_ru:%D0%A2%D0%B5%D1%81%D1%82123%21@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/TestDB?encrypt=false' AS mssql_uri_plain (TYPE mssql);
+ATTACH 'mssql://spec043_user_ru:%D0%A2%D0%B5%D1%81%D1%82123%21@{MSSQL_TEST_HOST}:{MSSQL_TEST_PORT}/TestDB?encrypt=false' AS mssql_uri_plain (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mssql_uri_plain', 'SELECT 1 AS one');
@@ -107,7 +107,7 @@ DETACH mssql_uri_plain;
 # ============================================================================
 
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=TestDB;User Id=spec043_user_ru;Password=Тест123!;Encrypt=true;TrustServerCertificate=true' AS mssql_ado_tls (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=TestDB;User Id=spec043_user_ru;Password=Тест123!;Encrypt=true;TrustServerCertificate=true' AS mssql_ado_tls (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mssql_ado_tls', 'SELECT 1 AS one');
@@ -118,7 +118,7 @@ statement ok
 DETACH mssql_ado_tls;
 
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=TestDB;User Id=spec043_user_ru;Password=Тест123!;Encrypt=false' AS mssql_ado_plain (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=TestDB;User Id=spec043_user_ru;Password=Тест123!;Encrypt=false' AS mssql_ado_plain (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mssql_ado_plain', 'SELECT 1 AS one');
@@ -135,8 +135,8 @@ DETACH mssql_ado_plain;
 statement ok
 CREATE OR REPLACE SECRET spec043_secret_ru (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
     "user" 'spec043_user_ru',
     password 'Тест123!',
@@ -164,7 +164,7 @@ DROP SECRET spec043_secret_ru;
 # ============================================================================
 
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=TestDB;User Id=spec043_user_braces;Password={Тест;123!};Encrypt=false' AS mssql_braces (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=TestDB;User Id=spec043_user_braces;Password={Тест;123!};Encrypt=false' AS mssql_braces (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mssql_braces', 'SELECT 1 AS one');

--- a/test/sql/integration/non_ascii_password.test
+++ b/test/sql/integration/non_ascii_password.test
@@ -28,7 +28,7 @@ require-env MSSQL_TEST_PASS
 # ============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_admin (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_admin (TYPE mssql);
 
 # Cyrillic password
 statement ok
@@ -92,8 +92,8 @@ DETACH mssql_admin;
 statement ok
 CREATE OR REPLACE SECRET spec043_secret_ru_tls (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
     "user" 'spec043_user_ru',
     password 'Тест123!',
@@ -117,8 +117,8 @@ DROP SECRET spec043_secret_ru_tls;
 statement ok
 CREATE OR REPLACE SECRET spec043_secret_ru_plain (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
     "user" 'spec043_user_ru',
     password 'Тест123!',
@@ -146,8 +146,8 @@ DROP SECRET spec043_secret_ru_plain;
 statement ok
 CREATE OR REPLACE SECRET spec043_secret_de (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
     "user" 'spec043_user_de',
     password 'Ünlaut$2024',
@@ -175,8 +175,8 @@ DROP SECRET spec043_secret_de;
 statement ok
 CREATE OR REPLACE SECRET spec043_secret_emoji (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
     database 'TestDB',
     "user" 'spec043_user_emoji',
     password '🔒secure!',
@@ -203,7 +203,7 @@ DROP SECRET spec043_secret_emoji;
 # ============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql_ascii (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql_ascii (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mssql_ascii', 'SELECT 1 AS one');

--- a/test/sql/integration/parallel_queries.test
+++ b/test/sql/integration/parallel_queries.test
@@ -15,7 +15,7 @@ SET mssql_connection_limit = 16;
 
 # Setup using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS paralleldb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS paralleldb (TYPE mssql);
 
 # Test 1: Two CTEs (may run in parallel depending on DuckDB planner)
 query I

--- a/test/sql/integration/pool_limits.test
+++ b/test/sql/integration/pool_limits.test
@@ -17,7 +17,7 @@ SET mssql_connection_limit = 2;
 
 # Attach with limited pool using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS limitdb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS limitdb (TYPE mssql);
 
 # Test 2: First query creates a connection
 query I

--- a/test/sql/integration/query_cancellation.test
+++ b/test/sql/integration/query_cancellation.test
@@ -14,7 +14,7 @@ require-env MSSQL_TEST_DSN
 
 # Setup using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS canceldb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS canceldb (TYPE mssql);
 
 # Test 1: Quick query completes normally
 query I

--- a/test/sql/integration/reset_connection.test
+++ b/test/sql/integration/reset_connection.test
@@ -35,7 +35,7 @@ statement ok
 SET mssql_connection_limit = 1;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS rc (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS rc (TYPE mssql);
 
 # -----------------------------------------------------------------------------
 # The lever: one connection, reused. Everything below depends on it.

--- a/test/sql/integration/time_scales.test
+++ b/test/sql/integration/time_scales.test
@@ -10,7 +10,7 @@ statement ok
 SET mssql_connection_cache=false;
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS time_test (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS time_test (TYPE mssql);
 
 # Create test table with TIME columns of various scales
 statement ok

--- a/test/sql/integration/tls_connection.test
+++ b/test/sql/integration/tls_connection.test
@@ -27,7 +27,7 @@ require-env MSSQL_TEST_DSN
 # Verifies that a TLS connection can be established and used for queries
 # ============================================================================
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS tls_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS tls_db (TYPE mssql);
 
 # Simple query over TLS
 query I
@@ -56,7 +56,7 @@ DETACH tls_db;
 # Verifies that TLS connections are tracked correctly in pool
 # ============================================================================
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS tls_pool_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS tls_pool_db (TYPE mssql);
 
 # Execute a query to ensure connection is established
 query I
@@ -90,7 +90,7 @@ DETACH tls_pool_db;
 # Verifies that TLS can handle larger data transfers
 # ============================================================================
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS tls_large_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS tls_large_db (TYPE mssql);
 
 # Query that returns multiple rows
 query I
@@ -140,10 +140,10 @@ DROP SECRET tls_test_secret;
 # ============================================================================
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS plain_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS plain_db (TYPE mssql);
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS encrypted_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS encrypted_db (TYPE mssql);
 
 # Both should return same data
 query I

--- a/test/sql/integration/tls_multipacket.test
+++ b/test/sql/integration/tls_multipacket.test
@@ -15,7 +15,7 @@ require-env MSSQL_TEST_DSN_TLS
 # Test 1: Single packet query over TLS (baseline)
 #
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS tls_mp_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS tls_mp_db (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('tls_mp_db', 'SELECT 1 AS val');

--- a/test/sql/integration/tls_parallel.test
+++ b/test/sql/integration/tls_parallel.test
@@ -16,7 +16,7 @@ require mssql
 require-env MSSQL_TEST_DSN_TLS
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS db (TYPE mssql);
 
 # ============================================================================
 # Test: Multiple Parallel Scans Over TLS
@@ -92,7 +92,7 @@ statement ok
 DETACH db;
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS db1 (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS db1 (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('db1', 'SELECT 100 AS val');
@@ -103,7 +103,7 @@ statement ok
 DETACH db1;
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS db2 (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS db2 (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('db2', 'SELECT 200 AS val');
@@ -114,7 +114,7 @@ statement ok
 DETACH db2;
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS db3 (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS db3 (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('db3', 'SELECT 300 AS val');

--- a/test/sql/integration/tls_queries.test
+++ b/test/sql/integration/tls_queries.test
@@ -16,7 +16,7 @@ require mssql
 require-env MSSQL_TEST_DSN_TLS
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN_TLS}' AS db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN_TLS}' AS db (TYPE mssql);
 
 # ============================================================================
 # Test: Various Data Types Over TLS

--- a/test/sql/mssql_attach.test
+++ b/test/sql/mssql_attach.test
@@ -22,7 +22,7 @@ require-env MSSQL_TEST_DB
 # Test 1: ATTACH with ADO.NET connection string (key-value format)
 #
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS kv_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS kv_db (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('kv_db', 'SELECT 1 AS val');
@@ -36,7 +36,7 @@ DETACH kv_db;
 # Test 2: ATTACH with URI format connection string
 #
 statement ok
-ATTACH '${MSSQL_TEST_URI}' AS uri_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_URI}' AS uri_db (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('uri_db', 'SELECT 2 AS val');
@@ -52,11 +52,11 @@ DETACH uri_db;
 statement ok
 CREATE SECRET attach_test_secret (
     TYPE mssql,
-    host '${MSSQL_TEST_HOST}',
-    port ${MSSQL_TEST_PORT},
-    database '${MSSQL_TEST_DB}',
-    user '${MSSQL_TEST_USER}',
-    password '${MSSQL_TEST_PASS}'
+    host '{MSSQL_TEST_HOST}',
+    port {MSSQL_TEST_PORT},
+    database '{MSSQL_TEST_DB}',
+    user '{MSSQL_TEST_USER}',
+    password '{MSSQL_TEST_PASS}'
 );
 
 statement ok
@@ -77,13 +77,13 @@ DROP SECRET attach_test_secret;
 # Test 4: Re-attach after detach
 #
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS reattach_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS reattach_db (TYPE mssql);
 
 statement ok
 DETACH reattach_db;
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS reattach_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS reattach_db (TYPE mssql);
 
 statement ok
 DETACH reattach_db;

--- a/test/sql/mssql_scan.test
+++ b/test/sql/mssql_scan.test
@@ -8,7 +8,7 @@ require-env MSSQL_TEST_DSN
 
 # Setup: attach database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS scandb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS scandb (TYPE mssql);
 
 # T041: Test mssql_scan with valid context - simple query
 query I

--- a/test/sql/multipacket.test
+++ b/test/sql/multipacket.test
@@ -10,7 +10,7 @@ require-env MSSQL_TEST_DSN
 # Test 1: Single packet query (baseline - small SQL)
 #
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS mp_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS mp_db (TYPE mssql);
 
 query I
 SELECT * FROM mssql_scan('mp_db', 'SELECT 1 AS val');

--- a/test/sql/named_instance/named_instance_resolve.test
+++ b/test/sql/named_instance/named_instance_resolve.test
@@ -13,7 +13,7 @@ require-env MSSQL_NAMED_INSTANCE_HOST
 # Basic resolution: host\TESTINST resolves via the Browser to the instance's
 # TCP port, and the attached catalog reads the probe row.
 statement ok
-ATTACH 'Server=${MSSQL_NAMED_INSTANCE_HOST}\TESTINST;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_basic (TYPE mssql);
+ATTACH 'Server={MSSQL_NAMED_INSTANCE_HOST}\TESTINST;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_basic (TYPE mssql);
 
 query IT
 SELECT id, payload FROM ni_basic.dbo.Probe ORDER BY id;
@@ -25,14 +25,14 @@ DETACH ni_basic;
 
 # Unknown instance: the Browser answers but has no such instance.
 statement error
-ATTACH 'Server=${MSSQL_NAMED_INSTANCE_HOST}\NONESUCH;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_unknown (TYPE mssql);
+ATTACH 'Server={MSSQL_NAMED_INSTANCE_HOST}\NONESUCH;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_unknown (TYPE mssql);
 ----
 not found
 
 # Explicit port skips the Browser entirely: host\TESTINST,11433 connects
 # straight to 11433 without a UDP round trip.
 statement ok
-ATTACH 'Server=${MSSQL_NAMED_INSTANCE_HOST}\TESTINST,11433;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_explicit (TYPE mssql);
+ATTACH 'Server={MSSQL_NAMED_INSTANCE_HOST}\TESTINST,11433;Database=NamedInstTest;User Id=sa;Password=TestPassword1;Encrypt=no' AS ni_explicit (TYPE mssql);
 
 query IT
 SELECT id, payload FROM ni_explicit.dbo.Probe ORDER BY id;

--- a/test/sql/query/basic_select.test
+++ b/test/sql/query/basic_select.test
@@ -11,7 +11,7 @@ require-env MSSQL_TEST_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS test_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS test_db (TYPE mssql);
 
 # Test basic SELECT with integer
 query I

--- a/test/sql/query/cancellation.test
+++ b/test/sql/query/cancellation.test
@@ -15,7 +15,7 @@ require-env MSSQL_TEST_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS cancel_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS cancel_db (TYPE mssql);
 
 # Basic query that completes quickly (no cancellation needed)
 query I

--- a/test/sql/query/counters_uniform_chunk.test
+++ b/test/sql/query/counters_uniform_chunk.test
@@ -36,7 +36,7 @@ require-env MSSQL_COUNTERS
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS ctr_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS ctr_db (TYPE mssql);
 
 statement ok
 CREATE OR REPLACE TABLE ctr_db.dbo.CounterUniform AS

--- a/test/sql/query/error_handling.test
+++ b/test/sql/query/error_handling.test
@@ -13,7 +13,7 @@ require-env MSSQL_TEST_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS errh_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS errh_db (TYPE mssql);
 
 # Syntax error
 statement error

--- a/test/sql/query/exec_query_timeout.test
+++ b/test/sql/query/exec_query_timeout.test
@@ -20,7 +20,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS mssql (TYPE mssql);
 
 # --- mssql_query_timeout is honored (was previously ignored) -----------------
 # A 2s timeout must abort a 5s server-side WAITFOR. Before the fix, mssql_exec used a

--- a/test/sql/query/info_messages.test
+++ b/test/sql/query/info_messages.test
@@ -11,7 +11,7 @@ require-env MSSQL_TEST_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS info_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS info_db (TYPE mssql);
 
 # Basic single-statement query works
 query I

--- a/test/sql/query/legacy_lob_types.test
+++ b/test/sql/query/legacy_lob_types.test
@@ -24,7 +24,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS lob (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS lob (TYPE mssql);
 
 statement ok
 SET mssql_exec_invalidate_cache = true;

--- a/test/sql/query/multi_table_subplan.test
+++ b/test/sql/query/multi_table_subplan.test
@@ -21,7 +21,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS subplan_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS subplan_db (TYPE mssql);
 
 statement ok
 CREATE OR REPLACE TABLE subplan_db.dbo.SubplanA (c VARCHAR);

--- a/test/sql/query/nbc_row.test
+++ b/test/sql/query/nbc_row.test
@@ -29,7 +29,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS nbc_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS nbc_db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('nbc_db', 'DROP TABLE IF EXISTS dbo.NbcRowTest');

--- a/test/sql/query/null_validity_streaming.test
+++ b/test/sql/query/null_validity_streaming.test
@@ -16,7 +16,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS nvdb (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS nvdb (TYPE mssql);
 
 # The projection reader: IS NULL must agree with the rendered NULL.
 # ORDER BY v puts the NULL row first (T-SQL sorts NULLs first ascending).

--- a/test/sql/query/staged_chunk_boundary.test
+++ b/test/sql/query/staged_chunk_boundary.test
@@ -17,7 +17,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS chunk_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS chunk_db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('chunk_db', 'DROP TABLE IF EXISTS dbo.ChunkBoundary');

--- a/test/sql/query/type_mapping.test
+++ b/test/sql/query/type_mapping.test
@@ -11,7 +11,7 @@ require-env MSSQL_TEST_DSN
 
 # Attach the database using connection string
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS typemap_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS typemap_db (TYPE mssql);
 
 # Integer types
 query I

--- a/test/sql/query/unpaired_surrogates.test
+++ b/test/sql/query/unpaired_surrogates.test
@@ -21,7 +21,7 @@ require mssql
 require-env MSSQL_TEST_DSN
 
 statement ok
-ATTACH '${MSSQL_TEST_DSN}' AS surr_db (TYPE mssql);
+ATTACH '{MSSQL_TEST_DSN}' AS surr_db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('surr_db', 'DROP TABLE IF EXISTS dbo.SurrogateTest');

--- a/test/sql/query/utf8_support.test
+++ b/test/sql/query/utf8_support.test
@@ -21,7 +21,7 @@ require-env MSSQL_TESTDB_DSN
 # =============================================================================
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS u8_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS u8_db (TYPE mssql);
 
 statement ok
 SELECT mssql_exec('u8_db', $$

--- a/test/sql/rowid/composite_pk_rowid.test
+++ b/test/sql/rowid/composite_pk_rowid.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_composite(TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_composite(TYPE mssql);
 
 # =============================================================================
 # Two-Column Composite PK Tests (INT, BIGINT)

--- a/test/sql/rowid/no_pk_rowid.test
+++ b/test/sql/rowid/no_pk_rowid.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_no_pk (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_no_pk (TYPE mssql);
 
 # =============================================================================
 # Error Tests: Tables without Primary Key

--- a/test/sql/rowid/rowid_filter_pushdown.test
+++ b/test/sql/rowid/rowid_filter_pushdown.test
@@ -15,7 +15,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_rowid_filter (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_rowid_filter (TYPE mssql);
 
 # =============================================================================
 # Scalar PK - Simple rowid equality filter

--- a/test/sql/rowid/scalar_pk_rowid.test
+++ b/test/sql/rowid/scalar_pk_rowid.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_scalar (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_scalar (TYPE mssql);
 
 # =============================================================================
 # INT Primary Key Tests

--- a/test/sql/rowid/view_rowid.test
+++ b/test/sql/rowid/view_rowid.test
@@ -11,7 +11,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Attach the TestDB database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS testdb_view_rowid (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS testdb_view_rowid (TYPE mssql);
 
 # =============================================================================
 # Error Tests: Views

--- a/test/sql/tds_connection/close_all.test
+++ b/test/sql/tds_connection/close_all.test
@@ -21,9 +21,9 @@ true
 # stored values for the ping assertion later.
 statement ok
 CREATE TEMP TABLE close_all_handles AS
-  SELECT mssql_open('${MSSQL_TEST_DSN}') AS h
-  UNION ALL SELECT mssql_open('${MSSQL_TEST_DSN}')
-  UNION ALL SELECT mssql_open('${MSSQL_TEST_DSN}');
+  SELECT mssql_open('{MSSQL_TEST_DSN}') AS h
+  UNION ALL SELECT mssql_open('{MSSQL_TEST_DSN}')
+  UNION ALL SELECT mssql_open('{MSSQL_TEST_DSN}');
 
 query I
 SELECT COUNT(*) FROM close_all_handles;

--- a/test/sql/tds_connection/open_close.test
+++ b/test/sql/tds_connection/open_close.test
@@ -9,7 +9,7 @@ require-env MSSQL_TEST_DSN
 # T015: Test successful connection open with connection string
 # Store handle in temp table to avoid hardcoded handle numbers
 statement ok
-CREATE TEMP TABLE conn_handle AS SELECT mssql_open('${MSSQL_TEST_DSN}') AS handle;
+CREATE TEMP TABLE conn_handle AS SELECT mssql_open('{MSSQL_TEST_DSN}') AS handle;
 
 query I
 SELECT handle >= 1 FROM conn_handle;

--- a/test/sql/tds_connection/pool_stats_no_credentials.test
+++ b/test/sql/tds_connection/pool_stats_no_credentials.test
@@ -28,7 +28,7 @@ require-env MSSQL_TEST_PASS
 # started concatenating the connection string into `pool_stats.db`
 # (or anywhere else queryable), this substring would surface.
 statement ok
-ATTACH 'Server=${MSSQL_TEST_HOST},${MSSQL_TEST_PORT};Database=master;User Id=${MSSQL_TEST_USER};Password=${MSSQL_TEST_PASS}' AS pool_stats_sentinel (TYPE mssql);
+ATTACH 'Server={MSSQL_TEST_HOST},{MSSQL_TEST_PORT};Database=master;User Id={MSSQL_TEST_USER};Password={MSSQL_TEST_PASS}' AS pool_stats_sentinel (TYPE mssql);
 
 # Touch the pool once so it has at least one connection to report on.
 statement ok
@@ -38,7 +38,7 @@ SELECT * FROM mssql_scan('pool_stats_sentinel', 'SELECT 1');
 # password. SC-005 grep gate.
 query I
 SELECT COUNT(*) FROM mssql_pool_stats('pool_stats_sentinel')
-WHERE db LIKE '%' || '${MSSQL_TEST_PASS}' || '%';
+WHERE db LIKE '%' || '{MSSQL_TEST_PASS}' || '%';
 ----
 0
 
@@ -51,7 +51,7 @@ SELECT COUNT(*) FROM mssql_pool_stats('pool_stats_sentinel');
 # And the all-pools variant: same redaction invariant.
 query I
 SELECT COUNT(*) FROM mssql_pool_stats()
-WHERE db LIKE '%' || '${MSSQL_TEST_PASS}' || '%';
+WHERE db LIKE '%' || '{MSSQL_TEST_PASS}' || '%';
 ----
 0
 

--- a/test/sql/transaction/transaction_autocommit.test
+++ b/test/sql/transaction/transaction_autocommit.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Setup: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
 
 # Setup: Create test table
 statement ok

--- a/test/sql/transaction/transaction_catalog_restriction.test
+++ b/test/sql/transaction/transaction_catalog_restriction.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Setup: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
 
 # Setup: Create test table
 statement ok

--- a/test/sql/transaction/transaction_commit.test
+++ b/test/sql/transaction/transaction_commit.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Setup: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
 
 # Setup: Create test table (outside transaction - DDL uses separate connection)
 statement ok

--- a/test/sql/transaction/transaction_mssql_exec.test
+++ b/test/sql/transaction/transaction_mssql_exec.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Setup: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
 
 # Setup: Create test table
 statement ok

--- a/test/sql/transaction/transaction_mssql_scan.test
+++ b/test/sql/transaction/transaction_mssql_scan.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Setup: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
 
 # Setup: Create test table
 statement ok

--- a/test/sql/transaction/transaction_rollback.test
+++ b/test/sql/transaction/transaction_rollback.test
@@ -12,7 +12,7 @@ require-env MSSQL_TESTDB_DSN
 
 # Setup: Attach database
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS txtest (TYPE mssql);
 
 # Setup: Create test table
 statement ok

--- a/test/sql/xml/xml_copy_bcp.test
+++ b/test/sql/xml/xml_copy_bcp.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS xml_bcp_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS xml_bcp_db (TYPE mssql);
 
 # ===========================================================================
 # Setup: Create a target table with XML column for COPY TO tests

--- a/test/sql/xml/xml_dml_error.test
+++ b/test/sql/xml/xml_dml_error.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS xml_dml_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS xml_dml_db (TYPE mssql);
 
 # ===========================================================================
 # Setup: Create test table with XML and non-XML columns

--- a/test/sql/xml/xml_nbc.test
+++ b/test/sql/xml/xml_nbc.test
@@ -14,7 +14,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS xml_nbc_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS xml_nbc_db (TYPE mssql);
 
 # ===========================================================================
 # Test 1: SELECT XML from XmlTestTable — includes both NULL and non-NULL XML

--- a/test/sql/xml/xml_read.test
+++ b/test/sql/xml/xml_read.test
@@ -10,7 +10,7 @@ require mssql
 require-env MSSQL_TESTDB_DSN
 
 statement ok
-ATTACH '${MSSQL_TESTDB_DSN}' AS xml_db (TYPE mssql);
+ATTACH '{MSSQL_TESTDB_DSN}' AS xml_db (TYPE mssql);
 
 # ===========================================================================
 # Test 1: SELECT simple XML document (FR-001)


### PR DESCRIPTION
Last of the three spec-070 follow-ups. Mechanical, no C++ change — done last on purpose because it touches every `.test` file and would sit noisily inside any other PR's diff.

## What

The DuckDB 2.0 sqllogictest runner deprecates two substitution forms and prints a `Replacing deprecated ...` warning for **every occurrence, once per run**, while still substituting.

- **`${VAR}` → `{VAR}`** across **159 `.test` files** (334 occurrences). `require-env` gating is unchanged: only a variable the same file declares substitutes; an undeclared name still arrives literally.
- **`__TEST_DIR__` → `{TEST_DIR}`** in `copy/vector_encodings_bcp.test` (2 occurrences). The W3 assertion is *"zero `Replacing deprecated` lines in the suite log"*, not *"zero `${`"* — the runner deprecates `__TEST_DIR__` with the identical warning line, so it had to go for the assertion to hold.
- **`docs/TESTING.md` + `test/README.md`** examples converted, with a short authoring note naming the brace-only form canonical and restating the require-env gating rule.
- **`test/TLS_TESTING.md` left untouched** — its `${VAR}` are real shell variables in `bash`/`curl` examples, not runner substitutions.

## Verify

Full integration suite green with **zero** `Replacing deprecated` lines in the log (grep the suite log — that absence *is* the assertion; a numeric floor on it would rot):

```
All tests passed (5 skipped tests, 5232 assertions in 165 test cases)
--- deprecation lines: 0
```

Scope check: `git diff --name-only` touches only `.test` files, `docs/TESTING.md`, `test/README.md`, and the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)