### PR TITLE
docs: recover the orphaned W1-split commit onto main, and finish the split at both ends of the section

### DIFF
--- a/docs/roadmap-v0.3.0.md
+++ b/docs/roadmap-v0.3.0.md
@@ -31,8 +31,8 @@ cut by then.
 | 067 | DML staging: UPDATE/DELETE via #temp bulk load + set-based JOIN; match-key ladder makes rowid/PK optional; closes #140 | spec on recon branch | 062 (bulk-load path), 066 | L | VGSML |
 | — | MERGE pushdown (T-SQL MERGE from DuckDB MERGE INTO; semantics mapped in 065 research) | recon only | 067 | M | VGSML |
 | 061 | **Collation-faithful pushdown** (widened in #277 from ORDER BY only). Makes the spec-039 ORDER BY/TOP pushdown default-safe (today experimental, opt-in `mssql_order_pushdown`) — the remaining half of #58 / discussion #59 — AND supplies the exactness that server-side DML requires: `native AND … COLLATE …_BIN2` plus a trailing-space sentinel, added beside the native predicate so the Index Seek survives. **Now a prerequisite, not an independent item** | spec on main (ORDER BY only); widening proposed in #277 — **OPEN**, mechanism lives on that PR branch | nothing | M | oluies |
-| — (W1 restriction) | Stop `ComplexFilterPushdown` shadowing `pushdown_expression`, so pushed predicates survive as EXPRESSION_FILTERs the planner can estimate. **Measured (see below): no pushdown lost. Gated on 061** — DuckDB's prefix→range rewrite is inexact against SQL Server collations, and the pushed predicate is not re-checked. Removing it is what deletes #274's selectivity stopgap (`table_scan.cpp` "DELETE THIS when the filters stay visible", `DATAMODEL.md` likewise) | measured, gated on 061 | **061** | M | unassigned |
-| — | JOIN / aggregation pushdown (`join-agg-pushdown.md` on the recon branch): reduction-vs-relocation ladder, materialize-then-decide; the community ask in discussion #75 | recon only | 066; #242 fixed; **and the W1-restriction row above, which decides whether it can rely on planner-visible filters** | L | pair — design review together, then split |
+| — (W1 restriction) | Stop `ComplexFilterPushdown` shadowing `pushdown_expression`, so pushed predicates survive as EXPRESSION_FILTERs the planner can estimate. **Measured (see below): no pushdown lost. Partially gated on 061** — available for NON-STRING predicates now; string comparisons must stay claimed by `ComplexFilterPushdown` until 061 supplies a collation-faithful form, because the combiner rewrites `prefix()` into a range that is inexact on any non-binary ordering. The re-check route is REJECTED (it breaks native semantics). Removing the string half is what deletes #274's selectivity stopgap (`table_scan.cpp` "DELETE THIS when the filters stay visible", `DATAMODEL.md` likewise) | measured, gated on 061 | **061** | M | unassigned |
+| — | JOIN / aggregation pushdown (`join-agg-pushdown.md` on the recon branch): reduction-vs-relocation ladder, materialize-then-decide; the community ask in discussion #75 | recon only | 066; #242 fixed; **and 061 → W1, which is what makes planner-visible filters available to it — for non-string predicates now, for string comparisons after 061** | L | pair — design review together, then split |
 | 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | **DONE** — W1 (#269), W2 (#270), W3 (#271) all merged | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
 
 Blocking prerequisite shared by 062 / 066 / 067 / join-relocation:
@@ -69,7 +69,7 @@ over 200000 rows estimated 200000, inside a join, with the join-order optimizer
 running.
 
 The mechanism is documented once, in
-[`DATAMODEL.md` — Layer 4 (Cache & registries)](../DATAMODEL.md) under the
+[`DATAMODEL.md` — Layer 4 (Cache & registries)](../DATAMODEL.md#layer-4--cache--registries) under the
 `MSSQLStatisticsProvider` bullets — it is expected to be DELETED when this is
 fixed, so it is not restated here. What belongs here is the consequence for
 sequencing.
@@ -103,14 +103,23 @@ the range returns 3. `main` returns 2; the restricted build returns 3. Silent
 wrong rows, and the entire suite passed in that state (#276 adds the missing
 coverage).
 
-Blast radius is narrower than it first looks, but wider than "what CTAS
-creates": a column reported as `MSSQL_NVARCHAR(n)` (spec 060) is **accidentally
-immune**, because DuckDB reaches the VARCHAR overload through a no-op cast and
-`TryPushdownPrefixFilter` requires a bare `BOUND_COLUMN_REF`. Exposed is
-everything `MSSQLColumnInfo::NativeDuckDBType` reports as a plain type — every
-column with `max_length <= 0`, so `text` / `ntext` / `varchar(max)` /
-`nvarchar(max)` on PRE-EXISTING user tables as well as the `NVARCHAR(MAX)` that
-COPY and CTAS create by default, plus lengths outside the inline limits.
+Blast radius: a column reported as `MSSQL_NVARCHAR(n)` (spec 060) is
+**accidentally immune**, because DuckDB reaches the VARCHAR overload through a
+no-op cast and `TryPushdownPrefixFilter` requires a bare `BOUND_COLUMN_REF`.
+Exposed is everything `MSSQLColumnInfo::NativeDuckDBType` leaves as a plain
+VARCHAR:
+
+- MAX columns (`max_length <= 0`) — including the `NVARCHAR(MAX)` COPY and CTAS
+  create by default, and `varchar(max)` / `nvarchar(max)` on pre-existing tables;
+- `text` / `ntext`, which reach it with a type name it does not map at all and
+  fall through the final `else` — NOT via the `max_length <= 0` guard, since
+  `sys.columns` reports 16 for them (the pointer size, the same 16 behind the
+  known `text`→16 CAST truncation);
+- cast-required and geometry columns, and lengths outside the inline limits;
+- **and every string column, `NVARCHAR(100)` included, whenever
+  `mssql_catalog_native_types` is `false`** — `NativeDuckDBType` is only
+  consulted when that setting is on, so turning it off removes the immunity
+  wholesale.
 
 ### DECIDED (VGSML, #275 / #277) — yes, 061 gates W1. The reason is DML, not SELECT.
 
@@ -181,13 +190,26 @@ only under the strict annotation — which narrows § 4.2. If DML is deliberatel
 strict, that must be stated outright, because a default that differs between
 SELECT and DML is the kind of thing discovered through someone's deleted rows.
 
+**This open question can withdraw one of the two reasons for the `061 → W1`
+edge, so do not treat that edge as fully settled.** The edge currently rests on
+DML exactness — "nothing downstream can re-check a server-side DML". If DML
+inherits native semantics by default, that requirement lapses and the `_BIN2`
+pair is needed only under the strict annotation. What survives either way is
+the mechanism-(a) reason: string comparisons cannot become planner-visible
+without a collation-faithful form. If the DML answer comes back "native
+everywhere", the W1 row, the order-of-battle edge, and the matching notes in
+`specs/070-duckdb-v2-followups/spec.md` and `src/table_scan/table_scan.cpp`
+must all be revisited together — three surfaces now encode this dependency.
+
 ## Order of battle (dependency-honest)
 
 ```text
 069 (2.0 migration, #267) ✔ ──► 070 W1 (#269) ✔ W2 (#270) ✔ W3 (#271) ✔   ← spec 070 COMPLETE
 step 0 (cardinality, #274) ✔ ──► 066 ──► 067 ──► MERGE   ← 066 is now the head of the critical path
 062 (single-writer seam) ──► 067
-061 (collation-faithful, #277) ──► W1 restriction ──► planner-visible filters ──► DML-collapse + join/agg
+061 (collation-faithful, #277) ──► W1 restriction (STRING predicates only; the
+                                   non-string half needs no gate) ──► planner-
+                                   visible filters ──► DML-collapse + join/agg
 join/agg — after 066 (+ #242, now closed) and after 061 → W1, which is what
            makes planner-visible filters available to it at all
 ```

--- a/docs/roadmap-v0.3.0.md
+++ b/docs/roadmap-v0.3.0.md
@@ -31,7 +31,7 @@ cut by then.
 | 067 | DML staging: UPDATE/DELETE via #temp bulk load + set-based JOIN; match-key ladder makes rowid/PK optional; closes #140 | spec on recon branch | 062 (bulk-load path), 066 | L | VGSML |
 | — | MERGE pushdown (T-SQL MERGE from DuckDB MERGE INTO; semantics mapped in 065 research) | recon only | 067 | M | VGSML |
 | 061 | **Collation-faithful pushdown** (widened in #277 from ORDER BY only). Makes the spec-039 ORDER BY/TOP pushdown default-safe (today experimental, opt-in `mssql_order_pushdown`) — the remaining half of #58 / discussion #59 — AND supplies the exactness that server-side DML requires: `native AND … COLLATE …_BIN2` plus a trailing-space sentinel, added beside the native predicate so the Index Seek survives. **Now a prerequisite, not an independent item** | spec on main (ORDER BY only); widening proposed in #277 — **OPEN**, mechanism lives on that PR branch | nothing | M | oluies |
-| — (W1 restriction) | Stop `ComplexFilterPushdown` shadowing `pushdown_expression`, so pushed predicates survive as EXPRESSION_FILTERs the planner can estimate. **Measured (see below): no pushdown lost. Partially gated on 061** — available for NON-STRING predicates now; string comparisons must stay claimed by `ComplexFilterPushdown` until 061 supplies a collation-faithful form, because the combiner rewrites `prefix()` into a range that is inexact on any non-binary ordering. The re-check route is REJECTED (it breaks native semantics). Removing the string half is what deletes #274's selectivity stopgap (`table_scan.cpp` "DELETE THIS when the filters stay visible", `DATAMODEL.md` likewise) | measured, gated on 061 | **061** | M | unassigned |
+| — (W1 restriction) | Stop `ComplexFilterPushdown` shadowing `pushdown_expression`, so pushed predicates survive as EXPRESSION_FILTERs the planner can estimate. **Measured (see below): no pushdown lost. Partially gated on 061** — available for NON-STRING predicates now; string comparisons must stay claimed by `ComplexFilterPushdown` until 061 supplies a collation-faithful form, because the combiner rewrites `prefix()` into a range that is inexact on any non-binary ordering. The re-check route is REJECTED (it breaks native semantics). Removing the string half is what deletes #274's selectivity stopgap (`table_scan.cpp` "DELETE THIS when the filters stay visible", `DATAMODEL.md` likewise) | measured; non-string half unblocked, string half gated on 061 | **061** (string predicates only) | M | unassigned |
 | — | JOIN / aggregation pushdown (`join-agg-pushdown.md` on the recon branch): reduction-vs-relocation ladder, materialize-then-decide; the community ask in discussion #75 | recon only | 066; #242 fixed; **and 061 → W1, which is what makes planner-visible filters available to it — for non-string predicates now, for string comparisons after 061** | L | pair — design review together, then split |
 | 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | **DONE** — W1 (#269), W2 (#270), W3 (#271) all merged | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
 
@@ -97,8 +97,9 @@ and should not be carried forward.
 predicate into a range — `prefix(col,'n')` becomes `col >= 'n' AND col < 'o'`
 (`FilterCombiner::TryPushdownPrefixFilter`). Exact for DuckDB's binary string
 comparison; **not** exact for SQL Server, where the collation decides ordering.
-On `SQL_Latin1_General_CP1_CI_AS` — SQL Server's DEFAULT collation — `'ñu'`
-sorts between `'n'` and `'o'`, so the server's `LIKE N'n%'` returns 2 rows and
+On any collation whose ordering is not binary — e.g. the common
+`SQL_Latin1_General_CP1_CI_AS` install default — `'ñu'` sorts between `'n'` and
+`'o'`, so the server's `LIKE N'n%'` returns 2 rows and
 the range returns 3. `main` returns 2; the restricted build returns 3. Silent
 wrong rows, and the entire suite passed in that state (#276 adds the missing
 coverage).
@@ -132,7 +133,8 @@ real reason is worth carrying:
 predicate matching one row too many does not return an extra row — it
 **modifies data DuckDB would never have touched**. So the DML-collapse
 workstream (067, MERGE) needs the pushed predicate to be *exactly* equivalent,
-and on the default `_CI_AS` collation a string predicate is not. That is 061's
+and on any collation whose ordering is not binary — the common `_CI_AS` install
+default included — a string predicate is not. That is 061's
 job. For SELECT the same looseness is survivable, because a client pass can
 still fix it; for DML it is not survivable at all.
 
@@ -207,9 +209,8 @@ must all be revisited together — three surfaces now encode this dependency.
 069 (2.0 migration, #267) ✔ ──► 070 W1 (#269) ✔ W2 (#270) ✔ W3 (#271) ✔   ← spec 070 COMPLETE
 step 0 (cardinality, #274) ✔ ──► 066 ──► 067 ──► MERGE   ← 066 is now the head of the critical path
 062 (single-writer seam) ──► 067
-061 (collation-faithful, #277) ──► W1 restriction (STRING predicates only; the
-                                   non-string half needs no gate) ──► planner-
-                                   visible filters ──► DML-collapse + join/agg
+061 (collation-faithful, #277) ──► W1 restriction, STRING half only ──► planner-visible filters ──► DML-collapse + join/agg
+    (W1's non-string half needs no gate and can be done today)
 join/agg — after 066 (+ #242, now closed) and after 061 → W1, which is what
            makes planner-visible filters available to it at all
 ```

--- a/specs/070-duckdb-v2-followups/spec.md
+++ b/specs/070-duckdb-v2-followups/spec.md
@@ -114,17 +114,30 @@ one of those shapes still reached the server, including the cast-bearing
 `year(dt) = 2024` beside a second predicate that this text named. Do not
 re-derive it.
 
-**The real blocker is semantic, and is gated on spec 061.** Once
+**The real blocker is semantic, and it splits the work in two.** Once
 `ComplexFilterPushdown` stops claiming a predicate, the combiner rewrites it
 before offering it: `prefix()` becomes a `>=`/`<` RANGE, exact for DuckDB's
-binary comparison and NOT for SQL Server's collation. On the default `_CI_AS`,
-`'ñu'` sorts between `'n'` and `'o'`: the server's `LIKE N'n%'` returns 2 rows
-and the range returns 3. Refusing the range instead pushes nothing at all, and
-the client net then applies DuckDB semantics — 1 row — breaking the
+binary comparison and NOT for SQL Server's, on any collation whose ordering is
+not binary — e.g. the common `_CI_AS` install default, where `'ñu'` sorts
+between `'n'` and `'o'` and the server's `LIKE N'n%'` returns 2 rows while the
+range returns 3. Refusing the range instead pushes nothing at all, and the
+client net then applies DuckDB semantics — 1 row — breaking the
 native-server-semantics contract from the other side. Pinned by
 `test/sql/catalog/like_pushdown_collation.test`.
 
-Until 061 lands, the registration is a no-op kept for the API surface, and the
+So the restriction is NOT a single blanket change, and must not be implemented
+as one (that would land the "refuse" case above and lose both the Index Seek
+and the contract):
+
+- **Non-string predicates — available now, no 061 dependency.** Nothing rewrites
+  them into a collation-sensitive form, so they can be deferred to
+  `pushdown_expression` and become planner-visible.
+- **String-pattern expressions — must stay claimed by `ComplexFilterPushdown`
+  until 061.** That is what keeps the exact `LIKE` going to the server, which is
+  what preserves both the seek and native semantics. They stay
+  planner-invisible in the meantime; that is the accepted cost.
+
+Until then the registration is a no-op kept for the API surface, and the
 encoder-level behaviour is pinned by `test/cpp/test_filter_encoder.cpp` — which
 asserts the T-SQL STRING, the thing a row-comparing sqllogictest cannot see
 (rows are identical whether the predicate ran on the server or in the spec-069

--- a/specs/070-duckdb-v2-followups/spec.md
+++ b/specs/070-duckdb-v2-followups/spec.md
@@ -98,9 +98,12 @@ What actually delivers `year(dt) = 2024` today is the temporal-cast strip in
 `EncodeFunctionExpression`, reached through `ComplexFilterPushdown`; deleting
 the `func.pushdown_expression = ...` line leaves every test passing.
 
-Making the callback reachable means restricting `ComplexFilterPushdown` to the
-shapes the combiner will not offer (it offers only expressions referencing
-exactly ONE column binding).
+Making the callback reachable means restricting `ComplexFilterPushdown` to
+(i) the shapes the combiner will not offer (it offers only expressions
+referencing exactly ONE column binding) **and (ii) string-pattern expressions,
+which it must keep claiming until 061** — see the split below. Note that (ii)
+makes the restriction TYPE-aware rather than merely offer-aware: it has to hold
+on to shapes the combiner would happily take.
 
 **The measurement this section asked for has been run** (branch
 `spec/070-w1-measure-shadowing`; recorded in `docs/roadmap-v0.3.0.md`).
@@ -137,7 +140,9 @@ and the contract):
   what preserves both the seek and native semantics. They stay
   planner-invisible in the meantime; that is the accepted cost.
 
-Until then the registration is a no-op kept for the API surface, and the
+The registration is a no-op **today**, and stays one for string-pattern
+expressions until 061 — but the non-string half can lift it now, so this is not
+"blocked until 061". The
 encoder-level behaviour is pinned by `test/cpp/test_filter_encoder.cpp` — which
 asserts the T-SQL STRING, the thing a row-comparing sqllogictest cannot see
 (rows are identical whether the predicate ran on the server or in the spec-069

--- a/src/catalog/mssql_column_info.cpp
+++ b/src/catalog/mssql_column_info.cpp
@@ -66,9 +66,16 @@ MSSQLColumnInfo::MSSQLColumnInfo(const string &name, int32_t column_id, const st
 
 LogicalType MSSQLColumnInfo::NativeDuckDBType() const {
 	// Only a bounded character column has anything to state. A MAX column
-	// (max_length -1) is already what a plain VARCHAR means, text/ntext are MAX
-	// by nature, and a column the scan has to CAST — geometry, hierarchyid,
-	// sql_variant — does not arrive as the type the catalog names anyway.
+	// (max_length -1) is already what a plain VARCHAR means, and a column the
+	// scan has to CAST — geometry, hierarchyid, sql_variant — does not arrive as
+	// the type the catalog names anyway.
+	//
+	// text/ntext are NOT caught by this guard, despite being MAX by nature:
+	// sys.columns reports max_length 16 for them (the pointer size — the same 16
+	// behind the text->16 CAST truncation), so they pass it and fall through the
+	// unmatched-type-name `else` in the switch below. Same outcome, different
+	// route — worth stating because the guard's clause list reads like a
+	// complete enumeration and is not one.
 	if (duckdb_type.id() != LogicalTypeId::VARCHAR || max_length <= 0 || is_cast_required || is_geometry) {
 		return duckdb_type;
 	}

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -900,14 +900,23 @@ static ExpressionEncodeContext BuildEncodeContext(const LogicalGet &get, const M
 // oversized IN, CanThrow with more than one filter) — DID NOT REPRODUCE. Every
 // one of those still reached the server. Do not re-derive it.
 //
-// The real blocker is semantic. Stop claiming a predicate here and the combiner
-// rewrites it before offering it: prefix() becomes a >=/< RANGE, which is exact
-// for DuckDB's binary comparison and NOT for SQL Server's collation ('ñu' sorts
-// between 'n' and 'o' on the default _CI_AS, so LIKE N'n%' returns 2 rows and
-// the range returns 3). Refusing the range instead pushes nothing at all and
-// the client net applies DuckDB semantics — 1 row — which breaks the
-// native-server-semantics contract just as surely. Pinned by
-// test/sql/catalog/like_pushdown_collation.test. Gated on spec 061.
+// The real blocker is semantic, and it splits the work in two — do NOT lift this
+// as one blanket change. Stop claiming a predicate here and the combiner
+// rewrites it before offering it: prefix() becomes a >=/< RANGE, exact for
+// DuckDB's binary comparison and NOT for SQL Server's on any collation whose
+// ordering is not binary (e.g. the common _CI_AS install default, where 'ñu'
+// sorts between 'n' and 'o', so LIKE N'n%' returns 2 rows and the range
+// returns 3). Refusing the range instead pushes nothing at all and the client
+// net applies DuckDB semantics — 1 row — breaking the native-server-semantics
+// contract just as surely. Pinned by
+// test/sql/catalog/like_pushdown_collation.test.
+//
+//   NON-STRING predicates  — safe to defer to pushdown_expression today.
+//   STRING-PATTERN expressions — must stay claimed HERE until spec 061 supplies
+//                                a collation-faithful form; that is what keeps
+//                                the exact LIKE (and the Index Seek) going to
+//                                the server. They stay planner-invisible until
+//                                then, which is the accepted cost.
 static bool MSSQLPushdownExpression(ClientContext &context, const LogicalGet &get, Expression &expr) {
 	if (!get.bind_data) {
 		return false;


### PR DESCRIPTION
@VGSML — two things here, and the first is the one that matters.

## A commit was lost: `f572d57` never reached `main`

#275 was merged at `f98aa58`. I pushed one more commit to that branch afterwards and the merge raced it, so the whole job-1154 fix was left orphaned:

- the mechanism-(a)/(b) split in `specs/070-duckdb-v2-followups/spec.md` and `src/table_scan/table_scan.cpp` — **the thing that stops an implementer building case (b)**,
- the blast-radius correction (`text`/`ntext` and `mssql_catalog_native_types=false`),
- the note that the open DML question can withdraw one of the two reasons for `061 → W1`,
- the DATAMODEL deep-link.

None of it is on `main`. Verified with `git merge-base --is-ancestor f572d57 origin/main` → not an ancestor; `e123e18`'s second parent is `f98aa58`.

This PR cherry-picks it onto `main` (clean, no conflicts). **Worth a glance at how #275 was merged** — if that was a merge-while-a-push-is-in-flight, it can happen again, and the failure is silent: the branch looks merged and the PR closes green.

## And the six findings from job 1159

Same shape as the round before: I corrected the framing where the new text was written and left it standing at both ends of the section.

- **spec 070's opening sentence** still defined the change as *offer-aware* — "restrict `ComplexFilterPushdown` to the shapes the combiner will not offer" — which **is case (b)**, the definition the split forty lines below forbids. The required predicate is *type-aware*: `ComplexFilterPushdown` has to keep claiming shapes the combiner would happily take. That distinction is now stated rather than implied.
- **Its closing sentence** still read *"Until 061 lands, the registration is a no-op"*. An implementer reading to the end still left with "blocked until 061".
- **The roadmap's W1 row** had a rewritten Title cell but unchanged **State** and **Depends-on** — the two cells someone triaging by column actually reads. The join/agg row *did* get the qualification in the same commit, so the table contradicted itself about one edge.
- **"SQL Server's DEFAULT collation"** survived in the roadmap — the document the other two copies came from — after being corrected in both of them.
- **`mssql_column_info.cpp`** listed "text/ntext are MAX by nature" inside the rationale for a guard that does **not** catch them (`sys.columns` reports 16, the pointer size). That invited precisely the inference the previous commit called out as wrong, on the surface where it matters most.
- The order-of-battle edge wrapped across three lines inside a ```` ```text ```` fence and hyphen-split `planner-visible`, which renders literally.

Build clean; suite **169 cases / 5310 assertions**; `make test-cpp` 17/17.