### PR TITLE
ci: group Dependabot updates, and start watching the 1391 npm packages nobody was watching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,83 @@
-# Dependabot keeps GitHub Actions versions current. Pinning to commit SHAs is
-# the safer hardening but produces noisier PRs; the project currently pins to
-# major-version tags (e.g. actions/checkout@v4), so monthly PRs bumping those
-# tags when v5 ships is the right cadence.
+# Dependabot configuration.
 #
-# vcpkg deps are NOT covered here -- Dependabot has no native vcpkg ecosystem
-# yet. vcpkg.json is bumped manually when DuckDB upgrades its baseline.
+# Shape follows GitHub's "tame Dependabot" guidance: group each ecosystem into
+# one PR, keep the cadence slow, and let security updates ignore both. Security
+# fixes are raised as soon as an advisory lands -- `groups`, `schedule` and
+# `cooldown` shape VERSION updates only -- so slowing the version stream costs
+# nothing in vulnerability response time.
+#
+# Ecosystems deliberately NOT covered, recorded so the omissions read as
+# decisions rather than oversights:
+#
+#   vcpkg (vcpkg.json)  No Dependabot ecosystem exists for it. Bumped by hand
+#                       when DuckDB moves its baseline.
+#   git submodules      duckdb and extension-ci-tools are pinned to reviewed
+#                       SHAs on purpose -- main compiles against the pinned
+#                       duckdb SHA only, so tracking their branch HEADs would
+#                       break the build on someone else's commit.
+#   docker (10 files)   Every base image is either a floating tag Dependabot
+#                       cannot compare (`:latest`, `mssql/server:2022-latest`)
+#                       or a deliberate pin: docker/Dockerfile.build stays on
+#                       ubuntu:22.04 for the glibc the released Linux binary
+#                       links against, and the kerberos / named-instance
+#                       fixtures pin the OS they were written against.
+#   web/index.html      Loads @duckdb/duckdb-wasm and @observablehq/plot from
+#                       jsDelivr at pinned versions. They are in no manifest,
+#                       so Dependabot cannot see them -- bump by hand.
 
 version: 2
 
 updates:
+  # GitHub Actions. Workflows pin major-version tags (actions/checkout@v7), so
+  # every update here is in practice a major bump; one grouped PR per month.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - ci
     commit-message:
       prefix: ci
+      include: scope
+
+  # Docusaurus documentation site: 1391 transitive packages that `npm ci` runs
+  # inside the Pages deploy, which holds `pages: write` + `id-token: write`.
+  # Much the largest third-party surface in the repo, and until now the only
+  # one Dependabot watched not at all.
+  #
+  # Split by update-type instead of one all-in group: a major here means
+  # Docusaurus 3 -> 4 or React 19 -> 20 and wants its own review, while the
+  # minor/patch stream is the one that should land in a single routine PR.
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      website-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      website-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - documentation
+    commit-message:
+      prefix: docs
       include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,9 +53,18 @@ updates:
   # Much the largest third-party surface in the repo, and until now the only
   # one Dependabot watched not at all.
   #
-  # Split by update-type instead of one all-in group: a major here means
-  # Docusaurus 3 -> 4 or React 19 -> 20 and wants its own review, while the
-  # minor/patch stream is the one that should land in a single routine PR.
+  # Only the minor/patch stream is grouped, and that asymmetry is the point:
+  # a major here means Docusaurus 3 -> 4 or React 19 -> 20 and wants its own
+  # review, so majors are left UNGROUPED and Dependabot gives each its own PR
+  # -- one that can be merged, reverted or bisected on its own. Grouping them
+  # would do the opposite, landing Docusaurus 4 and React 20 in a single
+  # branch mergeable only as a unit.
+  #
+  # Every PR from this ecosystem is built by .github/workflows/docs-build.yml,
+  # which runs `npm ci && npx docusaurus build` on any PR touching website/.
+  # pages.yml -- the only other place that builds the site -- has no
+  # pull_request trigger, so without that workflow these PRs would carry no
+  # evidence the site still builds.
   - package-ecosystem: npm
     directory: /website
     schedule:
@@ -68,11 +77,6 @@ updates:
         update-types:
           - minor
           - patch
-      website-major:
-        patterns:
-          - "*"
-        update-types:
-          - major
     cooldown:
       default-days: 7
     labels:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,55 @@
+name: Docs site build
+
+# Builds website/ on pull requests, and nothing else.
+#
+# pages.yml is the only other place that runs `npm ci && npx docusaurus
+# build`, and it triggers on release / schedule / push-to-main /
+# workflow_dispatch -- never on pull_request. ci.yml does run on these PRs
+# (its paths-ignore covers only **.md, docs/, LICENSE and .gitignore) but it
+# is a C++ build and test suite and exercises none of website/. So without
+# this file a Dependabot npm PR could be merged with no evidence the site
+# still builds, and a bad bump among the 1391 packages in
+# website/package-lock.json would first surface on main as a failed Pages
+# deploy -- which also stops the weekly refresh of _site/download-metrics.svg
+# that the README hotlinks.
+#
+# Deliberately a separate workflow rather than a pull_request trigger added
+# to pages.yml: that workflow holds `concurrency: group: pages,
+# cancel-in-progress: true` and `environment: github-pages`, so a PR run
+# there would cancel an in-flight production deploy and enter the deployment
+# environment for a change that is not being deployed. Build only; no
+# `pages:` or `id-token:` permission is needed or granted.
+
+on:
+  pull_request:
+    paths:
+      - "website/**"
+      - ".github/workflows/docs-build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: npm ci && docusaurus build
+        working-directory: website
+        run: |
+          npm ci
+          npx docusaurus build

--- a/website/docs/reading/queries.md
+++ b/website/docs/reading/queries.md
@@ -61,11 +61,11 @@ return different rows than DuckDB does (issue #242):
 > Pushed string predicates follow the **server's comparison semantics**: on a
 > case-insensitive collation, `WHERE name = 'abc'` matches `'ABC'` — exactly
 > what the same query returns in SSMS. See the collation notes under
-> [Target Column Types](/writing/table-options/).
+> [Target Column Types](../writing/table-options.md).
 >
 > **This applies to `UPDATE` and `DELETE` too**, where it is not merely a
 > different answer but a different set of rows modified — see
-> [String comparisons and collation](/writing/dml/#collation).
+> [String comparisons and collation](../writing/dml.md#collation).
 
 ### ORDER BY Pushdown (Experimental)
 


### PR DESCRIPTION
Applies [GitHub's "tame Dependabot" guidance](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/): **group your updates, slow the cadence, keep security fast.**

The cadence half was already right — `interval: monthly` since the file was written. So the substance here is grouping and, much more importantly, **coverage**.

## The gap

`website/` is a Docusaurus site with a committed `package-lock.json`:

```
$ git show HEAD:website/package-lock.json | grep -c '"node_modules/'
1391
```

`npm ci` runs that tree inside `pages.yml`, a job holding `pages: write` and `id-token: write`. Dependabot was not watching the directory **at all** — the config covered `github-actions` only, which is ~15 pinned major tags. The surface larger by two orders of magnitude was the unwatched one.

## What changed

| | before | after |
|---|---|---|
| ecosystems | `github-actions` | `github-actions`, `npm @ /website` |
| PRs/month, actions | up to 5, ungrouped | **1** grouped |
| PRs/month, npm | — (unwatched) | **2** — minor/patch grouped, majors separate |
| cooldown | none | 7 days, both |

Grouping github-actions into one PR is safe precisely because the workflows pin major tags (`actions/checkout@v7`), so every update there is a major bump anyway — there is no minor stream to keep separate.

npm splits by `update-types` rather than collapsing to one all-in group: a major here means Docusaurus 3 → 4 or React 19 → 20 and wants its own review, while minor/patch is the stream that should land as one routine PR.

`cooldown: default-days: 7` means a version published and yanked inside a week never reaches a PR. Per the article it delays **version** updates only.

**Security fixes are unaffected.** Dependabot raises those on advisory publication; `groups`, `schedule` and `cooldown` shape version updates only. Slowing the version stream costs nothing in vulnerability response time — that is the whole point of the article's title.

## The ecosystems that stay uncovered

Written into the file as decisions rather than left as silence:

- **vcpkg** — no Dependabot ecosystem exists. Bumped by hand when DuckDB moves its baseline.
- **git submodules** — `duckdb` and `extension-ci-tools` are pinned to reviewed SHAs on purpose. `CLAUDE.md`: main compiles against the pinned duckdb SHA only. Tracking their branch HEADs would break the build on someone else's commit.
- **docker (10 committed Dockerfiles)** — checked each one. Every base image is either a floating tag Dependabot cannot compare (`:latest`, `mcr.microsoft.com/mssql/server:2022-latest`) or a deliberate pin: `docker/Dockerfile.build` stays on `ubuntu:22.04` for the glibc the released Linux binary links against, and the kerberos / named-instance fixtures pin the OS they were written against. Adding the ecosystem would produce wrong PRs, not useful ones.
- **`web/index.html`** — loads `@duckdb/duckdb-wasm@1.29.0` and `@observablehq/plot@0.6.17` from jsDelivr at pinned versions. In no manifest, so Dependabot cannot see them; noted in the file so the next person knows they are hand-bumped. This one is a genuine residual gap, not a decision.

## Also

Created the `dependencies` and `ci` labels. The **existing** config already asked for both and neither existed in the repo (`gh label list` had only the nine defaults plus `deploy`/`fixed`), so `ci` was being silently dropped from every PR Dependabot would have opened.

## Verified

- `yamllint -d '{extends: relaxed, rules: {line-length: disable, truthy: disable, comments: disable}}'` — clean, same ruleset the `yamllint` job uses.
- Parses to the intended structure: 2 ecosystems, 3 groups, cooldown on both.
- Ecosystem inventory done by `git ls-files`, not by guessing — `vcpkg/` is untracked (local clone), so its `package.json` and Dockerfiles are correctly out of scope.