### PR TITLE
ci: run the checks on stacked PRs too — closes #285

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,14 @@ on:
     # The green tick was the problem: four checks ran and passed, so the page
     # looked fine. Only counting them against another PR showed the ten missing.
     #
-    # This also makes ci.yml consistent with every other workflow in the repo --
-    # it was the only one filtering PRs by base branch; the rest scope by
-    # `paths:`. Cost is CI minutes on stacked PRs, which is the point: a PR
-    # merging into a feature branch still reaches main eventually.
+    # This also makes ci.yml consistent with every other workflow in the repo:
+    # it was the only one filtering PRs by BASE BRANCH. The rest either scope
+    # by `paths:` (cflite-pr, concurrency-tests, docs-build, kerberos,
+    # named-instance) or take every PR unconditionally (lint-extra,
+    # security-scan) -- which is why those ran on #284 and this did not.
+    #
+    # Cost is CI minutes on stacked PRs, which is the point: a PR merging into
+    # a feature branch still reaches main eventually.
     #
     # Docs-only PRs skip CI (lint + C++ unit tests). Prose-scanning workflows
     # (prompt-injection, secret scan) have their own triggers and still run.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,23 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # NO `branches:` filter, deliberately (issue #285). With `branches: [main]`
+    # a PR whose base was another branch ran none of this -- and stacked PRs are
+    # normal here. #283 (base main) got 14 checks; #284, open the same day with
+    # base fix/roborev-backlog, got 4, all from workflows that have their own
+    # triggers. No Build, no Integration, no C++ Unit Tests, no Lint. #284's
+    # whole change was to THIS FILE, deleting twelve test blocks on the argument
+    # that `make test-cpp-run` covers them -- exactly what Build verifies, and
+    # exactly what its own checks could not.
+    #
+    # The green tick was the problem: four checks ran and passed, so the page
+    # looked fine. Only counting them against another PR showed the ten missing.
+    #
+    # This also makes ci.yml consistent with every other workflow in the repo --
+    # it was the only one filtering PRs by base branch; the rest scope by
+    # `paths:`. Cost is CI minutes on stacked PRs, which is the point: a PR
+    # merging into a feature branch still reaches main eventually.
+    #
     # Docs-only PRs skip CI (lint + C++ unit tests). Prose-scanning workflows
     # (prompt-injection, secret scan) have their own triggers and still run.
     # NOTE: if Lint / "C++ Unit Tests" are required status checks, GitHub treats


### PR DESCRIPTION
Closes #285.

`ci.yml` triggered on `pull_request: branches: [main]`, so a PR whose base was another branch ran **none** of it. Stacked PRs are a normal way to work here, and they arrived unverified.

## The evidence

Two PRs open the same day, same repo, differing only in base branch:

| PR | base | checks |
|---|---|---|
| #283 | `main` | **14** — Build, Integration, C++ Unit Tests ×2, Lint, Windows SSPI, smoke… |
| #284 | `fix/roborev-backlog` | **4** |

The four were `Concurrency stress`, `Scan PR prose for prompt injection`, `Secret scan (TruffleHog)` and `yamllint` — every one from a workflow with its *own* triggers. No Build. No Integration. No C++ Unit Tests. No Lint.

**#284 makes the point sharply**: its entire change was to `ci.yml` itself, deleting twelve hand-rolled test blocks on the argument that `make test-cpp-run` already covers them. That argument is exactly what a `Build` job verifies — and the PR's own checks could not. It had to be dispatched by hand ([run 33250064017](https://github.com/hugr-lab/mssql-extension/actions/runs/33250064017)) to get coverage, and that result attaches to a manual run, not to the PR.

The failure was quiet in the familiar way: four checks ran and passed, so the page looked green. Only counting them against another PR revealed the ten that never ran.

## Why option 1, not option 2

The issue offered listing the stacking bases (`branches: [main, 'fix/**', 'spec/**']`). Dropping the filter entirely is better: a prefix list needs maintaining and will be wrong for whatever prefix someone picks next.

It also makes `ci.yml` **consistent with the rest of the repo**. Checked every workflow — `ci.yml` was the *only* one filtering `pull_request` by base branch. `cflite-pr`, `concurrency-tests`, `docs-build`, `kerberos` and `named-instance` all scope by `paths:` instead, which is precisely why they *did* run on #284.

## Verified before changing anything

- **No job conditions needed changing.** `build` and `integration-test` already fire on `github.event_name == 'pull_request'` irrespective of base — added by #279.
- **Concurrency is safe.** The group keys on `github.ref`, which for a PR is `refs/pull/N/merge`, so a stacked PR's run cannot cancel another PR's or `main`'s.
- `smoke-test` deliberately still excludes `pull_request` (dispatch/schedule/push only) — unchanged, and why it still shows `skipping`.
- yamllint and actionlint clean.

## Cost

CI minutes on stacked PRs, which is the point of #279 one level up: a PR merging into a feature branch still reaches `main` eventually. `paths-ignore` still exempts docs-only PRs, and the Linux-only PR matrix still bounds each run.

https://claude.ai/code/session_01Urg6HnvrWsfeiJcStm2kyb