### PR TITLE
docs+ci: make the PR gate actually fail on a broken link, and split the github-actions group by update-type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,17 +28,26 @@
 version: 2
 
 updates:
-  # GitHub Actions. Workflows pin major-version tags (actions/checkout@v7), so
-  # every update here is in practice a major bump; one grouped PR per month.
+  # GitHub Actions. Split by update-type for the same reason as npm below, and
+  # the two pinning styles in use here are why: most workflows pin a major tag
+  # (actions/checkout@v7) where the only possible bump is a major, but
+  # codeql.yml pins a full patch version (github/codeql-action@v4.37.3) that
+  # moves on patch releases. So this ecosystem really does have both streams,
+  # and grouping all of it would ride a major in on the same approval as a
+  # patch -- PR #291 did exactly that, landing setup-node v6 -> v7 alongside a
+  # codeql-action patch. Majors are left ungrouped and get their own PR.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
     groups:
-      github-actions:
+      github-actions-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 7
     labels:

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -26,7 +26,7 @@ ATTACH 'Server=localhost;Database=AdventureWorks;User Id=sa;Password=...' AS mss
 SELECT * FROM mssql.dbo.SalesOrderHeader LIMIT 10;
 ```
 
-→ **[Getting Started](/getting-started/)** · **[Settings Reference](/reference/settings/)** · **[Download metrics](https://hugr-lab.github.io/mssql-extension/metrics/)**
+→ **[Getting Started](./getting-started.md)** · **[Settings Reference](./reference/settings.md)** · **[Download metrics](https://hugr-lab.github.io/mssql-extension/metrics/)**
 
 ## Community Extension Downloads
 

--- a/website/docs/reference/settings.md
+++ b/website/docs/reference/settings.md
@@ -43,7 +43,7 @@ sidebar_position: 1
 
 ### Bulk Load (COPY / CTAS) Settings
 
-Details: [COPY TO](/writing/copy/) and [CTAS](/writing/ctas/).
+Details: [COPY TO](../writing/copy.md) and [CTAS](../writing/ctas.md).
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -56,7 +56,7 @@ Details: [COPY TO](/writing/copy/) and [CTAS](/writing/ctas/).
 
 ### Target Type Settings
 
-Details: [Target Column Types and Table Shape](/writing/table-options/).
+Details: [Target Column Types and Table Shape](../writing/table-options.md).
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -72,7 +72,7 @@ Details: [Target Column Types and Table Shape](/writing/table-options/).
 | ---------------------------------- | ------- | ------- | ----- | ------------------------------------- |
 | `mssql_order_pushdown`             | BOOLEAN | false   | -     | Enable ORDER BY pushdown to SQL Server |
 
-The `order_pushdown` ATTACH option provides per-database control. See [ORDER BY Pushdown](/reading/queries/#order-by-pushdown-experimental) for details.
+The `order_pushdown` ATTACH option provides per-database control. See [ORDER BY Pushdown](../reading/queries.md#order-by-pushdown-experimental) for details.
 
 ### INSERT Settings
 

--- a/website/docs/reference/troubleshooting.md
+++ b/website/docs/reference/troubleshooting.md
@@ -63,7 +63,7 @@ Error: Unsupported SQL Server type 'UDT' (0xF0) for column 'col_name'
 
 **Solutions:**
 
-- Check the [Type Mapping](/reading/types/) section for supported types
+- Check the [Type Mapping](../reading/types.md) section for supported types
 - Cast unsupported columns to supported types in your query
 - Exclude unsupported columns from SELECT
 

--- a/website/docs/writing/ctas.md
+++ b/website/docs/writing/ctas.md
@@ -82,7 +82,7 @@ before any of that batch is sent.
 The `VARCHAR` row is the only one you can change, and it is the one worth
 changing: `nvarchar(max)` is an off-row LOB and measured 4.1× slower to load
 than a sized column. See
-[Target Column Types and Table Shape](/writing/table-options/) for
+[Target Column Types and Table Shape](./table-options.md) for
 `MSSQL_VARCHAR(n)` / `MSSQL_NVARCHAR(n)`, `mssql_default_string_length` and
 `mssql_ctas_text_type`.
 
@@ -95,7 +95,7 @@ than a sized column. See
 | `mssql_ctas_drop_on_failure` | BOOLEAN | `false` | Drop table if data transfer phase fails |
 
 Column lengths and the table's shape come from
-[Target Column Types and Table Shape](/writing/table-options/) —
+[Target Column Types and Table Shape](./table-options.md) —
 cast a column to `MSSQL_NVARCHAR(n)` in the SELECT list to size it, since CTAS
 has no options syntax of its own.
 

--- a/website/docs/writing/dml.md
+++ b/website/docs/writing/dml.md
@@ -151,7 +151,7 @@ DELETE FROM mssql.dbo.T WHERE name = 'abc';
 ```
 
 **To force exact-byte comparison**, write the T-SQL yourself with an explicit
-`COLLATE`, via [`mssql_exec()`](/reference/functions):
+`COLLATE`, via [`mssql_exec()`](../reference/functions.md):
 
 ```sql
 SELECT mssql_exec('mssql',

--- a/website/docs/writing/transactions.md
+++ b/website/docs/writing/transactions.md
@@ -27,10 +27,10 @@ All statements within a transaction execute on the same SQL Server connection. I
 - **One connection, one job**: because a transaction pins a single connection, it
   cannot stream a result set and receive a bulk load at once — a `COPY` that
   reads from the same catalog it writes to fails inside an explicit transaction.
-  See [Reading and writing the same catalog in one transaction](/writing/copy/#reading-and-writing-the-same-catalog-in-one-transaction)
+  See [Reading and writing the same catalog in one transaction](./copy.md#reading-and-writing-the-same-catalog-in-one-transaction)
 - **CTAS is outside the transaction**: it creates its table with autocommitting
   DDL and loads on connections of its own, so `ROLLBACK` undoes neither. See
-  [CTAS is not part of the transaction](/writing/copy/#ctas-is-not-part-of-the-transaction)
+  [CTAS is not part of the transaction](./copy.md#ctas-is-not-part-of-the-transaction)
 
 ### Multi-Statement SQL Batches
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -21,7 +21,13 @@ const config: Config = {
   projectName: 'mssql-extension',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  // 'throw', not 'warn': docs-build.yml is the PR gate for website/, and a
+  // gate that exits 0 on a broken cross-page anchor does not gate anything.
+  // A dangling anchor is exactly the breakage that reached main from #286 --
+  // the build reported it and passed. onBrokenMarkdownLinks lives under
+  // markdown.hooks now; the top-level key is deprecated in Docusaurus 3.10
+  // and removed in v4.
+  onBrokenAnchors: 'throw',
 
   i18n: {
     defaultLocale: 'en',
@@ -59,6 +65,9 @@ const config: Config = {
 
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
 
   themeConfig: {


### PR DESCRIPTION
Two findings from roborev job 1300 on `63aea12` (the #288 follow-up). #288 was already merged, so this lands on a fresh branch off `main`.

## MEDIUM — `docs-build.yml` could not catch the defect class it was written for

`docs-build.yml` was added so an npm PR carries evidence the site still builds, and the same commit fixed a dangling `#collation` anchor. But `onBrokenAnchors` was unset, so Docusaurus defaults it to **`warn`** — that exact breakage produced a warning and `npx docusaurus build` **still exited 0**. Which is why it reached `main` from #286 in the first place. `onBrokenMarkdownLinks` was at `'warn'` too, so a renamed target behind the newly-introduced relative links would also have sailed through.

Both are now `'throw'`. `onBrokenMarkdownLinks` moves to `markdown.hooks`, where Docusaurus 3.10 wants it — the top-level key is deprecated and removed in v4, so the migration also clears a warning printed on every build.

**Verified in both directions**, since a gate that has never been seen to fail is not a verified gate:

- No pre-existing anchor or markdown-link breakage anywhere in `docs/` **or** `versioned_docs/` — the tightening needs no cleanup pass first, which was the risk roborev flagged.
- Re-breaking the `#collation` anchor now fails:

  ```
  Error: Docusaurus found broken anchors!
  - Broken anchor on source page path = /mssql-extension/next/reading/queries/
  EXIT=1
  ```

  Before this commit the identical edit exited **0**.

⚠️ This also tightens the **production Pages deploy**, which builds the same config: a future broken anchor fails the deploy instead of shipping. That is deliberate — a dangling link in published docs is worth a red deploy — but it is a real behaviour change to `pages.yml`'s outcome, so flagging it rather than burying it.

## LOW — the version-escape fix reached one site out of many

`63aea12` fixed `queries.md` but left the same defect elsewhere. An absolute link like `/writing/table-options/` resolves into the **released** docs, so a page published under `/next/` sends the reader to stale content. It only avoids being a hard break while the released snapshot happens to still have that page.

Roborev named three sites; I swept the live tree instead and found **12**:

| file | links |
|---|---|
| `docs/index.md` | 2 |
| `docs/reference/settings.md` | 4 |
| `docs/reference/troubleshooting.md` | 1 |
| `docs/writing/ctas.md` | 2 |
| `docs/writing/dml.md` | 1 |
| `docs/writing/transactions.md` | 2 |

All now version-relative markdown links (`../writing/table-options.md`). **Three carried anchors** — `#order-by-pushdown-experimental` and two in `transactions.md` — which is the case that breaks silently, and the case the first finding is about.

Every rewrite was resolved against a target file that exists on disk; the script reported no unresolved targets.

## Verified

- `npx docusaurus build` green with both options at `'throw'`.
- Deprecation warning gone.
- Deliberate-break test above, restored and rebuilt green.