### PR TITLE
docs+ci: finish the link sweep the machine should have done, and stop Dependabot re-raising an uninstallable bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 # Dependabot configuration.
 #
-# Shape follows GitHub's "tame Dependabot" guidance: group each ecosystem into
-# one PR, keep the cadence slow, and let security updates ignore both. Security
-# fixes are raised as soon as an advisory lands -- `groups`, `schedule` and
-# `cooldown` shape VERSION updates only -- so slowing the version stream costs
-# nothing in vulnerability response time.
+# Shape follows GitHub's "tame Dependabot" guidance -- group your updates, slow
+# the cadence, keep security fast -- with one deliberate departure: the grouping
+# is per-STREAM, not per-ecosystem. Both ecosystems group only minor/patch and
+# leave majors ungrouped, so a major arrives in a PR that can be merged,
+# reverted or bisected on its own instead of riding in under a routine
+# approval. Cadence is monthly, with a 7-day cooldown.
+#
+# Security fixes are raised as soon as an advisory lands -- `groups`, `schedule`
+# and `cooldown` shape VERSION updates only -- so slowing the version stream
+# costs nothing in vulnerability response time.
 #
 # Ecosystems deliberately NOT covered, recorded so the omissions read as
 # decisions rather than oversights:
@@ -31,16 +36,21 @@ updates:
   # GitHub Actions. Split by update-type for the same reason as npm below, and
   # the two pinning styles in use here are why: most workflows pin a major tag
   # (actions/checkout@v7) where the only possible bump is a major, but
-  # codeql.yml pins a full patch version (github/codeql-action@v4.37.3) that
-  # moves on patch releases. So this ecosystem really does have both streams,
-  # and grouping all of it would ride a major in on the same approval as a
-  # patch -- PR #291 did exactly that, landing setup-node v6 -> v7 alongside a
-  # codeql-action patch. Majors are left ungrouped and get their own PR.
+  # codeql.yml pins a full patch version (github/codeql-action@v4.37.8 as of
+  # #291, and it moves again on the next patch). So this ecosystem really does
+  # have both streams, and grouping all of it would ride a major in on the same
+  # approval as a patch -- PR #291 did exactly that, landing setup-node
+  # v6 -> v7 alongside a codeql-action patch. Majors are left ungrouped and get
+  # their own PR.
+  #
+  # The limit is 10, not the default 5: the workflows use ~20 distinct actions
+  # and each major-updated one now takes a PR of its own, so 5 could silently
+  # withhold updates rather than merely defer them.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       github-actions-minor-patch:
         patterns:
@@ -78,7 +88,7 @@ updates:
     directory: /website
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       website-minor-patch:
         patterns:
@@ -86,6 +96,22 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @docusaurus/theme-mermaid 3.10.2 declares a peerOptional of
+      # @mermaid-js/layout-elk ^0.1.9, so anything in 0.2.x fails `npm ci`
+      # outright:
+      #   npm error ERESOLVE could not resolve
+      #   npm error peerOptional @mermaid-js/layout-elk@"^0.1.9"
+      #                          from @docusaurus/theme-mermaid@3.10.2
+      # Not a judgement call about the release -- the tree cannot install.
+      # Closing the PR does not hold: #289 was closed by hand and Dependabot
+      # re-raised it as #293 sixty-seven seconds after the next push to main,
+      # because it re-evaluates on every push.
+      #
+      # REMOVE THIS ENTRY once @docusaurus/theme-mermaid widens the peer range
+      # to accept 0.2.x -- check its package.json on the next Docusaurus bump.
+      - dependency-name: "@mermaid-js/layout-elk"
+        versions: [">=0.2.0"]
     cooldown:
       default-days: 7
     labels:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -24,6 +24,7 @@ on:
   pull_request:
     paths:
       - "website/**"
+      - "scripts/ci/check_docs_links.py"
       - ".github/workflows/docs-build.yml"
   workflow_dispatch:
 
@@ -41,6 +42,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+
+      # Cheap, and runs before the ~90 s npm install so a link error reports
+      # in seconds. Docusaurus cannot catch this class itself: an absolute
+      # link resolves to a page that really exists in the released version,
+      # so onBrokenLinks sees nothing wrong.
+      - name: No absolute internal doc links
+        run: python3 scripts/ci/check_docs_links.py
 
       - uses: actions/setup-node@v7
         with:

--- a/scripts/ci/check_docs_links.py
+++ b/scripts/ci/check_docs_links.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail if a docs page links to another page by absolute site path.
+
+Docusaurus resolves `](/writing/copy/)` against `baseUrl`, which always
+points at the *latest released* version. A page under docs/ publishes as
+/next/, so an absolute link there sends the reader out of the version they
+are reading and into the released snapshot -- and a page inside
+versioned_docs/version-0.2.3/ sends them forward to 0.2.4. Version-relative
+markdown links (`../writing/copy.md`) resolve within the version and are
+checked by Docusaurus itself.
+
+This exists because the same defect was swept by hand twice and both sweeps
+missed sections nobody thought to list (connection/, performance/). The rule
+is mechanical, so a machine should enforce it.
+"""
+import os
+import re
+import sys
+import glob
+
+PATTERN = re.compile(r"\]\((/(?!/)[^)#\s]*)(#[^)\s]*)?\)")
+
+
+def doc_roots():
+    roots = []
+    if os.path.isdir("website/docs"):
+        roots.append("website/docs")
+    roots.extend(sorted(glob.glob("website/versioned_docs/version-*")))
+    return roots
+
+
+def resolve(root, path):
+    """Return the file an absolute link would name inside `root`, or None."""
+    stem = path.strip("/")
+    if not stem:
+        return None
+    for cand in (os.path.join(root, stem + ".md"),
+                 os.path.join(root, stem, "index.md")):
+        if os.path.exists(cand):
+            return cand
+    return None
+
+
+def main():
+    roots = doc_roots()
+    if not roots:
+        print("no docs roots found under website/ -- nothing to check")
+        return 0
+
+    bad = []
+    for root in roots:
+        for dirpath, _, files in os.walk(root):
+            for fn in files:
+                if not fn.endswith(".md"):
+                    continue
+                p = os.path.join(dirpath, fn)
+                for lineno, line in enumerate(open(p), 1):
+                    for m in PATTERN.finditer(line):
+                        target = resolve(root, m.group(1))
+                        if target is None:
+                            # Not a page in this version: an asset path, an
+                            # external-ish route, or a genuine typo that
+                            # Docusaurus' own onBrokenLinks will catch.
+                            continue
+                        rel = os.path.relpath(target, dirpath)
+                        if not rel.startswith("."):
+                            rel = "./" + rel
+                        bad.append((p, lineno, m.group(0),
+                                    "](%s%s)" % (rel, m.group(2) or "")))
+
+    if not bad:
+        print("checked %d docs root(s): no absolute internal links" % len(roots))
+        return 0
+
+    print("Absolute internal doc links found (%d). Each one escapes its own "
+          "version:\n" % len(bad))
+    for p, lineno, found, suggested in bad:
+        print("  %s:%d\n      %s\n      use %s" % (p, lineno, found, suggested))
+    print("\nUse version-relative markdown links so a page links within its "
+          "own version.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/docs/connection/index.md
+++ b/website/docs/connection/index.md
@@ -89,9 +89,9 @@ CREATE SECRET secret_name (
 | `catalog`     | BOOLEAN | No       | Enable catalog integration (default: true). Set to false for serverless/restricted databases that don't support catalog queries |
 | `schema_filter` | VARCHAR | No     | Regex pattern to filter visible schemas (case-insensitive partial match) |
 | `table_filter`  | VARCHAR | No     | Regex pattern to filter visible tables/views (case-insensitive partial match) |
-| `azure_secret`  | VARCHAR | No     | Name of an Azure secret (DuckDB Azure extension) for Azure AD auth — see [AZURE.md](/connection/azure/) |
-| `access_token`  | VARCHAR | No     | Pre-acquired Azure AD JWT (hidden in `duckdb_secrets()`) — see [AZURE.md](/connection/azure/) |
-| `authenticator` | VARCHAR | No     | `krb5` (POSIX) or `winsspi` (Windows SSPI) — Kerberos / SSPI integrated auth, see [Kerberos.md](/connection/kerberos/) |
+| `azure_secret`  | VARCHAR | No     | Name of an Azure secret (DuckDB Azure extension) for Azure AD auth — see [AZURE.md](./azure.md) |
+| `access_token`  | VARCHAR | No     | Pre-acquired Azure AD JWT (hidden in `duckdb_secrets()`) — see [AZURE.md](./azure.md) |
+| `authenticator` | VARCHAR | No     | `krb5` (POSIX) or `winsspi` (Windows SSPI) — Kerberos / SSPI integrated auth, see [Kerberos.md](./kerberos.md) |
 | `krb5_configfile`    | VARCHAR | No | Per-secret `/etc/krb5.conf` override (Linux only) |
 | `krb5_keytabfile`    | VARCHAR | No | Path to a keytab — selects keytab credential mode (Linux only) |
 | `krb5_credcachefile` | VARCHAR | No | ccache path override (Linux only) |
@@ -114,9 +114,9 @@ ATTACH '' AS context_name (TYPE mssql, SECRET secret_name);
 | `User Id`                   | `Uid`, `User`                        |
 | `Password`                  | `Pwd`                                |
 | `Encrypt`                   | `Use Encryption for Data`, `TrustServerCertificate` |
-| `Trusted_Connection`        | `Trusted Connection`, `TrustedConnection` (yes/true/SSPI/1 -> Kerberos on POSIX, SSPI on Windows; see [Kerberos.md](/connection/kerberos/)) |
+| `Trusted_Connection`        | `Trusted Connection`, `TrustedConnection` (yes/true/SSPI/1 -> Kerberos on POSIX, SSPI on Windows; see [Kerberos.md](./kerberos.md)) |
 | `Integrated Security`       | `IntegratedSecurity`, `Integrated_Security` (same resolution as `Trusted_Connection`) |
-| `authenticator`             | `krb5` or `winsspi` (see [Kerberos.md](/connection/kerberos/)) |
+| `authenticator`             | `krb5` or `winsspi` (see [Kerberos.md](./kerberos.md)) |
 | `krb5-keytabfile`           | `krb5_keytabfile` (path to keytab; selects keytab mode, Linux only) |
 | `krb5-configfile`           | `krb5_configfile` (per-connection `/etc/krb5.conf` override, Linux only) |
 | `krb5-credcachefile`        | `krb5_credcachefile` (ccache path override, Linux only) |
@@ -149,7 +149,7 @@ Three credential modes are supported on POSIX:
 
 On Windows, **SSPI** (`authenticator=winsspi` or `Trusted_Connection=yes`) authenticates with the current Windows logon session via `secur32.dll`'s Negotiate package — no `kinit` needed. The connection-string surface is identical to POSIX; `Trusted_Connection=yes` / `Integrated Security=SSPI` resolve to `winsspi` automatically on Windows hosts.
 
-See [Kerberos.md](/connection/kerberos/) for prerequisites, full connection-string
+See [Kerberos.md](./kerberos.md) for prerequisites, full connection-string
 reference, the bundled docker-compose test stack (no real AD required),
 troubleshooting (including WSL2 specifics), and SPN verification.
 
@@ -307,7 +307,7 @@ In addition to options propagated from the secret / connection string, the follo
 | ------------------- | ------- | ---------------------------------------------------------------------------- |
 | `SECRET`            | VARCHAR | Name of an MSSQL secret holding connection parameters                        |
 | `azure_secret`      | VARCHAR | Override / supply Azure secret name for Azure AD auth                        |
-| `access_token`      | VARCHAR | Pre-acquired Azure AD JWT (see [AZURE.md](/connection/azure/))                         |
+| `access_token`      | VARCHAR | Pre-acquired Azure AD JWT (see [AZURE.md](./azure.md))                         |
 | `catalog`           | BOOLEAN | Enable catalog integration (default `true`)                                  |
 | `schema_filter`     | VARCHAR | Override secret schema_filter for this ATTACH                                |
 | `table_filter`      | VARCHAR | Override secret table_filter for this ATTACH                                 |

--- a/website/docs/connection/kerberos.md
+++ b/website/docs/connection/kerberos.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 # Kerberos / Integrated Authentication
 
 End-user guide for connecting to Active-Directory-joined SQL Server via Kerberos
-(POSIX) or SSPI (Windows). Spec 042. Mirrors the structure of [AZURE.md](/connection/azure/).
+(POSIX) or SSPI (Windows). Spec 042. Mirrors the structure of [AZURE.md](./azure.md).
 
 ## Table of Contents
 
@@ -805,7 +805,7 @@ Names verbatim from `microsoft/go-mssqldb`'s `integratedauth/` package.
 
 ### See Also
 
-- [AZURE.md](/connection/azure/) — Azure AD authentication (Entra ID, Service Principal,
+- [AZURE.md](./azure.md) — Azure AD authentication (Entra ID, Service Principal,
   device code, manual access token)
 - [README.md](/) — main extension documentation
 - [docs/architecture.md](https://github.com/hugr-lab/mssql-extension/blob/main/docs/architecture.md) — IAuthenticator abstraction and

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -48,8 +48,8 @@ SELECT * FROM mssql.dbo.SalesOrderHeader LIMIT 10;
 - Transaction support: BEGIN/COMMIT/ROLLBACK with connection pinning
 - Multi-statement SQL batches via `mssql_scan()` (e.g., temp table workflows)
 - DuckDB secret management for secure credential storage
-- [Azure AD authentication](/connection/azure/) (service principal, CLI, interactive device code flow)
-- [Kerberos / Windows SSPI integrated authentication](/connection/kerberos/) — POSIX (`kinit` / keytab / raw credentials) and Windows (current logon session via `secur32.dll`)
+- [Azure AD authentication](./connection/azure.md) (service principal, CLI, interactive device code flow)
+- [Kerberos / Windows SSPI integrated authentication](./connection/kerberos.md) — POSIX (`kinit` / keytab / raw credentials) and Windows (current logon session via `secur32.dll`)
 - Custom `Application Name` propagated to SQL Server `APP_NAME()` / `sys.dm_exec_sessions.program_name`
 - ATTACH-time credential validation (opt-out via `lazy_validation true`)
 - **Experimental**: ORDER BY pushdown to SQL Server (opt-in via `mssql_order_pushdown` setting)

--- a/website/docs/reference/functions.md
+++ b/website/docs/reference/functions.md
@@ -185,7 +185,7 @@ The function loads metadata per-schema to avoid SQL Server tempdb sort spills on
 ### Authentication Test Functions
 
 Connectivity diagnostics that exercise the auth path without a full query.
-Details on the auth pages: [Azure AD](/connection/azure/), [Kerberos / SSPI](/connection/kerberos/).
+Details on the auth pages: [Azure AD](../connection/azure.md), [Kerberos / SSPI](../connection/kerberos.md).
 
 | Function | Description |
 |---|---|

--- a/website/docs/reference/settings.md
+++ b/website/docs/reference/settings.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 | -------------------------- | ------- | ------- | ----- | ---------------------------------------- |
 | `mssql_connection_limit`   | BIGINT  | 64      | ≥1    | Max connections per attached database    |
 | `mssql_connection_cache`   | BOOLEAN | true    | -     | Enable connection pooling and reuse      |
-| `mssql_reset_connection`   | BOOLEAN | true    | -     | Reset session state when a connection returns to the pool ([details](/performance/#owning-the-session-mssql_reset_connection)) |
+| `mssql_reset_connection`   | BOOLEAN | true    | -     | Reset session state when a connection returns to the pool ([details](../performance.md#owning-the-session-mssql_reset_connection)) |
 | `mssql_connection_timeout` | BIGINT  | 30      | ≥0    | TCP connection timeout (seconds)         |
 | `mssql_idle_timeout`       | BIGINT  | 300     | ≥0    | Idle connection timeout (seconds, 0=none)|
 | `mssql_min_connections`    | BIGINT  | 0       | ≥0    | Minimum connections to maintain          |

--- a/website/docs/reference/troubleshooting.md
+++ b/website/docs/reference/troubleshooting.md
@@ -85,7 +85,7 @@ Error: Unsupported SQL Server type 'UDT' (0xF0) for column 'col_name'
 - **RETURNING for UPDATE/DELETE**: Only INSERT supports RETURNING clause; UPDATE/DELETE do not
 - **UPDATE/DELETE without PK**: Tables must have primary keys for UPDATE/DELETE operations
 - **Updating primary key columns**: UPDATE cannot modify primary key columns (used for row identification)
-- **Keytab / raw Kerberos credentials on macOS**: macOS's `GSS.framework` lacks MIT extensions for `gss_acquire_cred_from` keytab and raw-password paths. macOS supports credential-cache mode only (via `kinit`); keytab and raw-credentials modes are Linux-only. See [Kerberos.md](/connection/kerberos/) for the WSL2 / Docker testing path.
+- **Keytab / raw Kerberos credentials on macOS**: macOS's `GSS.framework` lacks MIT extensions for `gss_acquire_cred_from` keytab and raw-password paths. macOS supports credential-cache mode only (via `kinit`); keytab and raw-credentials modes are Linux-only. See [Kerberos.md](../connection/kerberos.md) for the WSL2 / Docker testing path.
 - **Multiple result sets**: Only one result-producing statement per `mssql_scan()` batch is allowed
 - **Stored Procedures with Output Parameters**: Use `mssql_scan()` for stored procedures
 - **rowid for views/tables without PK**: Only tables with primary keys expose `rowid`
@@ -157,6 +157,6 @@ The codec validates the input first and falls back to a slower scalar implementa
 - XML columns in INSERT/UPDATE are limited to 4096 bytes per value — use COPY TO with BCP protocol for larger documents
 - Very large DECIMAL values may lose precision at extreme scales
 - Connection pool statistics reset when all connections close
-- Microsoft Fabric Warehouse has no `nvarchar` type at all, and no `datetimeoffset` — so a `TIMESTAMP WITH TIME ZONE` column cannot be created there. `varchar(max)` is supported. See [AZURE.md](/connection/azure/#microsoft-fabric)
+- Microsoft Fabric Warehouse has no `nvarchar` type at all, and no `datetimeoffset` — so a `TIMESTAMP WITH TIME ZONE` column cannot be created there. `varchar(max)` is supported. See [AZURE.md](../connection/azure.md#microsoft-fabric)
 - A `#temp` table cannot be a BCP target on Microsoft Fabric: the load fails inside Fabric with an I/O error against a parquet file. Load into a permanent table
 

--- a/website/docs/writing/table-options.md
+++ b/website/docs/writing/table-options.md
@@ -75,7 +75,7 @@ bare identifier, so anything else is rejected at bind time rather than
 concatenated into a `CREATE TABLE`.
 
 On Microsoft Fabric only two collations exist and both are UTF-8; naming any
-other is refused before the DDL is built. See [AZURE.md](/connection/azure/#two-collations-both-utf-8).
+other is refused before the DDL is built. See [AZURE.md](../connection/azure.md#two-collations-both-utf-8).
 
 #### Using them with COPY
 

--- a/website/versioned_docs/version-0.2.3/connection/index.md
+++ b/website/versioned_docs/version-0.2.3/connection/index.md
@@ -89,9 +89,9 @@ CREATE SECRET secret_name (
 | `catalog`     | BOOLEAN | No       | Enable catalog integration (default: true). Set to false for serverless/restricted databases that don't support catalog queries |
 | `schema_filter` | VARCHAR | No     | Regex pattern to filter visible schemas (case-insensitive partial match) |
 | `table_filter`  | VARCHAR | No     | Regex pattern to filter visible tables/views (case-insensitive partial match) |
-| `azure_secret`  | VARCHAR | No     | Name of an Azure secret (DuckDB Azure extension) for Azure AD auth — see [AZURE.md](/connection/azure/) |
-| `access_token`  | VARCHAR | No     | Pre-acquired Azure AD JWT (hidden in `duckdb_secrets()`) — see [AZURE.md](/connection/azure/) |
-| `authenticator` | VARCHAR | No     | `krb5` (POSIX) or `winsspi` (Windows SSPI) — Kerberos / SSPI integrated auth, see [Kerberos.md](/connection/kerberos/) |
+| `azure_secret`  | VARCHAR | No     | Name of an Azure secret (DuckDB Azure extension) for Azure AD auth — see [AZURE.md](./azure.md) |
+| `access_token`  | VARCHAR | No     | Pre-acquired Azure AD JWT (hidden in `duckdb_secrets()`) — see [AZURE.md](./azure.md) |
+| `authenticator` | VARCHAR | No     | `krb5` (POSIX) or `winsspi` (Windows SSPI) — Kerberos / SSPI integrated auth, see [Kerberos.md](./kerberos.md) |
 | `krb5_configfile`    | VARCHAR | No | Per-secret `/etc/krb5.conf` override (Linux only) |
 | `krb5_keytabfile`    | VARCHAR | No | Path to a keytab — selects keytab credential mode (Linux only) |
 | `krb5_credcachefile` | VARCHAR | No | ccache path override (Linux only) |
@@ -114,9 +114,9 @@ ATTACH '' AS context_name (TYPE mssql, SECRET secret_name);
 | `User Id`                   | `Uid`, `User`                        |
 | `Password`                  | `Pwd`                                |
 | `Encrypt`                   | `Use Encryption for Data`, `TrustServerCertificate` |
-| `Trusted_Connection`        | `Trusted Connection`, `TrustedConnection` (yes/true/SSPI/1 -> Kerberos on POSIX, SSPI on Windows; see [Kerberos.md](/connection/kerberos/)) |
+| `Trusted_Connection`        | `Trusted Connection`, `TrustedConnection` (yes/true/SSPI/1 -> Kerberos on POSIX, SSPI on Windows; see [Kerberos.md](./kerberos.md)) |
 | `Integrated Security`       | `IntegratedSecurity`, `Integrated_Security` (same resolution as `Trusted_Connection`) |
-| `authenticator`             | `krb5` or `winsspi` (see [Kerberos.md](/connection/kerberos/)) |
+| `authenticator`             | `krb5` or `winsspi` (see [Kerberos.md](./kerberos.md)) |
 | `krb5-keytabfile`           | `krb5_keytabfile` (path to keytab; selects keytab mode, Linux only) |
 | `krb5-configfile`           | `krb5_configfile` (per-connection `/etc/krb5.conf` override, Linux only) |
 | `krb5-credcachefile`        | `krb5_credcachefile` (ccache path override, Linux only) |
@@ -149,7 +149,7 @@ Three credential modes are supported on POSIX:
 
 On Windows, **SSPI** (`authenticator=winsspi` or `Trusted_Connection=yes`) authenticates with the current Windows logon session via `secur32.dll`'s Negotiate package — no `kinit` needed. The connection-string surface is identical to POSIX; `Trusted_Connection=yes` / `Integrated Security=SSPI` resolve to `winsspi` automatically on Windows hosts.
 
-See [Kerberos.md](/connection/kerberos/) for prerequisites, full connection-string
+See [Kerberos.md](./kerberos.md) for prerequisites, full connection-string
 reference, the bundled docker-compose test stack (no real AD required),
 troubleshooting (including WSL2 specifics), and SPN verification.
 
@@ -307,7 +307,7 @@ In addition to options propagated from the secret / connection string, the follo
 | ------------------- | ------- | ---------------------------------------------------------------------------- |
 | `SECRET`            | VARCHAR | Name of an MSSQL secret holding connection parameters                        |
 | `azure_secret`      | VARCHAR | Override / supply Azure secret name for Azure AD auth                        |
-| `access_token`      | VARCHAR | Pre-acquired Azure AD JWT (see [AZURE.md](/connection/azure/))                         |
+| `access_token`      | VARCHAR | Pre-acquired Azure AD JWT (see [AZURE.md](./azure.md))                         |
 | `catalog`           | BOOLEAN | Enable catalog integration (default `true`)                                  |
 | `schema_filter`     | VARCHAR | Override secret schema_filter for this ATTACH                                |
 | `table_filter`      | VARCHAR | Override secret table_filter for this ATTACH                                 |

--- a/website/versioned_docs/version-0.2.3/connection/kerberos.md
+++ b/website/versioned_docs/version-0.2.3/connection/kerberos.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 # Kerberos / Integrated Authentication
 
 End-user guide for connecting to Active-Directory-joined SQL Server via Kerberos
-(POSIX) or SSPI (Windows). Spec 042. Mirrors the structure of [AZURE.md](/connection/azure/).
+(POSIX) or SSPI (Windows). Spec 042. Mirrors the structure of [AZURE.md](./azure.md).
 
 ## Table of Contents
 
@@ -805,7 +805,7 @@ Names verbatim from `microsoft/go-mssqldb`'s `integratedauth/` package.
 
 ### See Also
 
-- [AZURE.md](/connection/azure/) — Azure AD authentication (Entra ID, Service Principal,
+- [AZURE.md](./azure.md) — Azure AD authentication (Entra ID, Service Principal,
   device code, manual access token)
 - [README.md](/) — main extension documentation
 - [docs/architecture.md](https://github.com/hugr-lab/mssql-extension/blob/main/docs/architecture.md) — IAuthenticator abstraction and

--- a/website/versioned_docs/version-0.2.3/index.md
+++ b/website/versioned_docs/version-0.2.3/index.md
@@ -26,7 +26,7 @@ ATTACH 'Server=localhost;Database=AdventureWorks;User Id=sa;Password=...' AS mss
 SELECT * FROM mssql.dbo.SalesOrderHeader LIMIT 10;
 ```
 
-→ **[Getting Started](/getting-started/)** · **[Settings Reference](/reference/settings/)** · **[Download metrics](https://hugr-lab.github.io/mssql-extension/metrics/)**
+→ **[Getting Started](./getting-started.md)** · **[Settings Reference](./reference/settings.md)** · **[Download metrics](https://hugr-lab.github.io/mssql-extension/metrics/)**
 
 ## Community Extension Downloads
 
@@ -48,8 +48,8 @@ SELECT * FROM mssql.dbo.SalesOrderHeader LIMIT 10;
 - Transaction support: BEGIN/COMMIT/ROLLBACK with connection pinning
 - Multi-statement SQL batches via `mssql_scan()` (e.g., temp table workflows)
 - DuckDB secret management for secure credential storage
-- [Azure AD authentication](/connection/azure/) (service principal, CLI, interactive device code flow)
-- [Kerberos / Windows SSPI integrated authentication](/connection/kerberos/) — POSIX (`kinit` / keytab / raw credentials) and Windows (current logon session via `secur32.dll`)
+- [Azure AD authentication](./connection/azure.md) (service principal, CLI, interactive device code flow)
+- [Kerberos / Windows SSPI integrated authentication](./connection/kerberos.md) — POSIX (`kinit` / keytab / raw credentials) and Windows (current logon session via `secur32.dll`)
 - Custom `Application Name` propagated to SQL Server `APP_NAME()` / `sys.dm_exec_sessions.program_name`
 - ATTACH-time credential validation (opt-out via `lazy_validation true`)
 - **Experimental**: ORDER BY pushdown to SQL Server (opt-in via `mssql_order_pushdown` setting)

--- a/website/versioned_docs/version-0.2.3/reading/queries.md
+++ b/website/versioned_docs/version-0.2.3/reading/queries.md
@@ -48,7 +48,7 @@ are unchanged either way.
 > Pushed string predicates follow the **server's comparison semantics**: on a
 > case-insensitive collation, `WHERE name = 'abc'` matches `'ABC'` — exactly
 > what the same query returns in SSMS. See the collation notes under
-> [Target Column Types](/writing/table-options/).
+> [Target Column Types](../writing/table-options.md).
 
 ### ORDER BY Pushdown (Experimental)
 

--- a/website/versioned_docs/version-0.2.3/reference/functions.md
+++ b/website/versioned_docs/version-0.2.3/reference/functions.md
@@ -185,7 +185,7 @@ The function loads metadata per-schema to avoid SQL Server tempdb sort spills on
 ### Authentication Test Functions
 
 Connectivity diagnostics that exercise the auth path without a full query.
-Details on the auth pages: [Azure AD](/connection/azure/), [Kerberos / SSPI](/connection/kerberos/).
+Details on the auth pages: [Azure AD](../connection/azure.md), [Kerberos / SSPI](../connection/kerberos.md).
 
 | Function | Description |
 |---|---|

--- a/website/versioned_docs/version-0.2.3/reference/settings.md
+++ b/website/versioned_docs/version-0.2.3/reference/settings.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 | -------------------------- | ------- | ------- | ----- | ---------------------------------------- |
 | `mssql_connection_limit`   | BIGINT  | 64      | ≥1    | Max connections per attached database    |
 | `mssql_connection_cache`   | BOOLEAN | true    | -     | Enable connection pooling and reuse      |
-| `mssql_reset_connection`   | BOOLEAN | true    | -     | Reset session state when a connection returns to the pool ([details](/performance/#owning-the-session-mssql_reset_connection)) |
+| `mssql_reset_connection`   | BOOLEAN | true    | -     | Reset session state when a connection returns to the pool ([details](../performance.md#owning-the-session-mssql_reset_connection)) |
 | `mssql_connection_timeout` | BIGINT  | 30      | ≥0    | TCP connection timeout (seconds)         |
 | `mssql_idle_timeout`       | BIGINT  | 300     | ≥0    | Idle connection timeout (seconds, 0=none)|
 | `mssql_min_connections`    | BIGINT  | 0       | ≥0    | Minimum connections to maintain          |
@@ -43,7 +43,7 @@ sidebar_position: 1
 
 ### Bulk Load (COPY / CTAS) Settings
 
-Details: [COPY TO](/writing/copy/) and [CTAS](/writing/ctas/).
+Details: [COPY TO](../writing/copy.md) and [CTAS](../writing/ctas.md).
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -56,7 +56,7 @@ Details: [COPY TO](/writing/copy/) and [CTAS](/writing/ctas/).
 
 ### Target Type Settings
 
-Details: [Target Column Types and Table Shape](/writing/table-options/).
+Details: [Target Column Types and Table Shape](../writing/table-options.md).
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -72,7 +72,7 @@ Details: [Target Column Types and Table Shape](/writing/table-options/).
 | ---------------------------------- | ------- | ------- | ----- | ------------------------------------- |
 | `mssql_order_pushdown`             | BOOLEAN | false   | -     | Enable ORDER BY pushdown to SQL Server |
 
-The `order_pushdown` ATTACH option provides per-database control. See [ORDER BY Pushdown](/reading/queries/#order-by-pushdown-experimental) for details.
+The `order_pushdown` ATTACH option provides per-database control. See [ORDER BY Pushdown](../reading/queries.md#order-by-pushdown-experimental) for details.
 
 ### INSERT Settings
 

--- a/website/versioned_docs/version-0.2.3/reference/troubleshooting.md
+++ b/website/versioned_docs/version-0.2.3/reference/troubleshooting.md
@@ -63,7 +63,7 @@ Error: Unsupported SQL Server type 'UDT' (0xF0) for column 'col_name'
 
 **Solutions:**
 
-- Check the [Type Mapping](/reading/types/) section for supported types
+- Check the [Type Mapping](../reading/types.md) section for supported types
 - Cast unsupported columns to supported types in your query
 - Exclude unsupported columns from SELECT
 
@@ -85,7 +85,7 @@ Error: Unsupported SQL Server type 'UDT' (0xF0) for column 'col_name'
 - **RETURNING for UPDATE/DELETE**: Only INSERT supports RETURNING clause; UPDATE/DELETE do not
 - **UPDATE/DELETE without PK**: Tables must have primary keys for UPDATE/DELETE operations
 - **Updating primary key columns**: UPDATE cannot modify primary key columns (used for row identification)
-- **Keytab / raw Kerberos credentials on macOS**: macOS's `GSS.framework` lacks MIT extensions for `gss_acquire_cred_from` keytab and raw-password paths. macOS supports credential-cache mode only (via `kinit`); keytab and raw-credentials modes are Linux-only. See [Kerberos.md](/connection/kerberos/) for the WSL2 / Docker testing path.
+- **Keytab / raw Kerberos credentials on macOS**: macOS's `GSS.framework` lacks MIT extensions for `gss_acquire_cred_from` keytab and raw-password paths. macOS supports credential-cache mode only (via `kinit`); keytab and raw-credentials modes are Linux-only. See [Kerberos.md](../connection/kerberos.md) for the WSL2 / Docker testing path.
 - **Multiple result sets**: Only one result-producing statement per `mssql_scan()` batch is allowed
 - **Stored Procedures with Output Parameters**: Use `mssql_scan()` for stored procedures
 - **rowid for views/tables without PK**: Only tables with primary keys expose `rowid`
@@ -157,6 +157,6 @@ The codec validates the input first and falls back to a slower scalar implementa
 - XML columns in INSERT/UPDATE are limited to 4096 bytes per value — use COPY TO with BCP protocol for larger documents
 - Very large DECIMAL values may lose precision at extreme scales
 - Connection pool statistics reset when all connections close
-- Microsoft Fabric Warehouse has no `nvarchar` type at all, and no `datetimeoffset` — so a `TIMESTAMP WITH TIME ZONE` column cannot be created there. `varchar(max)` is supported. See [AZURE.md](/connection/azure/#microsoft-fabric)
+- Microsoft Fabric Warehouse has no `nvarchar` type at all, and no `datetimeoffset` — so a `TIMESTAMP WITH TIME ZONE` column cannot be created there. `varchar(max)` is supported. See [AZURE.md](../connection/azure.md#microsoft-fabric)
 - A `#temp` table cannot be a BCP target on Microsoft Fabric: the load fails inside Fabric with an I/O error against a parquet file. Load into a permanent table
 

--- a/website/versioned_docs/version-0.2.3/writing/ctas.md
+++ b/website/versioned_docs/version-0.2.3/writing/ctas.md
@@ -82,7 +82,7 @@ before any of that batch is sent.
 The `VARCHAR` row is the only one you can change, and it is the one worth
 changing: `nvarchar(max)` is an off-row LOB and measured 4.1× slower to load
 than a sized column. See
-[Target Column Types and Table Shape](/writing/table-options/) for
+[Target Column Types and Table Shape](./table-options.md) for
 `MSSQL_VARCHAR(n)` / `MSSQL_NVARCHAR(n)`, `mssql_default_string_length` and
 `mssql_ctas_text_type`.
 
@@ -95,7 +95,7 @@ than a sized column. See
 | `mssql_ctas_drop_on_failure` | BOOLEAN | `false` | Drop table if data transfer phase fails |
 
 Column lengths and the table's shape come from
-[Target Column Types and Table Shape](/writing/table-options/) —
+[Target Column Types and Table Shape](./table-options.md) —
 cast a column to `MSSQL_NVARCHAR(n)` in the SELECT list to size it, since CTAS
 has no options syntax of its own.
 

--- a/website/versioned_docs/version-0.2.3/writing/table-options.md
+++ b/website/versioned_docs/version-0.2.3/writing/table-options.md
@@ -75,7 +75,7 @@ bare identifier, so anything else is rejected at bind time rather than
 concatenated into a `CREATE TABLE`.
 
 On Microsoft Fabric only two collations exist and both are UTF-8; naming any
-other is refused before the DDL is built. See [AZURE.md](/connection/azure/#two-collations-both-utf-8).
+other is refused before the DDL is built. See [AZURE.md](../connection/azure.md#two-collations-both-utf-8).
 
 #### Using them with COPY
 

--- a/website/versioned_docs/version-0.2.3/writing/transactions.md
+++ b/website/versioned_docs/version-0.2.3/writing/transactions.md
@@ -27,10 +27,10 @@ All statements within a transaction execute on the same SQL Server connection. I
 - **One connection, one job**: because a transaction pins a single connection, it
   cannot stream a result set and receive a bulk load at once — a `COPY` that
   reads from the same catalog it writes to fails inside an explicit transaction.
-  See [Reading and writing the same catalog in one transaction](/writing/copy/#reading-and-writing-the-same-catalog-in-one-transaction)
+  See [Reading and writing the same catalog in one transaction](./copy.md#reading-and-writing-the-same-catalog-in-one-transaction)
 - **CTAS is outside the transaction**: it creates its table with autocommitting
   DDL and loads on connections of its own, so `ROLLBACK` undoes neither. See
-  [CTAS is not part of the transaction](/writing/copy/#ctas-is-not-part-of-the-transaction)
+  [CTAS is not part of the transaction](./copy.md#ctas-is-not-part-of-the-transaction)
 
 ### Multi-Statement SQL Batches
 

--- a/website/versioned_docs/version-0.2.4/connection/index.md
+++ b/website/versioned_docs/version-0.2.4/connection/index.md
@@ -89,9 +89,9 @@ CREATE SECRET secret_name (
 | `catalog`     | BOOLEAN | No       | Enable catalog integration (default: true). Set to false for serverless/restricted databases that don't support catalog queries |
 | `schema_filter` | VARCHAR | No     | Regex pattern to filter visible schemas (case-insensitive partial match) |
 | `table_filter`  | VARCHAR | No     | Regex pattern to filter visible tables/views (case-insensitive partial match) |
-| `azure_secret`  | VARCHAR | No     | Name of an Azure secret (DuckDB Azure extension) for Azure AD auth — see [AZURE.md](/connection/azure/) |
-| `access_token`  | VARCHAR | No     | Pre-acquired Azure AD JWT (hidden in `duckdb_secrets()`) — see [AZURE.md](/connection/azure/) |
-| `authenticator` | VARCHAR | No     | `krb5` (POSIX) or `winsspi` (Windows SSPI) — Kerberos / SSPI integrated auth, see [Kerberos.md](/connection/kerberos/) |
+| `azure_secret`  | VARCHAR | No     | Name of an Azure secret (DuckDB Azure extension) for Azure AD auth — see [AZURE.md](./azure.md) |
+| `access_token`  | VARCHAR | No     | Pre-acquired Azure AD JWT (hidden in `duckdb_secrets()`) — see [AZURE.md](./azure.md) |
+| `authenticator` | VARCHAR | No     | `krb5` (POSIX) or `winsspi` (Windows SSPI) — Kerberos / SSPI integrated auth, see [Kerberos.md](./kerberos.md) |
 | `krb5_configfile`    | VARCHAR | No | Per-secret `/etc/krb5.conf` override (Linux only) |
 | `krb5_keytabfile`    | VARCHAR | No | Path to a keytab — selects keytab credential mode (Linux only) |
 | `krb5_credcachefile` | VARCHAR | No | ccache path override (Linux only) |
@@ -114,9 +114,9 @@ ATTACH '' AS context_name (TYPE mssql, SECRET secret_name);
 | `User Id`                   | `Uid`, `User`                        |
 | `Password`                  | `Pwd`                                |
 | `Encrypt`                   | `Use Encryption for Data`, `TrustServerCertificate` |
-| `Trusted_Connection`        | `Trusted Connection`, `TrustedConnection` (yes/true/SSPI/1 -> Kerberos on POSIX, SSPI on Windows; see [Kerberos.md](/connection/kerberos/)) |
+| `Trusted_Connection`        | `Trusted Connection`, `TrustedConnection` (yes/true/SSPI/1 -> Kerberos on POSIX, SSPI on Windows; see [Kerberos.md](./kerberos.md)) |
 | `Integrated Security`       | `IntegratedSecurity`, `Integrated_Security` (same resolution as `Trusted_Connection`) |
-| `authenticator`             | `krb5` or `winsspi` (see [Kerberos.md](/connection/kerberos/)) |
+| `authenticator`             | `krb5` or `winsspi` (see [Kerberos.md](./kerberos.md)) |
 | `krb5-keytabfile`           | `krb5_keytabfile` (path to keytab; selects keytab mode, Linux only) |
 | `krb5-configfile`           | `krb5_configfile` (per-connection `/etc/krb5.conf` override, Linux only) |
 | `krb5-credcachefile`        | `krb5_credcachefile` (ccache path override, Linux only) |
@@ -149,7 +149,7 @@ Three credential modes are supported on POSIX:
 
 On Windows, **SSPI** (`authenticator=winsspi` or `Trusted_Connection=yes`) authenticates with the current Windows logon session via `secur32.dll`'s Negotiate package — no `kinit` needed. The connection-string surface is identical to POSIX; `Trusted_Connection=yes` / `Integrated Security=SSPI` resolve to `winsspi` automatically on Windows hosts.
 
-See [Kerberos.md](/connection/kerberos/) for prerequisites, full connection-string
+See [Kerberos.md](./kerberos.md) for prerequisites, full connection-string
 reference, the bundled docker-compose test stack (no real AD required),
 troubleshooting (including WSL2 specifics), and SPN verification.
 
@@ -307,7 +307,7 @@ In addition to options propagated from the secret / connection string, the follo
 | ------------------- | ------- | ---------------------------------------------------------------------------- |
 | `SECRET`            | VARCHAR | Name of an MSSQL secret holding connection parameters                        |
 | `azure_secret`      | VARCHAR | Override / supply Azure secret name for Azure AD auth                        |
-| `access_token`      | VARCHAR | Pre-acquired Azure AD JWT (see [AZURE.md](/connection/azure/))                         |
+| `access_token`      | VARCHAR | Pre-acquired Azure AD JWT (see [AZURE.md](./azure.md))                         |
 | `catalog`           | BOOLEAN | Enable catalog integration (default `true`)                                  |
 | `schema_filter`     | VARCHAR | Override secret schema_filter for this ATTACH                                |
 | `table_filter`      | VARCHAR | Override secret table_filter for this ATTACH                                 |

--- a/website/versioned_docs/version-0.2.4/connection/kerberos.md
+++ b/website/versioned_docs/version-0.2.4/connection/kerberos.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 # Kerberos / Integrated Authentication
 
 End-user guide for connecting to Active-Directory-joined SQL Server via Kerberos
-(POSIX) or SSPI (Windows). Spec 042. Mirrors the structure of [AZURE.md](/connection/azure/).
+(POSIX) or SSPI (Windows). Spec 042. Mirrors the structure of [AZURE.md](./azure.md).
 
 ## Table of Contents
 
@@ -805,7 +805,7 @@ Names verbatim from `microsoft/go-mssqldb`'s `integratedauth/` package.
 
 ### See Also
 
-- [AZURE.md](/connection/azure/) — Azure AD authentication (Entra ID, Service Principal,
+- [AZURE.md](./azure.md) — Azure AD authentication (Entra ID, Service Principal,
   device code, manual access token)
 - [README.md](/) — main extension documentation
 - [docs/architecture.md](https://github.com/hugr-lab/mssql-extension/blob/main/docs/architecture.md) — IAuthenticator abstraction and

--- a/website/versioned_docs/version-0.2.4/index.md
+++ b/website/versioned_docs/version-0.2.4/index.md
@@ -26,7 +26,7 @@ ATTACH 'Server=localhost;Database=AdventureWorks;User Id=sa;Password=...' AS mss
 SELECT * FROM mssql.dbo.SalesOrderHeader LIMIT 10;
 ```
 
-→ **[Getting Started](/getting-started/)** · **[Settings Reference](/reference/settings/)** · **[Download metrics](https://hugr-lab.github.io/mssql-extension/metrics/)**
+→ **[Getting Started](./getting-started.md)** · **[Settings Reference](./reference/settings.md)** · **[Download metrics](https://hugr-lab.github.io/mssql-extension/metrics/)**
 
 ## Community Extension Downloads
 
@@ -48,8 +48,8 @@ SELECT * FROM mssql.dbo.SalesOrderHeader LIMIT 10;
 - Transaction support: BEGIN/COMMIT/ROLLBACK with connection pinning
 - Multi-statement SQL batches via `mssql_scan()` (e.g., temp table workflows)
 - DuckDB secret management for secure credential storage
-- [Azure AD authentication](/connection/azure/) (service principal, CLI, interactive device code flow)
-- [Kerberos / Windows SSPI integrated authentication](/connection/kerberos/) — POSIX (`kinit` / keytab / raw credentials) and Windows (current logon session via `secur32.dll`)
+- [Azure AD authentication](./connection/azure.md) (service principal, CLI, interactive device code flow)
+- [Kerberos / Windows SSPI integrated authentication](./connection/kerberos.md) — POSIX (`kinit` / keytab / raw credentials) and Windows (current logon session via `secur32.dll`)
 - Custom `Application Name` propagated to SQL Server `APP_NAME()` / `sys.dm_exec_sessions.program_name`
 - ATTACH-time credential validation (opt-out via `lazy_validation true`)
 - **Experimental**: ORDER BY pushdown to SQL Server (opt-in via `mssql_order_pushdown` setting)

--- a/website/versioned_docs/version-0.2.4/reading/queries.md
+++ b/website/versioned_docs/version-0.2.4/reading/queries.md
@@ -48,7 +48,7 @@ are unchanged either way.
 > Pushed string predicates follow the **server's comparison semantics**: on a
 > case-insensitive collation, `WHERE name = 'abc'` matches `'ABC'` — exactly
 > what the same query returns in SSMS. See the collation notes under
-> [Target Column Types](/writing/table-options/).
+> [Target Column Types](../writing/table-options.md).
 
 ### ORDER BY Pushdown (Experimental)
 

--- a/website/versioned_docs/version-0.2.4/reference/functions.md
+++ b/website/versioned_docs/version-0.2.4/reference/functions.md
@@ -185,7 +185,7 @@ The function loads metadata per-schema to avoid SQL Server tempdb sort spills on
 ### Authentication Test Functions
 
 Connectivity diagnostics that exercise the auth path without a full query.
-Details on the auth pages: [Azure AD](/connection/azure/), [Kerberos / SSPI](/connection/kerberos/).
+Details on the auth pages: [Azure AD](../connection/azure.md), [Kerberos / SSPI](../connection/kerberos.md).
 
 | Function | Description |
 |---|---|

--- a/website/versioned_docs/version-0.2.4/reference/settings.md
+++ b/website/versioned_docs/version-0.2.4/reference/settings.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 | -------------------------- | ------- | ------- | ----- | ---------------------------------------- |
 | `mssql_connection_limit`   | BIGINT  | 64      | ≥1    | Max connections per attached database    |
 | `mssql_connection_cache`   | BOOLEAN | true    | -     | Enable connection pooling and reuse      |
-| `mssql_reset_connection`   | BOOLEAN | true    | -     | Reset session state when a connection returns to the pool ([details](/performance/#owning-the-session-mssql_reset_connection)) |
+| `mssql_reset_connection`   | BOOLEAN | true    | -     | Reset session state when a connection returns to the pool ([details](../performance.md#owning-the-session-mssql_reset_connection)) |
 | `mssql_connection_timeout` | BIGINT  | 30      | ≥0    | TCP connection timeout (seconds)         |
 | `mssql_idle_timeout`       | BIGINT  | 300     | ≥0    | Idle connection timeout (seconds, 0=none)|
 | `mssql_min_connections`    | BIGINT  | 0       | ≥0    | Minimum connections to maintain          |
@@ -43,7 +43,7 @@ sidebar_position: 1
 
 ### Bulk Load (COPY / CTAS) Settings
 
-Details: [COPY TO](/writing/copy/) and [CTAS](/writing/ctas/).
+Details: [COPY TO](../writing/copy.md) and [CTAS](../writing/ctas.md).
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -56,7 +56,7 @@ Details: [COPY TO](/writing/copy/) and [CTAS](/writing/ctas/).
 
 ### Target Type Settings
 
-Details: [Target Column Types and Table Shape](/writing/table-options/).
+Details: [Target Column Types and Table Shape](../writing/table-options.md).
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -72,7 +72,7 @@ Details: [Target Column Types and Table Shape](/writing/table-options/).
 | ---------------------------------- | ------- | ------- | ----- | ------------------------------------- |
 | `mssql_order_pushdown`             | BOOLEAN | false   | -     | Enable ORDER BY pushdown to SQL Server |
 
-The `order_pushdown` ATTACH option provides per-database control. See [ORDER BY Pushdown](/reading/queries/#order-by-pushdown-experimental) for details.
+The `order_pushdown` ATTACH option provides per-database control. See [ORDER BY Pushdown](../reading/queries.md#order-by-pushdown-experimental) for details.
 
 ### INSERT Settings
 

--- a/website/versioned_docs/version-0.2.4/reference/troubleshooting.md
+++ b/website/versioned_docs/version-0.2.4/reference/troubleshooting.md
@@ -63,7 +63,7 @@ Error: Unsupported SQL Server type 'UDT' (0xF0) for column 'col_name'
 
 **Solutions:**
 
-- Check the [Type Mapping](/reading/types/) section for supported types
+- Check the [Type Mapping](../reading/types.md) section for supported types
 - Cast unsupported columns to supported types in your query
 - Exclude unsupported columns from SELECT
 
@@ -85,7 +85,7 @@ Error: Unsupported SQL Server type 'UDT' (0xF0) for column 'col_name'
 - **RETURNING for UPDATE/DELETE**: Only INSERT supports RETURNING clause; UPDATE/DELETE do not
 - **UPDATE/DELETE without PK**: Tables must have primary keys for UPDATE/DELETE operations
 - **Updating primary key columns**: UPDATE cannot modify primary key columns (used for row identification)
-- **Keytab / raw Kerberos credentials on macOS**: macOS's `GSS.framework` lacks MIT extensions for `gss_acquire_cred_from` keytab and raw-password paths. macOS supports credential-cache mode only (via `kinit`); keytab and raw-credentials modes are Linux-only. See [Kerberos.md](/connection/kerberos/) for the WSL2 / Docker testing path.
+- **Keytab / raw Kerberos credentials on macOS**: macOS's `GSS.framework` lacks MIT extensions for `gss_acquire_cred_from` keytab and raw-password paths. macOS supports credential-cache mode only (via `kinit`); keytab and raw-credentials modes are Linux-only. See [Kerberos.md](../connection/kerberos.md) for the WSL2 / Docker testing path.
 - **Multiple result sets**: Only one result-producing statement per `mssql_scan()` batch is allowed
 - **Stored Procedures with Output Parameters**: Use `mssql_scan()` for stored procedures
 - **rowid for views/tables without PK**: Only tables with primary keys expose `rowid`
@@ -157,6 +157,6 @@ The codec validates the input first and falls back to a slower scalar implementa
 - XML columns in INSERT/UPDATE are limited to 4096 bytes per value — use COPY TO with BCP protocol for larger documents
 - Very large DECIMAL values may lose precision at extreme scales
 - Connection pool statistics reset when all connections close
-- Microsoft Fabric Warehouse has no `nvarchar` type at all, and no `datetimeoffset` — so a `TIMESTAMP WITH TIME ZONE` column cannot be created there. `varchar(max)` is supported. See [AZURE.md](/connection/azure/#microsoft-fabric)
+- Microsoft Fabric Warehouse has no `nvarchar` type at all, and no `datetimeoffset` — so a `TIMESTAMP WITH TIME ZONE` column cannot be created there. `varchar(max)` is supported. See [AZURE.md](../connection/azure.md#microsoft-fabric)
 - A `#temp` table cannot be a BCP target on Microsoft Fabric: the load fails inside Fabric with an I/O error against a parquet file. Load into a permanent table
 

--- a/website/versioned_docs/version-0.2.4/writing/ctas.md
+++ b/website/versioned_docs/version-0.2.4/writing/ctas.md
@@ -82,7 +82,7 @@ before any of that batch is sent.
 The `VARCHAR` row is the only one you can change, and it is the one worth
 changing: `nvarchar(max)` is an off-row LOB and measured 4.1× slower to load
 than a sized column. See
-[Target Column Types and Table Shape](/writing/table-options/) for
+[Target Column Types and Table Shape](./table-options.md) for
 `MSSQL_VARCHAR(n)` / `MSSQL_NVARCHAR(n)`, `mssql_default_string_length` and
 `mssql_ctas_text_type`.
 
@@ -95,7 +95,7 @@ than a sized column. See
 | `mssql_ctas_drop_on_failure` | BOOLEAN | `false` | Drop table if data transfer phase fails |
 
 Column lengths and the table's shape come from
-[Target Column Types and Table Shape](/writing/table-options/) —
+[Target Column Types and Table Shape](./table-options.md) —
 cast a column to `MSSQL_NVARCHAR(n)` in the SELECT list to size it, since CTAS
 has no options syntax of its own.
 

--- a/website/versioned_docs/version-0.2.4/writing/table-options.md
+++ b/website/versioned_docs/version-0.2.4/writing/table-options.md
@@ -75,7 +75,7 @@ bare identifier, so anything else is rejected at bind time rather than
 concatenated into a `CREATE TABLE`.
 
 On Microsoft Fabric only two collations exist and both are UTF-8; naming any
-other is refused before the DDL is built. See [AZURE.md](/connection/azure/#two-collations-both-utf-8).
+other is refused before the DDL is built. See [AZURE.md](../connection/azure.md#two-collations-both-utf-8).
 
 #### Using them with COPY
 

--- a/website/versioned_docs/version-0.2.4/writing/transactions.md
+++ b/website/versioned_docs/version-0.2.4/writing/transactions.md
@@ -27,10 +27,10 @@ All statements within a transaction execute on the same SQL Server connection. I
 - **One connection, one job**: because a transaction pins a single connection, it
   cannot stream a result set and receive a bulk load at once — a `COPY` that
   reads from the same catalog it writes to fails inside an explicit transaction.
-  See [Reading and writing the same catalog in one transaction](/writing/copy/#reading-and-writing-the-same-catalog-in-one-transaction)
+  See [Reading and writing the same catalog in one transaction](./copy.md#reading-and-writing-the-same-catalog-in-one-transaction)
 - **CTAS is outside the transaction**: it creates its table with autocommitting
   DDL and loads on connections of its own, so `ROLLBACK` undoes neither. See
-  [CTAS is not part of the transaction](/writing/copy/#ctas-is-not-part-of-the-transaction)
+  [CTAS is not part of the transaction](./copy.md#ctas-is-not-part-of-the-transaction)
 
 ### Multi-Statement SQL Batches
 


### PR DESCRIPTION
Roborev jobs 1316 and 1318 on the merged #292 work, plus the recurrence of the closed #289 as #293.

## The #292 sweep missed 17 links — and #292 armed a gate in front of them

#292 said it swept the docs tree and rewrote 12 links. It rewrote **12 of 29**. The script carried a hand-written list of section prefixes — `writing|reading|reference|getting-started|guides|intro|troubleshooting` — and the tree also has `connection/` and `performance/`. Everything under those was invisible both to the sweep and to the grep that "verified" it.

Measured on `origin/main` before this branch:

```
16  ](/connection/
 1  ](/performance/
```

Three of the 17 are anchored, which is the part that matters: **#292 also set `onBrokenAnchors: 'throw'`.** An absolute anchor link in `docs/` is validated against the *released snapshot's* copy of the page, so renaming a heading in `docs/connection/azure.md` would fail the build — and the Pages deploy — while pointing at a file that looks fine. Tightening the gate was right. Leaving live rounds behind it was not.

Swept again with **no allowlist**: a link is internal if the path it names resolves to a file inside that version's root.

| root | rewritten | unresolved |
|---|---|---|
| `website/docs` | 17 | 0 |
| `versioned_docs/version-0.2.3` | 29 | 0 |
| `versioned_docs/version-0.2.4` | 29 | 0 |
| **total** | **75** | **0** |

The frozen snapshots had it worse than `docs/` — a reader on 0.2.3 following "COPY TO" silently landed on the 0.2.4 page (roborev's third finding, pre-existing).

## A check, because hand-sweeping has now failed twice

`scripts/ci/check_docs_links.py`, wired into `docs-build.yml` **ahead of** `npm ci` so a link error reports in seconds rather than after a 90-second install.

Docusaurus cannot catch this class itself: an absolute link resolves to a page that genuinely exists in the released version, so `onBrokenLinks` sees nothing wrong. That is precisely why two hand sweeps and a green build all missed it.

Verified in both directions:

```
$ python3 scripts/ci/check_docs_links.py
checked 3 docs root(s): no absolute internal links        # EXIT=0

$ # put one link back
  website/docs/reference/functions.md:188
      ](/connection/azure/)
      use ](../connection/azure.md)                        # EXIT=1
```

## Dependabot — job 1318, and why #289 came back

**`ignore` for `@mermaid-js/layout-elk >=0.2.0`.** Not a judgement about the release: `@docusaurus/theme-mermaid@3.10.2` declares `peerOptional: "^0.1.9"` (confirmed in its own `package.json`), so 0.2.x cannot install — `npm ci` fails `ERESOLVE`. **Closing the PR does not hold:** #289 was closed by hand, and Dependabot re-raised it as #293 **67 seconds** after the next push to `main`, because it re-evaluates on every push. The entry carries its own removal condition.

The three low findings, all correct:

- The file header still described the shape as *"group each ecosystem into one PR"* — neither ecosystem does that any more. It now states the per-stream rule it actually implements.
- The `github-actions` comment quoted `codeql-action@v4.37.3`; #291 had already bumped it to `v4.37.8`. The claim was right, the citation stale.
- `open-pull-requests-limit` 5 → **10** on both. With majors ungrouped, ~20 distinct actions can each want a PR, and 5 would silently *withhold* updates rather than defer them.

## Note

Once this merges, #293 should close itself on Dependabot's next run — an open PR matching a new `ignore` rule gets closed automatically. I'll confirm rather than assume.