### PR TITLE
docs: "no pushdown lost" was too broad — rowid and relaxation-only shapes do lose, and must be excluded from any W1 deferral

### DIFF
--- a/docs/roadmap-v0.3.0.md
+++ b/docs/roadmap-v0.3.0.md
@@ -31,7 +31,7 @@ cut by then.
 | 067 | DML staging: UPDATE/DELETE via #temp bulk load + set-based JOIN; match-key ladder makes rowid/PK optional; closes #140 | spec on recon branch | 062 (bulk-load path), 066 | L | VGSML |
 | — | MERGE pushdown (T-SQL MERGE from DuckDB MERGE INTO; semantics mapped in 065 research) | recon only | 067 | M | VGSML |
 | 061 | **Collation-faithful pushdown** (widened in #277 from ORDER BY only). Makes the spec-039 ORDER BY/TOP pushdown default-safe (today experimental, opt-in `mssql_order_pushdown`) — the remaining half of #58 / discussion #59 — AND supplies the exactness that server-side DML requires: `native AND … COLLATE …_BIN2` plus a trailing-space sentinel, added beside the native predicate so the Index Seek survives. **Now a prerequisite, not an independent item** | spec on main (ORDER BY only); widening proposed in #277 — **OPEN**, mechanism lives on that PR branch | nothing | M | oluies |
-| — (W1 restriction) | Stop `ComplexFilterPushdown` shadowing `pushdown_expression`, so pushed predicates survive as EXPRESSION_FILTERs the planner can estimate. **Measured (see below): no pushdown lost. Partially gated on 061** — available for NON-STRING predicates now; string comparisons must stay claimed by `ComplexFilterPushdown` until 061 supplies a collation-faithful form, because the combiner rewrites `prefix()` into a range that is inexact on any non-binary ordering. The re-check route is REJECTED (it breaks native semantics). Removing the string half is what deletes #274's selectivity stopgap (`table_scan.cpp` "DELETE THIS when the filters stay visible", `DATAMODEL.md` likewise) | measured; non-string half unblocked, string half gated on 061 | **061** (string predicates only) | M | unassigned |
+| — (W1 restriction) | Stop `ComplexFilterPushdown` shadowing `pushdown_expression`, so pushed predicates survive as EXPRESSION_FILTERs the planner can estimate. **Measured (see below): the #269 gates objection did not reproduce, but two shapes DO lose pushdown and must be excluded from the deferral (relaxation-only filters, and `rowid`). Partially gated on 061** — available for NON-STRING predicates now; string comparisons must stay claimed by `ComplexFilterPushdown` until 061 supplies a collation-faithful form, because the combiner rewrites `prefix()` into a range that is inexact on any non-binary ordering. The re-check route is REJECTED (it breaks native semantics). Removing the string half is what deletes #274's selectivity stopgap (`table_scan.cpp` "DELETE THIS when the filters stay visible", `DATAMODEL.md` likewise) | measured; non-string half unblocked, string half gated on 061 | **061** (string predicates only) | M | unassigned |
 | — | JOIN / aggregation pushdown (`join-agg-pushdown.md` on the recon branch): reduction-vs-relocation ladder, materialize-then-decide; the community ask in discussion #75 | recon only | 066; #242 fixed; **and 061 → W1, which is what makes planner-visible filters available to it — for non-string predicates now, for string comparisons after 061** | L | pair — design review together, then split |
 | 070 | 2.0 follow-ups: `pushdown_expression` (W1), lazy writer ramp-up (W2), `${VAR}`→`{VAR}` (W3) | **DONE** — W1 (#269), W2 (#270), W3 (#271) all merged | 069 merged | W1 M / W2 S / W3 S | W1 VGSML, W2+W3 oluies |
 
@@ -86,12 +86,38 @@ against a live server.
 
 **Most of it worked.** No pushdown was lost — every shape DuckDB's combiner
 gates still reached the server (`IN` at the 6-value threshold,
-`year(dt) = 2024` beside a second predicate, `LIKE`). The planner could finally
-see predicates: `EXPLAIN` showed `Filters: id < 100` on the scan with real
+`year(dt) = 2024` beside a second predicate). The planner could finally see
+predicates: `EXPLAIN` showed `Filters: id < 100` on the scan with real
 selectivity. Full suite green. **The objection recorded in #269 — that the
 combiner's gates (volatile, oversized `IN`, `CanThrow() && filters.size() > 1`)
-would silently lose pushdown — DID NOT REPRODUCE.** That reasoning was wrong
-and should not be carried forward.
+would silently lose pushdown — DID NOT REPRODUCE.** That specific reasoning was
+wrong and should not be carried forward.
+
+**But "no pushdown lost" was too broad a generalisation from those shapes, and
+is false** (roborev job 1130, verified against the source). Two classes DO lose,
+neither of them tested by that measurement:
+
+- **Relaxation-only shapes.** `GenerateTableScanFilters` returns
+  `PUSHED_DOWN_PARTIALLY` for `LIKE`, OR-chains, non-dense `IN` and
+  temporal-cast filters, and `pushdown_get.cpp` then SKIPS
+  `TryPushdownGenericExpression` for anything not `NO_PUSHDOWN`. So the server
+  receives only the combiner's *relaxation* — prefix bounds, an optional filter,
+  margin-adjusted temporal bounds — and the exact predicate stays above the
+  scan. The `LIKE` result recorded above as "reached the server" was in fact
+  `[name] >= N'n' AND [name] < N'o'`: the relaxation, not the predicate.
+  `WHERE name LIKE 'ab%cd'` over 200k rows streams the whole `ab` prefix range
+  to the client.
+- **`rowid` predicates lose pushdown entirely.** A rowid filter is
+  single-column, so it defers — but `FilterEncoder::Encode` refuses every
+  virtual column (`table_col_idx >= VIRTUAL_COL_START`) and routes it to the
+  client net, whereas `ComplexFilterPushdown` reached `EncodeColumnRef`, which
+  rewrites rowid to the scalar PK column and pushes real T-SQL. So
+  `WHERE rowid > 100` goes from `WHERE [id] > 100` to a full table scan. Rows
+  stay correct; the wire cost does not.
+
+Neither is a reason the restriction cannot be done — both are shapes the
+deferral must EXCLUDE. But the tracked claim has to be "the #269 gates objection
+did not reproduce", not "no pushdown lost".
 
 **What blocks it is unrelated to any of that.** DuckDB rewrites a prefix
 predicate into a range — `prefix(col,'n')` becomes `col >= 'n' AND col < 'o'`

--- a/specs/070-duckdb-v2-followups/spec.md
+++ b/specs/070-duckdb-v2-followups/spec.md
@@ -112,10 +112,26 @@ The objection stated here first — that the combiner applies gates the
 complex-filter path does not (volatile, `COMPARE_IN` above
 `InClauseRewriter::IN_CLAUSE_REWRITE_THRESHOLD`, and any expression where
 `CanThrow() && filters.size() > 1`), so a deferred predicate would be offered
-to nobody and silently regress to client-side — **DID NOT REPRODUCE**. Every
-one of those shapes still reached the server, including the cast-bearing
+to nobody and silently regress to client-side — **DID NOT REPRODUCE**. Each of
+those shapes still reached the server, including the cast-bearing
 `year(dt) = 2024` beside a second predicate that this text named. Do not
 re-derive it.
+
+**Do not read that as "no pushdown lost", which was the generalisation first
+recorded and is false** (job 1130, verified against the source). Two classes
+lose and must be EXCLUDED from any deferral:
+
+1. **Relaxation-only shapes.** `GenerateTableScanFilters` returns
+   `PUSHED_DOWN_PARTIALLY` for `LIKE`, OR-chains, non-dense `IN` and
+   temporal-cast filters, and `pushdown_get.cpp` skips
+   `TryPushdownGenericExpression` for anything not `NO_PUSHDOWN` — so the server
+   gets the combiner's relaxation (prefix bounds, an optional filter) while the
+   exact predicate stays above the scan. `WHERE name LIKE 'ab%cd'` sends
+   `[name] >= 'ab' AND [name] < 'ac'` and streams the prefix range.
+2. **`rowid`.** Single-column, so it defers — but `FilterEncoder::Encode`
+   refuses virtual columns outright, while `ComplexFilterPushdown` reached
+   `EncodeColumnRef`, which rewrites rowid to the scalar PK. `WHERE rowid > 100`
+   goes from `WHERE [id] > 100` to a full scan.
 
 **The real blocker is semantic, and it splits the work in two.** Once
 `ComplexFilterPushdown` stops claiming a predicate, the combiner rewrites it

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -897,8 +897,20 @@ static ExpressionEncodeContext BuildEncodeContext(const LogicalGet &get, const M
 // MEASURED SINCE (roadmap v0.3.0, branch spec/070-w1-measure-shadowing): the
 // reason first given for keeping both — that restricting ComplexFilterPushdown
 // would lose pushdown for the shapes the combiner itself declines (volatile,
-// oversized IN, CanThrow with more than one filter) — DID NOT REPRODUCE. Every
-// one of those still reached the server. Do not re-derive it.
+// oversized IN, CanThrow with more than one filter) — DID NOT REPRODUCE. Each
+// of those still reached the server. Do not re-derive it.
+//
+// That is NOT the same as "no pushdown lost" (job 1130). Two classes DO lose and
+// any deferral must exclude them:
+//   * relaxation-only shapes — GenerateTableScanFilters returns
+//     PUSHED_DOWN_PARTIALLY for LIKE / OR-chains / non-dense IN / temporal-cast,
+//     and pushdown_get.cpp then SKIPS TryPushdownGenericExpression, so only the
+//     combiner's relaxation reaches the server and the exact predicate stays
+//     above the scan;
+//   * rowid — single-column, so it would defer, but FilterEncoder::Encode
+//     refuses virtual columns while EncodeColumnRef (reached only through THIS
+//     path) rewrites rowid to the scalar PK. `rowid > 100` would go from
+//     `[id] > 100` to a full scan.
 //
 // The real blocker is semantic, and it splits the work in two — do NOT lift this
 // as one blanket change. Stop claiming a predicate here and the combiner


### PR DESCRIPTION
@VGSML — roborev job 1130 reviewed the measurement branch and found **two High-severity pushdown losses my measurement never tested**. Both verified against the source. This corrects a claim that is currently on `main` in four places.

## What still stands

The narrow claim is fine: the #269 gates objection (volatile, oversized `IN`, `CanThrow() && filters.size() > 1`) **did not** reproduce — those shapes were tested and each reached the server.

## What does not

The generalisation that grew out of it — **"no pushdown lost"** — is false.

**1. Relaxation-only shapes.** `GenerateTableScanFilters` returns `PUSHED_DOWN_PARTIALLY` for `LIKE`, OR-chains, non-dense `IN` and temporal-cast filters, and `pushdown_get.cpp` then *skips* `TryPushdownGenericExpression` for anything not `NO_PUSHDOWN`. The server gets the combiner's **relaxation** — prefix bounds, an optional filter, margin-adjusted temporal bounds — while the exact predicate stays above the scan.

I recorded `LIKE` as "reached the server" on the strength of seeing `[name] >= N'n' AND [name] < N'o'` in the debug log. **That is the relaxation, not the predicate.** I read a weaker predicate as a successful push, then built a conclusion on it. `WHERE name LIKE 'ab%cd'` over 200k rows streams the entire `ab` prefix range to the client.

**2. `rowid` loses pushdown entirely.** A rowid predicate is single-column, so it defers — but `FilterEncoder::Encode` refuses every virtual column (`table_col_idx >= VIRTUAL_COL_START`) and routes it to the client net, whereas `ComplexFilterPushdown` reached `EncodeColumnRef`, which rewrites rowid to the scalar PK and pushes real T-SQL:

| | pushed |
|---|---|
| today | `WHERE [id] > 100` |
| under the deferral | *(nothing)* — full table scan |

Rows stay correct; the wire cost does not. My measurement covered `id`, `dt` and `name` — never `rowid`.

## Why this is still not "blocked"

Neither is a reason the restriction can't be done. Both are shapes the deferral must **exclude** — which is a narrower and more actionable statement than either "no pushdown lost" or "blocked on 061". Corrected in all four surfaces that carried the overstatement: the roadmap section, its W1 row, spec 070's W1 outcome, and the `table_scan.cpp` reachability note.

Build clean; suite **169 cases / 5310 assertions**; `make test-cpp` 17/17.

---

**Process note worth acting on.** This sat unread because `roborev fix --list` defaults to the **current branch**. From `main` it reports "No open jobs found" while **nine reviews across seven branches are open — 33 findings, including these two High**. Enumerating `roborev list --branch <b> --open` per branch is the only way to see them. Every merged feature branch in this session has unread findings against code now on `main`.