### PR TITLE
test: pin that a pushed LIKE agrees with the server's LIKE, not with a range rewrite

### DIFF
--- a/test/sql/catalog/like_pushdown_collation.test
+++ b/test/sql/catalog/like_pushdown_collation.test
@@ -1,0 +1,81 @@
+# name: test/sql/catalog/like_pushdown_collation.test
+# description: A pushed LIKE must agree with the SERVER's own LIKE, not with a range rewrite
+# group: [mssql]
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+# =============================================================================
+# WHY THIS EXISTS
+#
+# DuckDB rewrites a prefix predicate into a RANGE: `prefix(col, 'n')` becomes
+# `col >= 'n' AND col < 'o'` (FilterCombiner::TryPushdownPrefixFilter). That is
+# exact for DuckDB's own binary string comparison. It is NOT exact for SQL
+# Server, whose collation decides the ordering:
+#
+#   on SQL_Latin1_General_CP1_CI_AS — SQL Server's DEFAULT collation —
+#   'ñu' sorts BETWEEN 'n' and 'o', so the range MATCHES it
+#   while `LIKE N'n%'` does NOT.
+#
+# Measured: 4 rows ('nero', 'Nero', 'ñu', 'oslo'), `LIKE 'n%'` -> 2 on the
+# server, the range -> 3. A scan that pushed the range would silently return an
+# extra row.
+#
+# Today the LIKE is encoded by ComplexFilterPushdown and reaches the server AS a
+# LIKE, so this passes. It is pinned because any change that lets DuckDB's
+# TableFilter machinery see these predicates — which is desirable for other
+# reasons, it is how the planner gets selectivity — makes the range rewrite
+# reachable and this WRONG. The full suite passed in exactly that state; nothing
+# else covers it.
+#
+# The assertion is written against the SERVER'S OWN ANSWER rather than a fixed
+# count, so it holds under any collation: a BIN2 database answers 1, a CI_AS
+# database answers 2, and either way the pushed query must agree.
+# =============================================================================
+
+statement ok
+ATTACH '{MSSQL_TESTDB_DSN}' AS lc (TYPE mssql);
+
+statement ok
+SET mssql_exec_invalidate_cache = true;
+
+statement ok
+CREATE OR REPLACE TABLE lc_src AS SELECT * FROM (VALUES ('nero'), ('Nero'), ('ñu'), ('oslo')) v(name);
+
+statement ok
+COPY lc_src TO 'lc.dbo.LikeCollation' (FORMAT bcp, CREATE_TABLE true, replace true);
+
+# The invariant: pushing LIKE must not change which rows come back, whatever the
+# server's collation says. Both sides ask the same server the same question.
+query I
+SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE 'n%')
+     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''n%'''));
+----
+true
+
+# Same for a suffix and an infix, which take the same encoder path.
+query I
+SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%o')
+     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%o'''));
+----
+true
+
+query I
+SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%er%')
+     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%er%'''));
+----
+true
+
+# And the accented row is the one that separates the two forms: it must NOT be
+# returned by a prefix match, on any collation where LIKE excludes it.
+query I
+SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE 'n%' AND name = 'ñu';
+----
+0
+
+statement ok
+SELECT mssql_exec('lc', 'DROP TABLE dbo.LikeCollation');
+
+statement ok
+DETACH lc;

--- a/test/sql/catalog/like_pushdown_collation.test
+++ b/test/sql/catalog/like_pushdown_collation.test
@@ -30,17 +30,26 @@ require-env MSSQL_TESTDB_DSN
 # else covers it.
 #
 # Every assertion is written against the SERVER'S OWN ANSWER rather than a fixed
-# count, so it holds under any collation.
+# count, so what is asserted stays true whatever the collation does.
 #
-# But holding is not the same as DETECTING, and under a _BIN2/_BIN database
-# default this file would be green while testing nothing: there 'ñu' sorts AFTER
-# 'o', so `LIKE N'n%'` and the range `>= N'n' AND < N'o'` agree, and the rewrite
-# this exists to catch would sail through. `mssql_ctas_text_type` defaults to
-# NVARCHAR, so the COPY-created column inherits the database default and the
-# whole question is decided by the server the suite happens to point at. So the
-# first assertion below PINS THE ENVIRONMENT AS DISCRIMINATING — on a server
-# where this test cannot do its job, it says so instead of passing vacuously
-# (PR #276 review).
+# But holding is not the same as DETECTING. Whether this file can detect
+# anything depends on the COLUMN's collation, and a COPY-created column inherits
+# the DATABASE default (`mssql_ctas_text_type` is NVARCHAR) — so the question was
+# decided by whichever server the suite happened to point at. Under _BIN2 the
+# range and the LIKE agree and the whole file passes while testing nothing;
+# under CS_AS the upper-case patterns match nothing on either side and go
+# vacuous too.
+#
+# A previous revision tried to PROBE for that (assert server-LIKE differs from
+# server-range). That was the wrong quantity — the suffix/infix cases depend on
+# CASE-insensitivity, which such a probe never measures — and it was wrong in
+# both directions: false green on CS_AS, false red on CI_AI (job 1133).
+#
+# So the collation is PINNED instead. The table is created explicitly with
+# `COLLATE Latin1_General_CI_AS` (the pattern from varchar_encoding.test) and
+# COPY loads into it, so every assertion below discriminates on every server and
+# no probe is needed. The pin itself is verified, because a server that quietly
+# substituted a different collation would take the file back to vacuous.
 # =============================================================================
 
 statement ok
@@ -53,16 +62,37 @@ statement ok
 CREATE OR REPLACE TABLE lc_src AS SELECT * FROM (VALUES ('nero'), ('Nero'), ('ñu'), ('oslo')) v(name);
 
 statement ok
-COPY lc_src TO 'lc.dbo.LikeCollation' (FORMAT bcp, CREATE_TABLE true, replace true);
+SELECT mssql_exec('lc', 'DROP TABLE IF EXISTS dbo.LikeCollation');
 
-# GUARD: this server must be able to tell the two forms apart at all. If the
-# server's own LIKE and the range rewrite return the SAME count, the assertions
-# below are vacuous and the file must fail rather than reassure.
+# The collation is the whole experiment, so it is stated rather than inherited.
+# CI_AS: case-INsensitive (so 'Nero' matches '%ER%') and accent-SENSITIVE (so
+# 'ñu' is not equal to an 'n' string, yet still sorts between 'n' and 'o' — which
+# is exactly what makes the range rewrite differ from LIKE).
+# NVARCHAR(MAX), not NVARCHAR(n), and that is load-bearing rather than
+# incidental. Spec 060 reports a LENGTH-CARRYING string column as
+# MSSQL_NVARCHAR(n), and DuckDB then reaches the VARCHAR overload through an
+# implicit no-op cast — which makes the column ref a BOUND_FUNCTION, so
+# `FilterCombiner::TryPushdownPrefixFilter` (which requires a bare
+# BOUND_COLUMN_REF) never fires and such a column is ACCIDENTALLY IMMUNE to the
+# rewrite this file exists to catch. Measured: on the restricted build,
+# NVARCHAR(100) pushes `[name] LIKE N'n%'` while NVARCHAR(MAX) pushes
+# `[name] >= N'n' AND [name] < N'o'`. MAX reports as a plain VARCHAR, which is
+# the shape at risk — and the shape COPY and CTAS create by default.
+statement ok
+SELECT mssql_exec('lc', 'CREATE TABLE dbo.LikeCollation (name NVARCHAR(MAX) COLLATE Latin1_General_CI_AS)');
+
+statement ok
+SELECT mssql_refresh_cache('lc');
+
+statement ok
+COPY lc_src TO 'lc.dbo.LikeCollation' (FORMAT bcp);
+
+# The pin must have taken. A server that substituted its own collation would send
+# this file back to passing vacuously, so it fails here instead.
 query I
-SELECT (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''n%'''))
-    <> (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name >= N''n'' AND name < N''o'''));
+SELECT c FROM mssql_scan('lc', 'SELECT CAST(collation_name AS NVARCHAR(128)) AS c FROM sys.columns WHERE object_id = OBJECT_ID(N''dbo.LikeCollation'') AND name = N''name''');
 ----
-true
+Latin1_General_CI_AS
 
 # The invariant: pushing LIKE must not change which rows come back, whatever the
 # server's collation says. Both sides ask the same server the same question.
@@ -73,10 +103,11 @@ SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE 'n%')
 true
 
 # Suffix and infix take the same encoder path. The patterns are UPPER-CASE on
-# purpose: a case-insensitive server matches 'nero'/'Nero' while DuckDB's own
-# binary suffix/contains match nothing, so these separate "the server answered"
-# from "the client answered". Lower-case patterns look equivalent here and
-# cannot fail in either state (PR #276 review).
+# purpose, and the pinned CI_AS collation is what makes that meaningful: the
+# server matches 'nero'/'Nero' (2 and 3 respectively) while DuckDB's own binary
+# suffix/contains match NOTHING (0), so these separate "the server answered"
+# from "the client answered". Lower-case patterns agree on both sides and cannot
+# fail in either state (PR #276 review).
 query I
 SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%O')
      = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%O'''));

--- a/test/sql/catalog/like_pushdown_collation.test
+++ b/test/sql/catalog/like_pushdown_collation.test
@@ -29,9 +29,18 @@ require-env MSSQL_TESTDB_DSN
 # reachable and this WRONG. The full suite passed in exactly that state; nothing
 # else covers it.
 #
-# The assertion is written against the SERVER'S OWN ANSWER rather than a fixed
-# count, so it holds under any collation: a BIN2 database answers 1, a CI_AS
-# database answers 2, and either way the pushed query must agree.
+# Every assertion is written against the SERVER'S OWN ANSWER rather than a fixed
+# count, so it holds under any collation.
+#
+# But holding is not the same as DETECTING, and under a _BIN2/_BIN database
+# default this file would be green while testing nothing: there 'ñu' sorts AFTER
+# 'o', so `LIKE N'n%'` and the range `>= N'n' AND < N'o'` agree, and the rewrite
+# this exists to catch would sail through. `mssql_ctas_text_type` defaults to
+# NVARCHAR, so the COPY-created column inherits the database default and the
+# whole question is decided by the server the suite happens to point at. So the
+# first assertion below PINS THE ENVIRONMENT AS DISCRIMINATING — on a server
+# where this test cannot do its job, it says so instead of passing vacuously
+# (PR #276 review).
 # =============================================================================
 
 statement ok
@@ -46,6 +55,15 @@ CREATE OR REPLACE TABLE lc_src AS SELECT * FROM (VALUES ('nero'), ('Nero'), ('ñ
 statement ok
 COPY lc_src TO 'lc.dbo.LikeCollation' (FORMAT bcp, CREATE_TABLE true, replace true);
 
+# GUARD: this server must be able to tell the two forms apart at all. If the
+# server's own LIKE and the range rewrite return the SAME count, the assertions
+# below are vacuous and the file must fail rather than reassure.
+query I
+SELECT (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''n%'''))
+    <> (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name >= N''n'' AND name < N''o'''));
+----
+true
+
 # The invariant: pushing LIKE must not change which rows come back, whatever the
 # server's collation says. Both sides ask the same server the same question.
 query I
@@ -54,25 +72,29 @@ SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE 'n%')
 ----
 true
 
-# Same for a suffix and an infix, which take the same encoder path.
+# Suffix and infix take the same encoder path. The patterns are UPPER-CASE on
+# purpose: a case-insensitive server matches 'nero'/'Nero' while DuckDB's own
+# binary suffix/contains match nothing, so these separate "the server answered"
+# from "the client answered". Lower-case patterns look equivalent here and
+# cannot fail in either state (PR #276 review).
 query I
-SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%o')
-     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%o'''));
+SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%O')
+     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%O'''));
 ----
 true
 
 query I
-SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%er%')
-     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%er%'''));
+SELECT (SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE '%ER%')
+     = (SELECT c FROM mssql_scan('lc', 'SELECT COUNT(*) AS c FROM dbo.LikeCollation WHERE name LIKE N''%ER%'''));
 ----
 true
 
-# And the accented row is the one that separates the two forms: it must NOT be
-# returned by a prefix match, on any collation where LIKE excludes it.
-query I
-SELECT count(*) FROM lc.dbo.LikeCollation WHERE name LIKE 'n%' AND name = 'ñu';
-----
-0
+# (A `... AND name = 'ñu'` case was here and is deliberately gone. It asserted a
+# hard-coded 0 — contradicting this file's own server-relative rule, and wrong on
+# an accent-INSENSITIVE collation where the server's LIKE does match 'ñu' — and
+# in the regression it targets DuckDB can fold `name >= 'n' AND name < 'o' AND
+# name = 'ñu'` to empty under its own ordering without asking the server, so it
+# would read 0 either way. The prefix assertion above carries the signal.)
 
 statement ok
 SELECT mssql_exec('lc', 'DROP TABLE dbo.LikeCollation');


### PR DESCRIPTION
@VGSML — this came out of running the measurement spec 070's W1 outcome asks for. **The measurement's answer is "no, not as-is", and this test is why.**

## What I measured

I restricted `ComplexFilterPushdown` to defer single-column predicates to `pushdown_expression`, so they survive as EXPRESSION_FILTERs in `get.table_filters`. That is the change #269 discussed and #275 recommends measuring.

**Most of it went well.** Against a live server:

- No pushdown lost — every shape DuckDB's combiner gates still reached the server (`IN` at the 6-value threshold, `year(dt)=2024` alongside a second predicate, `LIKE`).
- The planner could finally *see* predicates: `EXPLAIN` showed `Filters: id < 100` on the scan and applied real selectivity, instead of the string-shaped blind spot described in #275.
- Full integration suite: **168 cases, 5297 assertions, green.**

My stated objection in #269 — that the combiner's gates (`volatile`, oversized `IN`, `CanThrow() && filters.size() > 1`) would silently lose pushdown — **did not reproduce.** That reasoning was wrong.

## What killed it

DuckDB rewrites a prefix predicate into a range: `prefix(col,'n')` → `col >= 'n' AND col < 'o'`. Exact for DuckDB's binary string comparison. **Not** exact for SQL Server, where the collation decides the ordering.

On `SQL_Latin1_General_CP1_CI_AS` — SQL Server's **default** collation — `'ñu'` sorts between `'n'` and `'o'`:

| query | rows |
|---|---|
| server's own `LIKE N'n%'` | **2** (`nero`, `Nero`) |
| the range `>= N'n' AND < N'o'` | **3** (adds `ñu`) |
| `main` today | **2** ✅ |
| with the restriction | **3** ❌ |

Silent wrong rows, on the default collation. And **the entire 168-case suite passed in that state** — nothing covered it.

## So this PR is just the test

No behaviour change. It pins the invariant on `main`, where the LIKE is encoded by `ComplexFilterPushdown` and reaches the server *as a LIKE*. Verified it fails (line 51) against the restricted build.

It asserts against **the server's own answer**, not a fixed count, so it holds under any collation — BIN2 answers 1, CI_AS answers 2, and either way the pushed query must agree with the unpushed one.

## What this means for the roadmap

The restriction is not dead, but it now has a **prerequisite**: the encoder must refuse — or correctly translate — DuckDB's range-rewritten prefix filters before those predicates may become TableFilters. That is spec **061** (collation-aware pushdown) territory, which is already on the roadmap and independent.

So the dependency edge is the other way around from what #275 assumes: **061 gates the W1 restriction, which gates planner-visible filters, which is what join/agg pushdown actually wants.** I'd suggest recording that. The measurement branch is `spec/070-w1-measure-shadowing` if you want to reproduce any of it.