### PR TITLE
docs: collation semantics for UPDATE/DELETE, and the filter pushdown missing from README + architecture.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ architecture), [docs/](docs/) (internals), [docs/TESTING.md](docs/TESTING.md),
 - Native TDS protocol implementation (no external dependencies)
 - Stream query results directly into DuckDB without buffering
 - Full DuckDB catalog integration with three-part naming and lazy metadata loading
+- **Filter pushdown**: `WHERE` clauses are translated to T-SQL and evaluated by SQL Server, including mapped functions (`year`, `lower`, `LIKE` patterns, arithmetic). Anything the translator declines is applied locally instead — with the string-comparison caveat below
+- Row-count estimates reported to the DuckDB optimizer, so join order around an MSSQL scan is planned rather than guessed
 - Row identity (`rowid`) support for tables with primary keys
 - Connection pooling with configurable limits and automatic session reset
 - TLS/SSL encrypted connections
@@ -69,6 +71,15 @@ architecture), [docs/](docs/) (internals), [docs/TESTING.md](docs/TESTING.md),
 - Custom `Application Name` propagated to SQL Server `APP_NAME()` / `sys.dm_exec_sessions.program_name`
 - ATTACH-time credential validation (opt-out via `lazy_validation true`)
 - **Experimental**: ORDER BY pushdown to SQL Server (opt-in via `mssql_order_pushdown` setting)
+
+> **A note on string comparisons.** A pushed predicate is evaluated by SQL
+> Server, so it follows the **column's collation**, not DuckDB's byte
+> comparison: on a case-insensitive collation `WHERE name = 'abc'` matches
+> `'ABC'` — the same answer SSMS gives. This applies to `UPDATE` and `DELETE`
+> too, where it changes which rows are *modified*. It also means a predicate
+> that pushes and the same predicate evaluated locally can disagree on a
+> case-insensitive column ([#272](https://github.com/hugr-lab/mssql-extension/issues/272)).
+> See [String comparisons and collation](https://hugr-lab.github.io/docs/writing/dml/#collation).
 
 
 ## Quick Start

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,6 +202,42 @@ src/
 | `PhysicalOperator` | `MSSQLPhysicalDelete` | DELETE execution operator |
 | `PhysicalOperator` | `MSSQLPhysicalCreateTableAs` | CTAS execution operator (Sink) |
 
+## Query Pushdown
+
+The scan is a **table function**, not a table, which decides most of what
+follows. DuckDB hands it three separate opportunities and they are easy to
+confuse:
+
+| Callback | What it is asked | Where it lives |
+|---|---|---|
+| `filter_pushdown` + `TableFilter`s | "render these simple filters as SQL" | `FilterEncoder::Encode` |
+| `pushdown_complex_filter` | "take whatever you can of these expressions" | `ComplexFilterPushdown` |
+| `pushdown_expression` | "can you push this one single-column expression?" | `MSSQLPushdownExpression` |
+| `cardinality` | "how many rows will you return?" | `MSSQLCatalogScanCardinality` |
+
+Two consequences are load-bearing and non-obvious:
+
+- **A filter handed to a `filter_pushdown` scan MUST be applied by the scan.**
+  DuckDB 2.0 does not re-check it. Anything the encoder refuses is caught by the
+  client-filter net in `table_scan.cpp`; without that net a refused filter
+  returns wrong rows silently.
+- **`pushdown_complex_filter` runs FIRST** and erases every expression it can
+  render, so `pushdown_expression` only ever sees what that pass refused — it is
+  registered but effectively unreachable today. The predicates it consumes leave
+  the plan entirely (they become a WHERE-clause string), which is why the
+  planner cannot estimate their selectivity and why `cardinality` applies a
+  stopgap factor of its own.
+
+**Comparison semantics are the server's.** A pushed string predicate is
+evaluated by SQL Server under the column's collation, so `WHERE name = 'abc'`
+matches `'ABC'` on a `_CI_AS` column. That extends to `UPDATE`/`DELETE`, which
+target rows by primary key sourced from such a scan — see
+[String comparisons and collation](../website/docs/writing/dml.md).
+
+`DATAMODEL.md` carries the depth: the statistics/cardinality invariants, the
+selectivity stopgap and its removal condition, and the collation hazards that
+gate widening this further (spec 061).
+
 ## Registered Functions
 
 | Function | Type | Signature | Purpose |
@@ -239,10 +275,10 @@ src/
 ### Statistics
 | Setting | Default | Description |
 |---|---|---|
-| `mssql_enable_statistics` | true | Expose row count to optimizer |
-| `mssql_statistics_level` | 0 | 0=rowcount, 1=histogram, 2=NDV |
-| `mssql_statistics_use_dbcc` | false | Use DBCC SHOW_STATISTICS (requires permissions) |
-| `mssql_statistics_cache_ttl_seconds` | 300 | Statistics cache TTL |
+| `mssql_enable_statistics` | true | Report each scan's row count to the optimizer via `TableFunction::cardinality`. Without it every MSSQL scan plans as ~1 row and join order around it is arbitrary |
+| `mssql_statistics_level` | 0 | **Registered but READ BY NOTHING.** `LoadStatisticsConfig` assembles it and has no callers; histogram (1) and NDV (2) are not implemented. Setting it has no effect |
+| `mssql_statistics_use_dbcc` | false | **Registered but READ BY NOTHING**, same as above |
+| `mssql_statistics_cache_ttl_seconds` | 300 | How long a cached row count stays usable. Read at the point of use from the asking session — never written into the shared per-catalog provider. Counts loaded by the catalog are exempt on the table-listing path (refreshed by invalidation, not by age) |
 
 ### INSERT Tuning
 | Setting | Default | Description |

--- a/website/docs/reading/queries.md
+++ b/website/docs/reading/queries.md
@@ -62,6 +62,10 @@ return different rows than DuckDB does (issue #242):
 > case-insensitive collation, `WHERE name = 'abc'` matches `'ABC'` — exactly
 > what the same query returns in SSMS. See the collation notes under
 > [Target Column Types](/writing/table-options/).
+>
+> **This applies to `UPDATE` and `DELETE` too**, where it is not merely a
+> different answer but a different set of rows modified — see
+> [String comparisons and collation](/writing/dml/#collation).
 
 ### ORDER BY Pushdown (Experimental)
 

--- a/website/docs/writing/dml.md
+++ b/website/docs/writing/dml.md
@@ -96,6 +96,82 @@ SET mssql_dml_batch_size = 500;
 - Tables must have a primary key (uses rowid for row identification)
 - Updates use a single `UPDATE ... FROM target JOIN (VALUES ...)` statement per batch, joining on the primary key (scalar or composite)
 
+## String comparisons and collation {#collation}
+
+:::warning A `DELETE` can remove more rows than a DuckDB user expects
+
+`UPDATE` and `DELETE` choose their rows the same way a `SELECT` does: the
+`WHERE` clause is pushed to SQL Server, and **SQL Server's collation decides
+what matches** — not DuckDB's byte comparison.
+
+On a case-insensitive collation (`_CI_AS`, the default for most installations)
+that means:
+
+```sql
+-- table dbo.T contains 'abc' and 'ABC'
+SELECT count(*) FROM mssql.dbo.T WHERE name = 'abc';   -- 2
+DELETE FROM mssql.dbo.T WHERE name = 'abc';            -- deletes BOTH
+```
+
+The same statement against a native DuckDB table deletes one row. This is
+consistent — the `DELETE` removes exactly the rows the equivalent `SELECT`
+returns, and exactly what SSMS would do — but it is not what a reader who
+thinks in DuckDB semantics will predict, and on a destructive statement the
+difference is not recoverable.
+:::
+
+### Why it works this way
+
+Pushing the predicate is what makes the operation fast, and the pushed
+predicate is evaluated by the server. `UPDATE`/`DELETE` then target rows by
+primary key (see the rowid note in Limitations above), so the rows acted on are
+precisely the rows the scan returned — with the server's comparison rules
+already applied.
+
+The consequences worth knowing:
+
+| collation | `WHERE name = 'abc'` also matches | so `DELETE` also removes |
+|---|---|---|
+| `_CI_AS` (case-insensitive) | `'ABC'`, `'Abc'` | those rows |
+| `_CI_AI` (accent-insensitive too) | `'ábc'` | those rows |
+| `_BIN2` / `_BIN` | nothing extra | nothing extra |
+
+Trailing spaces are their own case: SQL Server pads on comparison, so
+`name = 'abc'` matches `'abc '` under **every** collation including `_BIN2`.
+
+### Making a statement collation-exact
+
+**Look before you delete.** The matching statement is the cheapest check there
+is, and it is exact — the `SELECT` returns precisely the rows the `DELETE`
+will take:
+
+```sql
+SELECT * FROM mssql.dbo.T WHERE name = 'abc';   -- these rows, exactly
+DELETE FROM mssql.dbo.T WHERE name = 'abc';
+```
+
+**To force exact-byte comparison**, write the T-SQL yourself with an explicit
+`COLLATE`, via [`mssql_exec()`](/reference/functions):
+
+```sql
+SELECT mssql_exec('mssql',
+  'DELETE FROM dbo.T WHERE name = N''abc'' COLLATE Latin1_General_BIN2');
+```
+
+That is case- and accent-sensitive whatever the column's collation says. Note
+it still will not distinguish a trailing space, because SQL Server pads on
+comparison under every collation — for that, add a sentinel:
+`WHERE name + N'~' = N'abc~'`.
+
+### Planned change
+
+Spec 061 proposes making server-side `UPDATE`/`DELETE` **collation-exact by
+default** — emitting the native predicate *and* a forced `COLLATE …_BIN2`
+comparison, so the rows modified are the rows DuckDB's own predicate selects.
+That is a deliberate divergence from `SELECT`, which keeps native server
+semantics: a destructive statement should be the conservative one. Until that
+lands, the behaviour on this page is what applies.
+
 ## DELETE
 
 DELETE operations are supported for tables with primary keys.


### PR DESCRIPTION
@VGSML — docs only, independent of the #283/#284 stack. Two commits.

## 1. What a collation does to `UPDATE` and `DELETE`

Nothing user-facing said what a pushed string predicate means for a **destructive** statement. `writing/dml.md` had zero mentions of collation, and the one page that documents pushed-predicate semantics frames it purely as which rows come *back*.

**I checked before writing, and my initial premise was wrong.** On a `_CI_AS` column holding `'abc'` and `'ABC'`:

```
SELECT count(*) ... WHERE name = 'abc'   -> 2
DELETE          ... WHERE name = 'abc'   -> removes BOTH
```

So there is **no SELECT/DML asymmetry today** — `UPDATE`/`DELETE` target rows by primary key, and those keys come from a scan that already pushed the predicate, so the server's collation has decided what is in play. The behaviour is *consistent*; consistent is not *expected*. The same statement against a native DuckDB table removes one row, and on a `DELETE` the difference isn't recoverable.

The new section covers what happens, why (the rowid path inherits the scan's matching), what each collation family adds, and that **trailing-space padding applies under every collation including `_BIN2`**. Two practical answers: run the matching `SELECT` first (exact by construction), or write the T-SQL with an explicit `COLLATE` via `mssql_exec()`. It records the 061 proposal as *planned*, not current.

## 2. Filter pushdown was missing from both top-level docs

- **README** listed *"Experimental: ORDER BY pushdown"* and said nothing about **filter pushdown**, which ships enabled and is the main reason queries are fast. A reader evaluating the extension couldn't tell it pushes predicates at all.
- **`docs/architecture.md`** had **no coverage of the pushdown path whatsoever** — `grep -ci "filter pushdown|ComplexFilterPushdown|cardinality"` returned **0** across 634 lines, while `DATAMODEL.md` carries it in depth. Added a section naming the four callbacks and the two non-obvious consequences: a filter handed to a `filter_pushdown` scan **must** be applied by the scan (2.0 does not re-check), and `pushdown_complex_filter` running first is what makes `pushdown_expression` unreachable *and* the planner blind to pushed predicates.

## 3. Two settings that do nothing

`architecture.md`'s Statistics table presented `mssql_statistics_level` and `mssql_statistics_use_dbcc` as functional. They are registered, and `LoadStatisticsConfig` — the only reader — **has no callers** outside `mssql_settings.cpp`; the struct is built and discarded. Marked **READ BY NOTHING** rather than wired, since histogram/NDV statistics is a feature, not a fix.

That is the third setting in this codebase documented as doing something it doesn't (`mssql_enable_statistics` was the same until step 0 wired it). Might be worth a standing check.

---

One self-correction worth flagging: my first draft of the README line claimed *"results never depend on what pushed"* — false for exactly the case described two paragraphs below it (#272). Reworded, and #272 linked.