### PR TITLE
docs: bring the v0.3.0 roadmap up to date with what actually shipped

### DIFF
--- a/docs/roadmap-v0.3.0.md
+++ b/docs/roadmap-v0.3.0.md
@@ -32,7 +32,7 @@ cut by then.
 | — | MERGE pushdown (T-SQL MERGE from DuckDB MERGE INTO; semantics mapped in 065 research) | recon only | 067 | M | VGSML |
 | 061 | Collation-aware ORDER BY pushdown — makes the spec-039 ORDER BY/TOP pushdown default-safe (today experimental, opt-in `mssql_order_pushdown`); the remaining half of #58 / discussion #59 | spec on main (spun off 060) | nothing | M | oluies |
 | — | JOIN / aggregation pushdown (`join-agg-pushdown.md` on the recon branch): reduction-vs-relocation ladder, materialize-then-decide; the community ask in discussion #75 | recon only | 066; #242 fixed | L | pair — design review together, then split |
-| 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | **W1 MERGED** (#269); **W2 in review** (#270); W3 done ahead of the spec (#271) | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
+| 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | **DONE** — W1 (#269), W2 (#270), W3 (#271) all merged | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
 
 Blocking prerequisite shared by 062 / 066 / 067 / join-relocation:
 **the single-writer-on-a-given-connection seam** — one place that owns "this
@@ -60,7 +60,7 @@ consume it.
 ## Order of battle (dependency-honest)
 
 ```text
-069 (2.0 migration, #267) ✔ ──► 070.W1 (#269) ✔ + W3 (#271) ✔ ──► 070.W2 (#270) in review
+069 (2.0 migration, #267) ✔ ──► 070 W1 (#269) ✔ W2 (#270) ✔ W3 (#271) ✔   ← spec 070 COMPLETE
 step 0 (cardinality) ──► 066 ──► 067 ──► MERGE          ← step 0 NOT STARTED, blocks most of the release
 062 (single-writer seam) ──► 067
 061 — independent, any time

--- a/docs/roadmap-v0.3.0.md
+++ b/docs/roadmap-v0.3.0.md
@@ -24,7 +24,7 @@ cut by then.
 
 | Spec | Title | State | Depends on | Size | Proposed owner |
 | --- | --- | --- | --- | --- | --- |
-| — (#242 fix) | Filter-mapping correctness: STOP pushing `length()` (no exact T-SQL form on non-`_SC` collations — `LEN` loses rows TODAY) and audit `dayofweek`/`week` (`@@DATEFIRST`-dependent) and `'/'`. Cheap on 2.0: an unmapped function falls to the client net / plan filter, correct by construction | open bug, repro in #242 | 069 merged (the net) | S | oluies |
+| — (#242 fix) | Filter-mapping correctness: STOP pushing `length()` (no exact T-SQL form on non-`_SC` collations — `LEN` loses rows TODAY) and audit `dayofweek`/`week` (`@@DATEFIRST`-dependent) and `'/'`. Cheap on 2.0: an unmapped function falls to the client net / plan filter, correct by construction | **DONE** — shipped in #269 with 070 W1 | 069 merged (the net) | S | oluies |
 | — (step 0) | Cardinality callback: MSSQL scans estimate 1 row today, poisoning every join order around them | not started; named in 065 research | nothing | S | oluies |
 | 062 | INSERT via BCP (replaces batched VALUES; 2–10× on multi-row INSERT) | spec on main | single-writer seam (below) | M | VGSML |
 | 066 | Materialize-own-scan (#239): a DML/JOIN plan that reads the target table materializes through its own scan, not a second query | spec on recon branch | step 0 | M | oluies |
@@ -32,7 +32,7 @@ cut by then.
 | — | MERGE pushdown (T-SQL MERGE from DuckDB MERGE INTO; semantics mapped in 065 research) | recon only | 067 | M | VGSML |
 | 061 | Collation-aware ORDER BY pushdown — makes the spec-039 ORDER BY/TOP pushdown default-safe (today experimental, opt-in `mssql_order_pushdown`); the remaining half of #58 / discussion #59 | spec on main (spun off 060) | nothing | M | oluies |
 | — | JOIN / aggregation pushdown (`join-agg-pushdown.md` on the recon branch): reduction-vs-relocation ladder, materialize-then-decide; the community ask in discussion #75 | recon only | 066; #242 fixed | L | pair — design review together, then split |
-| 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | spec drafted (069 branch) | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
+| 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | **W1 MERGED** (#269); **W2 in review** (#270); W3 done ahead of the spec (#271) | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
 
 Blocking prerequisite shared by 062 / 066 / 067 / join-relocation:
 **the single-writer-on-a-given-connection seam** — one place that owns "this
@@ -47,16 +47,22 @@ consume it.
 - AVG pushes ONLY by SUM + COUNT_BIG decomposition.
 - Reduction-vs-relocation ladder with materialize-then-decide; relocation of
   a small DuckDB table into #temp is a lever, not a default.
-- Issue **#242 gates function pushdown**: `length`→`LEN` returns wrong rows
-  TODAY; `dayofweek`/`week` and `'/'` mappings need an audit before any of
-  them may enter group keys or join conditions.
+- Issue **#242 gated function pushdown**, and is now CLOSED (#269) — but read
+  how. The audit was resolved by **removal, not by finding exact T-SQL forms**:
+  `length`/`len`, `'/'` and `date_diff`/`date_add`/`date_part` are gone from the
+  mapping table, and `dayofweek`/`week` were already out. So "#242 fixed" does
+  NOT mean those functions push — it means they fall to the client net, which is
+  correct by construction and is the answer for group keys and join conditions
+  too. Anything wanting `length()` server-side needs an exact form first, and
+  there isn't one on non-`_SC` collations. (`%` was audited with them and kept,
+  gated to exact-numeric operands: T-SQL modulo rejects float/real.)
 
 ## Order of battle (dependency-honest)
 
 ```text
-069 (2.0 migration, PR #267) ──► 070.W1/W2/W3
-step 0 (cardinality) ──► 066 ──► 067 ──► MERGE
+069 (2.0 migration, #267) ✔ ──► 070.W1 (#269) ✔ + W3 (#271) ✔ ──► 070.W2 (#270) in review
+step 0 (cardinality) ──► 066 ──► 067 ──► MERGE          ← step 0 NOT STARTED, blocks most of the release
 062 (single-writer seam) ──► 067
 061 — independent, any time
-join/agg — after 066 + #242 audit
+join/agg — after 066 (+ #242, now closed)
 ```

--- a/specs/070-duckdb-v2-followups/spec.md
+++ b/specs/070-duckdb-v2-followups/spec.md
@@ -1,8 +1,10 @@
 # Spec 070 — DuckDB 2.0 follow-ups: expression pushdown, writer ramp-up, test-var syntax
 
-**Status**: spec 069 merged (main is 2.0). **W1 DONE** (this branch:
-`pushdown_expression` + temporal-cast passthrough + the #242 mapping removal +
-`expression_pushdown.test`). W2/W3 ready to start.
+**Status**: **COMPLETE** — all three workstreams merged to main.
+W1 `pushdown_expression` + temporal-cast passthrough + the #242 mapping removal
++ `expression_pushdown.test` (#269); W2 lazy writer ramp-up (#270); W3 the
+`${VAR}` → `{VAR}` sweep (#271, landed first — it touches every .test file, so
+it went in ahead of the other two rather than sitting in their diffs).
 **Follows**: spec 069, which migrated main to the 2.0 API and deliberately
 left three items out of scope. Each is an independent workstream; they share
 a spec because all three exist for the same reason — 2.0 changed the ground
@@ -179,7 +181,7 @@ and CTAS.
 
 ---
 
-## W3 — `${VAR}` → `{VAR}` in .test files
+## W3 — `${VAR}` → `{VAR}` in .test files — DONE
 
 The 2.0 sqllogictest runner deprecates the `${VAR}` substitution form and
 prints a warning per occurrence per run ("please replace with {VAR}") while


### PR DESCRIPTION
@VGSML — the roadmap is where we split the work, so a stale row costs something. Two went stale when #269 merged.

**State flips**

- The **#242 fix** row still read *"open bug, repro in #242"*. It shipped in #269 alongside 070 W1.
- The **070** row still read *"spec drafted (069 branch)"*. W1 is merged (#269), W3 landed ahead of the spec (#271), W2 is open for your review (#270).

**One that needed more than a state flip**

The "settled during recon" note said the mappings *"need an audit before any of them may enter group keys or join conditions."* That audit happened — and it was resolved by **removal, not by finding exact T-SQL forms**. `length`/`len`, `/` and `date_diff`/`date_add`/`date_part` are gone from the mapping table; `dayofweek`/`week` were already out.

That distinction matters for the join/agg workstream, which lists `#242 fixed` as a dependency. Read as a bare "fixed", the next reader concludes `length()` may now enter a group key. It may not — it falls to the client net, which is the correct answer and is also the answer for join conditions. Anything wanting it server-side needs an exact form first, and there isn't one on non-`_SC` collations. The note now says so, including the one function the audit **kept**: `%`, gated to exact-numeric operands because T-SQL's modulo rejects float/real.

**Order of battle** marks what's done, and calls out the thing I think is the real headline: **step 0, the cardinality callback, is still not started** — size S, depends on nothing, and gates 066 → 067 → MERGE, i.e. most of the release. Everything else in flight is downstream of it or independent.

**Not touched on purpose**: `specs/070-duckdb-v2-followups/spec.md`, whose status line still says "W2/W3 ready to start". #270 already edits that file and this would conflict with it — worth a one-line fix inside #270 instead.

Owners are unchanged; the file says to claim by editing, so swap freely.