### PR TITLE
ci: fix three inaccuracies #299 introduced, and record the Windows dispatch result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,29 @@ on:
     # Weekly regression build (Mondays 05:00 UTC). The heavy build job is
     # manual-dispatch only, so without this the C++ unit tests it carries
     # (incl. test_login_error_state, issue #164) and the integration suite get
-    # no automatic coverage between releases. Runs build + smoke + integration;
-    # Windows / Azure stay manual (CI cost).
+    # no automatic coverage between releases. Runs build + smoke + integration.
     #
-    # That used to read "and #165 keeps MSVC red". #165 was CLOSED/COMPLETED on
-    # 2026-08-02, and v0.2.4 -- released 2026-08-17, after it -- ships both
-    # mssql-0.2.4-windows_amd64.duckdb_extension (MSVC) and the MinGW build, so
-    # MSVC is green on the release path. The comment outlived the issue it
-    # named and was still being read as current state a month later
-    # (discussion #298). Cost is now the only reason these are gated.
+    # Windows BUILDS stay manual, for CI cost alone. Note "builds": the
+    # windows-sspi-test job below carries no `if:` guard and compiles
+    # winsspi_authenticator.cpp with MSVC `cl /std:c++17` on every push, PR and
+    # scheduled run, so MSVC compilation is continuously exercised already.
+    #
+    # Azure stays manual for reasons that are NOT cost: the job needs the
+    # 'test' environment's secrets, and its `if:` refuses to run on main by
+    # design (see the run_azure_tests input -- feature branches only).
+    #
+    # This block used to say "and #165 keeps MSVC red". #165 was CLOSED as
+    # COMPLETED on 2026-08-02; v0.2.4, released 2026-08-17 after it, ships both
+    # mssql-0.2.4-windows_amd64.duckdb_extension (MSVC) and the MinGW build.
+    # The comment outlived the issue it named and was still being quoted as
+    # current state a month later, in discussion #298, as grounds for believing
+    # Windows-on-PRs was blocked behind a compiler bug.
+    #
+    # Confirmed on the CI lane, not just the release lane -- those do not share
+    # runner configuration, so the release artifacts alone did not settle it.
+    # Dispatch with run_windows_build=true, 2026-09-03, actions run
+    # 33793132193: Build Windows (MSVC), Build Windows (MinGW), Smoke Test
+    # Windows (MSVC), Smoke Test Windows (MinGW) -- all success.
     - cron: '0 5 * * 1'
   workflow_dispatch:
     inputs:

--- a/docs/proposals/simd-chunk-materialization-design.md
+++ b/docs/proposals/simd-chunk-materialization-design.md
@@ -136,7 +136,7 @@ All checked directly in the pinned v1.5.5 submodule — not from memory.
      local builds, our CI, and community-extensions builds alike (the config ships with the
      extension; no pipeline knob needed).
    - Gate before adoption: full-matrix build + tests (Linux GCC, macOS Clang, **MSVC and
-     MinGW** — bundled fmt is a known MSVC sore spot, cf. issue #165; watch for C++17
+     MinGW** — bundled fmt is a known MSVC sore spot, cf. issue #165 (closed 2026-08-02); watch for C++17
      removals like `std::random_shuffle` in third_party).
    - **Adoption stance (maintainer decision):** C++17 is *not scheduled*. It is taken up only
      when a concrete kernel or refactor is demonstrably better in C++17 (readability or
@@ -465,7 +465,7 @@ it measured report approximately nothing.
 | [#197](https://github.com/hugr-lab/mssql-extension/issues/197) — NTEXT/IMAGE unreadable (no decoder for wire types 0x63/0x22) | Decode-path gap in the same row-reader/codec layer the staging refactor rewrites | **Phase 1** ride-along: add legacy LONGLEN readers while the value-read dispatch is being restructured (cheaper to do during the pivot than before/after) |
 | [#153](https://github.com/hugr-lab/mssql-extension/issues/153) — should BCP COPY allow compatible numeric coercion (BIGINT→INT) into existing tables? | Write-path type-mapping policy, adjacent to the representation-aware encoder | Open question for **Phase 3**: batch encoders make per-column coercion kernels cheap; policy decision (error vs range-checked coercion) stays a spec-level question |
 
-Not related (tracked separately): #199 (test infra), #204/#122 (connectivity), #140 (DML), #85/#86 (catalog), #189, #129, #165 (MSVC fmt — relevant only as a C++17-gate canary, §2.7), #119.
+Not related (tracked separately): #199 (test infra), #204/#122 (connectivity), #140 (DML), #85/#86 (catalog), #189, #129, #119. (#165, the MSVC fmt C++17-gate canary of §2.7, was closed 2026-08-02.)
 
 ## 10. Phasing → specs
 


### PR DESCRIPTION
Follow-up to #299, which merged before a design review of it came back. The review passed the change on its central claim but found three ways the *replacement* text was wrong — a comment whose entire value is being accurate.

## The three corrections

**1 — "Cost is now the only reason these are gated" is false for Azure.** (Medium)

`ci.yml`'s Azure job gate is:

```yaml
if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_build
        && inputs.run_azure_tests && github.ref != 'refs/heads/main' }}
environment: test
```

Two of those are not cost: it needs the `test` environment's secrets, and it is **refused on `main` by design** (the `run_azure_tests` input says "use on feature branches only"). #299 existed to stop the next person acting on a stale claim, and put a smaller false claim in the same sentence — the identical failure mode, one issue later. Windows and Azure now get separate clauses.

**2 — "Windows / Azure stay manual" is imprecise, and hid the best evidence.** (Low)

`windows-sspi-test` carries **no `if:` guard**. It compiles `winsspi_authenticator.cpp` with MSVC `cl /std:c++17` on every push, PR and scheduled run. So MSVC compilation was already exercised continuously — a stronger argument for exactly the claim #299 was making than the release artifacts it cited.

Worth being blunt: that job has been showing up as a passing **"Windows SSPI Unit Test"** in every PR check list I looked at this week, and I wrote "Windows is skipped on every PR" in #298 anyway. The *builds* are skipped; an MSVC compile is not. Now reads "Windows **BUILDS** stay manual" and names the job.

**3 — #165 was still cited as live elsewhere.** (Low)

`docs/proposals/simd-chunk-materialization-design.md:139` calls it "a known MSVC sore spot, cf. issue #165", and `:468` lists it under "tracked separately" as a live C++17-gate canary. Fixing `ci.yml` alone left the stale premise findable in the other place someone would look. Both annotated with the close date.

## And the answer #299 promised

#299 said a dispatch was "in flight" and deliberately did not pre-judge it. It has since completed — **[run 33793132193](https://github.com/hugr-lab/mssql-extension/actions/runs/33793132193)**, `run_windows_build=true`:

```
success   Build Windows (MSVC)
success   Build Windows (MinGW)
success   Smoke Test Windows (MSVC)
success   Smoke Test Windows (MinGW)
```

This is the part the release artifacts could not establish, since the release workflow and `ci.yml` do not share runner configuration. Windows is green on **both** lanes; the dispatch gate is a CI-cost decision and nothing else.

The run id is now in the comment, so the evidence travels with the claim instead of needing re-derivation — which is precisely how the #165 line went stale to begin with.

## Scope

Comment and documentation only. No job is ungated, no CI behaviour changes. Whether to actually run Windows builds on PRs is the item under discussion in #298 and stays there.

https://claude.ai/code/session_01Urg6HnvrWsfeiJcStm2kyb