### PR TITLE
ci: run build + integration on pull requests, and export the TLS DSN in the CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,32 +278,40 @@ jobs:
   build:
     name: Build (${{ matrix.platform.id }})
     runs-on: ${{ matrix.platform.runner }}
-    # Also on a merge to `main` (issue #212 gap 1). A pull request never compiled
-    # the extension, so a C++ regression could reach main behind green checks —
-    # three times in one week when that issue was filed. Building on the merge
-    # catches it on main rather than at the next release, and costs nothing on
-    # the PRs themselves: the `push` trigger is `branches: [main]` and the
-    # workflow's `paths-ignore` keeps docs-only merges free.
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_build) || github.event_name == 'schedule' || github.event_name == 'push' }}
+    # On a merge to `main` (issue #212 gap 1) AND on the pull request itself
+    # (issue #279). Building only on the merge turned a green PR into "nobody has
+    # compiled this yet" — the regression is still found, just after it has
+    # landed. #269, #270 and #274 all changed src/table_scan/ or src/copy/ and
+    # none was compiled by CI before merge.
+    #
+    # On a pull request this is LINUX ONLY, deliberately: it is the platform the
+    # integration lane needs anyway, and one compile per PR is the price of the
+    # check. macOS and Windows stay on merge/schedule/dispatch, where a
+    # platform-specific break is still caught before a release rather than at it.
+    # Docs-only PRs are already free via the workflow's `paths-ignore`.
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch' && inputs.run_build)
+          || github.event_name == 'schedule'
+          || github.event_name == 'push'
+          || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          # Linux x86_64 - with Docker support for integration tests
-          - id: linux_amd64
-            os: linux
-            arch: amd64
-            runner: ubuntu-22.04
-            docker_available: true
-            vcpkg_triplet: x64-linux
-
-          # macOS ARM64 - load-only testing
-          - id: osx_arm64
-            os: osx
-            arch: arm64
-            runner: macos-14
-            docker_available: false
-            vcpkg_triplet: arm64-osx
+        # Linux x86_64 (Docker, and what the integration lane consumes) plus
+        # macOS ARM64 (load-only). A PULL REQUEST builds Linux only (issue
+        # #279): it is the platform integration needs, and one compile per PR is
+        # the price of the check — macOS stays on merge / schedule / dispatch,
+        # where a platform-specific break is still caught before a release.
+        #
+        # Written as fromJSON rather than a condition on the job's `if`, because
+        # GitHub does NOT expose the `matrix` context to `jobs.<id>.if`. A
+        # `matrix.platform.id == '…'` test there evaluates to empty and the job
+        # silently never runs — the failure would look exactly like the coverage
+        # gap this is fixing.
+        platform: >-
+          ${{ github.event_name == 'pull_request'
+              && fromJSON('[{"id":"linux_amd64","os":"linux","arch":"amd64","runner":"ubuntu-22.04","docker_available":true,"vcpkg_triplet":"x64-linux"}]')
+              || fromJSON('[{"id":"linux_amd64","os":"linux","arch":"amd64","runner":"ubuntu-22.04","docker_available":true,"vcpkg_triplet":"x64-linux"},{"id":"osx_arm64","os":"osx","arch":"arm64","runner":"macos-14","docker_available":false,"vcpkg_triplet":"arm64-osx"}]') }}
 
     env:
       # Send vcpkg's binary cache to a directory actions/cache persists (see
@@ -769,11 +777,16 @@ jobs:
     name: Integration Test (linux_amd64)
     runs-on: ubuntu-22.04
     needs: build
-    # On a merge to `main` as well: the suite went from weekly to per-merge, which
-    # is what makes a SQL regression visible while the change is still fresh.
-    # Only worth having because the selection is fixed — this job used to report
-    # PASSED having run zero files (#212 gap 2).
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_build && inputs.run_integration_tests) || github.event_name == 'schedule' || github.event_name == 'push' }}
+    # On a merge to `main`, and on the pull request itself (issue #279): the suite
+    # went from weekly to per-merge to per-PR, which is what makes a SQL
+    # regression visible while the change is still a proposal rather than
+    # history. Only worth having because the selection is fixed and floored —
+    # this job used to report PASSED having run zero files (#212 gap 2).
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch' && inputs.run_build && inputs.run_integration_tests)
+          || github.event_name == 'schedule'
+          || github.event_name == 'push'
+          || github.event_name == 'pull_request' }}
 
     services:
       sqlserver:

--- a/scripts/ci/check_require_env.sh
+++ b/scripts/ci/check_require_env.sh
@@ -56,6 +56,10 @@ cd "$(dirname "$0")/../.."
 # meant to skip the file. Anything NOT here must be exported by the Makefile.
 OPT_IN='^(AZURE_|MSSQL_COUNTERS$|MSSQL_KERBEROS_TEST$|MSSQL_WINSSPI_TEST$|MSSQL_NAMED_INSTANCE_HOST$)'
 
+# The OTHER lane that runs this suite. `make integration-test` is not what CI
+# uses; this is (.github/workflows/ci.yml, "Run integration tests").
+CI_LANE='scripts/ci/integration_test.sh'
+
 fail=0
 
 #===----------------------------------------------------------------------===#
@@ -84,16 +88,27 @@ for v in $vars; do
 	fi
 	# Assigned is not enough — an unexported make variable never reaches the
 	# test binary. Require an actual `export`.
-	if grep -qE "^export[[:space:]]+${v}([[:space:]]|=|:=|\?=|$)" Makefile; then
+	#
+	# And require it in BOTH lanes (issue #278). Two different things run this
+	# suite: `make integration-test` and, in CI, scripts/ci/integration_test.sh,
+	# which builds its own selection and exports its own environment. This check
+	# used to look only at the Makefile — so when MSSQL_TEST_DSN_TLS was fixed
+	# there, the four TLS files kept skipping in CI and this script kept printing
+	# OK. A variable exported in one lane and not the other is exactly the shape
+	# that produced that.
+	missing=""
+	grep -qE "^export[[:space:]]+${v}([[:space:]]|=|:=|\?=|$)" Makefile || missing="Makefile"
+	grep -qE "^export[[:space:]]+${v}=" "$CI_LANE" || missing="${missing:+${missing} and }${CI_LANE}"
+	if [ -z "$missing" ]; then
 		continue
 	fi
-	echo "check_require_env: ${v} is not exported by the Makefile — these files SKIP silently:" >&2
+	echo "check_require_env: ${v} is not exported by ${missing} — these files SKIP silently there:" >&2
 	echo "    ${files}" >&2
-	if grep -qE "^[[:space:]]*${v}[[:space:]]*[:?]?=" Makefile; then
+	if [ "$missing" = "Makefile" ] && grep -qE "^[[:space:]]*${v}[[:space:]]*[:?]?=" Makefile; then
 		echo "    (it IS assigned in the Makefile, but never exported — assignment alone" >&2
 		echo "     does not reach the child process.)" >&2
 	fi
-	echo "    Fix: 'export ${v}' in the Makefile, or add it to OPT_IN in $0" >&2
+	echo "    Fix: export it in BOTH the Makefile and ${CI_LANE}, or add it to OPT_IN in $0" >&2
 	fail=1
 done
 

--- a/scripts/ci/integration_test.sh
+++ b/scripts/ci/integration_test.sh
@@ -44,6 +44,14 @@ export MSSQL_TESTDB_DSN="${MSSQL_TESTDB_DSN:-Server=${MSSQL_TEST_HOST},${MSSQL_T
 export MSSQL_TESTDB_URI="${MSSQL_TESTDB_URI:-mssql://${MSSQL_TEST_USER}:${MSSQL_TEST_PASS}@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/TestDB}"
 export MSSQL_TEST_SERVER="${MSSQL_TEST_SERVER:-$MSSQL_TEST_DSN}"
 export MSSQL_TEST_CONNECTION_STRING="${MSSQL_TEST_CONNECTION_STRING:-$MSSQL_TEST_DSN}"
+# Issue #278. The Makefile exports this; THIS lane did not, so the four TLS files
+# (tls_connection, tls_queries, tls_parallel, tls_multipacket) skipped on every
+# CI run while the job reported PASSED — 163 cases here against 167 locally, a
+# difference nothing was watching. The 2022 service container this job starts has
+# TLS on by default with a self-signed certificate (see tls_connection.test), so
+# there is nothing to opt into. check_require_env.sh now requires the export in
+# both lanes, and will fail if this line is removed.
+export MSSQL_TEST_DSN_TLS="${MSSQL_TEST_DSN_TLS:-mssql://${MSSQL_TEST_USER}:${MSSQL_TEST_PASS}@${MSSQL_TEST_HOST}:${MSSQL_TEST_PORT}/${MSSQL_TEST_DB}?encrypt=true}"
 
 if [[ -z "$DUCKDB_CLI" ]] || [[ -z "$EXTENSION_PATH" ]]; then
     echo "ERROR: Both arguments required" >&2


### PR DESCRIPTION
Closes #278, closes #279. @VGSML

**This PR is its own test.** If the #279 change works, this PR should be the first one in the repo's history that CI compiles and integration-tests before merge — and the integration job should report **167** cases rather than 163, because of the #278 change. Both numbers are checkable on the checks tab below.

## #278 — the four TLS files have never run in CI

`MSSQL_TEST_DSN_TLS` *is* exported by the Makefile (fixed after the PR #264 review). But CI doesn't go through that target — it runs `scripts/ci/integration_test.sh`, which exported ten variables and not that one. The job reported PASSED at **163 cases against 167 locally**, and the `MSSQL_MIN_TEST_CASES` floor of 150 cannot see a four-case difference.

The reason it stayed hidden is the more useful half. `check_require_env.sh` — written precisely to catch this class, and whose own header names `MSSQL_TEST_DSN_TLS` as the bug that motivated its export check — greps **`Makefile` only**. So the fix landed in one of the two lanes that run this suite, and the guard was blind to the other.

It now requires the export in **both**. Verified in both directions:

```
# before the fix, with the widened guard:
check_require_env: MSSQL_TEST_DSN_TLS is not exported by scripts/ci/integration_test.sh
    — these files SKIP silently there:
    tls_connection.test tls_queries.test tls_parallel.test tls_multipacket.test

# after:
check_require_env: OK — 30 variables exported or documented-opt-in
```

## #279 — pull requests still never compiled the extension

#212 gap 1 was addressed by building on merge to `main`, which converts prevention into post-hoc detection. Concretely: **#269, #270 and #274 all changed `src/table_scan/` or `src/copy/`, and none was compiled by CI before it landed.** Each needed a local `make release` and a local SQL Server to verify.

`Build` and `Integration Test` now run on `pull_request`.

**On a PR the build is Linux only** — it's the platform the integration lane consumes, and one compile per PR is the price of the check. macOS stays on merge/schedule/dispatch, where a platform-specific break is still caught before a release rather than at it. Docs-only PRs remain free via `paths-ignore`.

### One implementation note worth reading

That restriction is a `fromJSON` matrix, not a condition on the job's `if`, because **GitHub does not expose the `matrix` context to `jobs.<id>.if`**. My first version used `matrix.platform.id == 'linux_amd64'` there — it evaluates to empty, so the job would have silently never run on PRs. That failure is indistinguishable from the coverage gap being fixed, which is a bad way for a CI change to be wrong. The comment in the file says so.

## Not changed

`scripts/ci/integration_test.sh` already carries a case-count floor (#212 gap 2), so the third suggestion on #279 was already implemented — I've corrected that on the issue. Its limitation stands: it catches "almost nothing", not "quietly four fewer". The guard widening is what covers that class.

yamllint clean; both `fromJSON` arrays verified to parse.