### PR TITLE
ci: the comment blaming #165 for red MSVC outlived the issue by a month

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ on:
     # manual-dispatch only, so without this the C++ unit tests it carries
     # (incl. test_login_error_state, issue #164) and the integration suite get
     # no automatic coverage between releases. Runs build + smoke + integration;
-    # Windows / Azure stay manual (cost, and #165 keeps MSVC red).
+    # Windows / Azure stay manual (CI cost).
+    #
+    # That used to read "and #165 keeps MSVC red". #165 was CLOSED/COMPLETED on
+    # 2026-08-02, and v0.2.4 -- released 2026-08-17, after it -- ships both
+    # mssql-0.2.4-windows_amd64.duckdb_extension (MSVC) and the MinGW build, so
+    # MSVC is green on the release path. The comment outlived the issue it
+    # named and was still being read as current state a month later
+    # (discussion #298). Cost is now the only reason these are gated.
     - cron: '0 5 * * 1'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Comment-only change, from @VGSML's correction in #298.

`ci.yml`'s schedule block said:

> Windows / Azure stay manual (cost, and **#165 keeps MSVC red**).

Half of that stopped being true a month ago:

| | |
|---|---|
| **#165** *"Windows MSVC build fails in DuckDB bundled fmt/format.h (C2143/C2447)"* | **CLOSED / COMPLETED 2026-08-02** |
| **v0.2.4**, published **2026-08-17** — after the close | ships `mssql-0.2.4-windows_amd64.duckdb_extension` (**MSVC**) and `..._windows_amd64_mingw` |

So MSVC is green on the release path, and cost is the only remaining reason the jobs are dispatch-gated — a decision, not a blocker.

The reason this is worth its own PR rather than a drive-by: **the stale comment was actively misleading someone**. I quoted it in #298 as evidence that enabling Windows on PRs was blocked behind a compiler bug, and built a proposed work ordering on top of that. A comment naming a closed issue reads exactly like current state, and nothing makes it go stale loudly.

## What this does not claim

Only that the *comment* was wrong. Whether the Windows jobs pass on a **PR-triggered** run is a separate question — the release workflow and `ci.yml` do not share runner configuration, and `run_windows_build` has not been dispatched since #165 closed (checked: the most recent `workflow_dispatch`, 2026-08-29, left the box unticked, and all three Windows jobs show `skipped`).

A dispatch is in flight to establish that. This PR deliberately does **not** ungate the jobs on that assumption — that decision belongs with the result.

https://claude.ai/code/session_01Urg6HnvrWsfeiJcStm2kyb