### PR TITLE
chore: track duckdb's v2.0 pre-release branch (v2.0-cyanoptera)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1270,8 +1270,9 @@ jobs:
           # ExtensionHelper::GetVersionDirectoryName(), which returns the
           # version tag only for a RELEASE build; for anything carrying `-dev`
           # it returns DuckDB::SourceID() -- a 10-char commit hash, which never
-          # starts with `v`. The duckdb submodule is pinned to `branch = main`
-          # and this workflow passes neither OVERRIDE_GIT_DESCRIBE nor
+          # starts with `v`. The duckdb submodule is pinned to a SHA on
+          # `branch = v2.0-cyanoptera` and this workflow passes neither
+          # OVERRIDE_GIT_DESCRIBE nor
           # DUCKDB_EXPLICIT_VERSION, so `git describe` lands off-tag,
           # DUCKDB_VERSION becomes vX.Y.Z-devN and the hash is what gets used.
           # A `v*` glob matches nothing here and the step dies before running a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,24 @@ jobs:
         run: |
           mkdir -p build/release
           cd build/release
+          # -DENABLE_UNITTEST_CPP_TESTS=FALSE drops DuckDB's OWN C++ unit tests
+          # (its test/ subdirs api, appender, arrow, catalog, common, logging,
+          # memoryleak, secrets, optimizer, serialize, sql, ossfuzz, mbedtls,
+          # encryption, persistence). Not an optimisation dressed up as a fix:
+          # `make` has ALWAYS passed it -- extension-ci-tools has it in
+          # BUILD_FLAGS -- so every cmake line in these workflows was configuring
+          # a different build from the one developers run, and compiling upstream
+          # test code that nothing in this repo executes. Measured on this tree:
+          # 1937 -> 1706 build edges, with the `unittest` and test/sqlite targets
+          # identical either way. They sit OUTSIDE the gate in DuckDB's
+          # test/CMakeLists.txt, which is why the sqllogictest driver the
+          # integration job runs is unaffected.
+          #
+          # It stopped being merely wasteful on the v2.0-cyanoptera bump: a
+          # compile error in duckdb/test/common/test_http_transport_manager.cpp
+          # -- returning unique_ptr<MockHTTPParams> where unique_ptr<HTTPParams>
+          # is declared, which GCC rejects -- failed Build (linux_amd64) on a PR
+          # that touched none of it.
           cmake -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -492,6 +510,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../../vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -DVCPKG_MANIFEST_DIR="$(pwd)/../.." \
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE \
             ../../duckdb
           cmake --build . --config Release
 
@@ -948,6 +967,7 @@ jobs:
             -DVCPKG_HOST_TRIPLET=x64-windows-static-release `
             -DVCPKG_MANIFEST_DIR="$(Get-Location)/../.." `
             -DDUCKDB_EXTENSION_CONFIGS="$(Get-Location)/../../extension_config.cmake" `
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE `
             ../../duckdb
           cmake --build . --config Release
           Pop-Location
@@ -1117,6 +1137,7 @@ jobs:
             -DVCPKG_HOST_TRIPLET=x64-mingw-static \
             -DVCPKG_MANIFEST_DIR="$(pwd)/../.." \
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE \
             ../../duckdb
           cmake --build . --config Release
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -126,11 +126,30 @@ jobs:
         run: |
           mkdir -p build/release
           cd build/release
+          # -DENABLE_UNITTEST_CPP_TESTS=FALSE drops DuckDB's OWN C++ unit tests
+          # (its test/ subdirs api, appender, arrow, catalog, common, logging,
+          # memoryleak, secrets, optimizer, serialize, sql, ossfuzz, mbedtls,
+          # encryption, persistence). Not an optimisation dressed up as a fix:
+          # `make` has ALWAYS passed it -- extension-ci-tools has it in
+          # BUILD_FLAGS -- so every cmake line in these workflows was configuring
+          # a different build from the one developers run, and compiling upstream
+          # test code that nothing in this repo executes. Measured on this tree:
+          # 1937 -> 1706 build edges, with the `unittest` and test/sqlite targets
+          # identical either way. They sit OUTSIDE the gate in DuckDB's
+          # test/CMakeLists.txt, which is why the sqllogictest driver the
+          # integration job runs is unaffected.
+          #
+          # It stopped being merely wasteful on the v2.0-cyanoptera bump: a
+          # compile error in duckdb/test/common/test_http_transport_manager.cpp
+          # -- returning unique_ptr<MockHTTPParams> where unique_ptr<HTTPParams>
+          # is declared, which GCC rejects -- failed Build (linux_amd64) on a PR
+          # that touched none of it.
           cmake -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../../vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -DVCPKG_MANIFEST_DIR="$(pwd)/../.." \
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE \
             ../../duckdb
           cmake --build . --config Release --target mssql_loadable_extension
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,24 @@ jobs:
         run: |
           mkdir -p build/release
           cd build/release
+          # -DENABLE_UNITTEST_CPP_TESTS=FALSE drops DuckDB's OWN C++ unit tests
+          # (its test/ subdirs api, appender, arrow, catalog, common, logging,
+          # memoryleak, secrets, optimizer, serialize, sql, ossfuzz, mbedtls,
+          # encryption, persistence). Not an optimisation dressed up as a fix:
+          # `make` has ALWAYS passed it -- extension-ci-tools has it in
+          # BUILD_FLAGS -- so every cmake line in these workflows was configuring
+          # a different build from the one developers run, and compiling upstream
+          # test code that nothing in this repo executes. Measured on this tree:
+          # 1937 -> 1706 build edges, with the `unittest` and test/sqlite targets
+          # identical either way. They sit OUTSIDE the gate in DuckDB's
+          # test/CMakeLists.txt, which is why the sqllogictest driver the
+          # integration job runs is unaffected.
+          #
+          # It stopped being merely wasteful on the v2.0-cyanoptera bump: a
+          # compile error in duckdb/test/common/test_http_transport_manager.cpp
+          # -- returning unique_ptr<MockHTTPParams> where unique_ptr<HTTPParams>
+          # is declared, which GCC rejects -- failed Build (linux_amd64) on a PR
+          # that touched none of it.
           cmake -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -190,6 +208,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../../vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -DVCPKG_MANIFEST_DIR="$(pwd)/../.." \
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE \
             ../../duckdb
           cmake --build . --config Release
 
@@ -328,6 +347,7 @@ jobs:
             -DVCPKG_HOST_TRIPLET=x64-windows-static-release `
             -DVCPKG_MANIFEST_DIR="$(Get-Location)/../.." `
             -DDUCKDB_EXTENSION_CONFIGS="$(Get-Location)/../../extension_config.cmake" `
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE `
             ../../duckdb
           cmake --build . --config Release
           Pop-Location
@@ -479,6 +499,7 @@ jobs:
             -DVCPKG_HOST_TRIPLET=x64-mingw-static \
             -DVCPKG_MANIFEST_DIR="$(pwd)/../.." \
             -DDUCKDB_EXTENSION_CONFIGS="$(pwd)/../../extension_config.cmake" \
+            -DENABLE_UNITTEST_CPP_TESTS=FALSE \
             ../../duckdb
           cmake --build . --config Release
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "duckdb"]
 	path = duckdb
 	url = https://github.com/duckdb/duckdb.git
-	branch = main
+	branch = v2.0-cyanoptera
 [submodule "extension-ci-tools"]
 	path = extension-ci-tools
 	url = https://github.com/duckdb/extension-ci-tools.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ DuckDB extension for SQL Server via a custom TDS protocol implementation (no Fre
 ## Technology
 
 - **Language**: C++17 (DuckDB extension standard)
-- **DuckDB**: main branch (2.0 API track, spec 069). The 1.5.x world lives on branch `duckdb-v1.5.5` for 0.2.x maintenance releases; main compiles against the pinned duckdb submodule SHA only (no dual-API shim since spec 069 retired `mssql_compat.hpp`)
+- **DuckDB**: `v2.0-cyanoptera`, DuckDB's v2.0 pre-release stabilisation branch (2.0 API track, spec 069). Tracked instead of `main` since the branch was cut on 2026-09-03: it is where the 2.0 line is being stabilised, and `main` has already diverged from it. The 1.5.x world lives on branch `duckdb-v1.5.5` for 0.2.x maintenance releases; main compiles against the pinned duckdb submodule SHA only (no dual-API shim since spec 069 retired `mssql_compat.hpp`)
 - **TLS**: OpenSSL via vcpkg (statically linked, symbol visibility controlled)
 - **Platforms**: Linux (GCC), macOS (Clang), Windows (MSVC, MinGW/Rtools 4.2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,17 @@ target_link_libraries(${EXTENSION_NAME} simdutf::simdutf)
 if(WIN32)
     # Windows: static OpenSSL and httplib need Windows system libraries (both MSVC and MinGW)
     target_link_libraries(${EXTENSION_NAME} ws2_32 crypt32)
+elseif(APPLE)
+    # macOS: httplib reads the trusted roots out of the system keychain rather
+    # than an OpenSSL CA bundle -- it turns CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
+    # on by itself for Apple + clang + OpenSSL, and calls SecTrustSettingsCopyCertificates
+    # and the CoreFoundation accessors around it. Without these two frameworks the
+    # link fails outright on undefined _SecTrustSettingsCopyCertificates / _CFRelease.
+    #
+    # This is what we WANT on macOS: vcpkg's static OpenSSL carries no CA bundle,
+    # so the alternative (CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES)
+    # leaves Azure AD token acquisition verifying against an empty trust store.
+    target_link_libraries(${EXTENSION_NAME} "-framework CoreFoundation" "-framework Security")
 endif()
 
 # Integrated Authentication (Spec 042) — compile defines + link libs per platform
@@ -309,6 +320,17 @@ target_link_libraries(${LOADABLE_EXTENSION_NAME} simdutf::simdutf)
 if(WIN32)
     # Windows: static OpenSSL and httplib need Windows system libraries (both MSVC and MinGW)
     target_link_libraries(${LOADABLE_EXTENSION_NAME} ws2_32 crypt32)
+elseif(APPLE)
+    # macOS: httplib reads the trusted roots out of the system keychain rather
+    # than an OpenSSL CA bundle -- it turns CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN
+    # on by itself for Apple + clang + OpenSSL, and calls SecTrustSettingsCopyCertificates
+    # and the CoreFoundation accessors around it. Without these two frameworks the
+    # link fails outright on undefined _SecTrustSettingsCopyCertificates / _CFRelease.
+    #
+    # This is what we WANT on macOS: vcpkg's static OpenSSL carries no CA bundle,
+    # so the alternative (CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES)
+    # leaves Azure AD token acquisition verifying against an empty trust store.
+    target_link_libraries(${LOADABLE_EXTENSION_NAME} "-framework CoreFoundation" "-framework Security")
 endif()
 
 # Integrated Authentication (Spec 042) — compile defines + link libs per platform

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -458,7 +458,7 @@ optional_ptr<CatalogEntry> MSSQLCatalog::CreateSchema(CatalogTransaction transac
 
 	// Handle IF NOT EXISTS: check if schema already exists (Issue #54)
 	if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
-		EntryLookupInfo lookup(CatalogType::SCHEMA_ENTRY, info.SchemaName());
+		EntryLookupInfo lookup(CatalogType::SCHEMA_ENTRY, QualifiedName(info.SchemaName()));
 		auto existing = LookupSchema(transaction, lookup, OnEntryNotFound::RETURN_NULL);
 		if (existing) {
 			return existing.get();
@@ -483,7 +483,7 @@ void MSSQLCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 	// Handle IF EXISTS: check if schema exists before attempting DROP (Issue #54)
 	if (info.if_not_found == OnEntryNotFound::RETURN_NULL) {
 		CatalogTransaction cat_transaction = GetCatalogTransaction(context);
-		EntryLookupInfo lookup(CatalogType::SCHEMA_ENTRY, info.GetQualifiedName().Name());
+		EntryLookupInfo lookup(CatalogType::SCHEMA_ENTRY, QualifiedName(info.GetQualifiedName().Name()));
 		auto existing = LookupSchema(cat_transaction, lookup, OnEntryNotFound::RETURN_NULL);
 		if (!existing) {
 			return;

--- a/src/catalog/mssql_table_entry.cpp
+++ b/src/catalog/mssql_table_entry.cpp
@@ -45,16 +45,24 @@ bool MSSQLReportsNativeTypes(Catalog &catalog) {
 	return setting.IsNull() ? true : setting.GetValue<bool>();
 }
 
-static CreateTableInfo MakeTableInfo(const MSSQLTableMetadata &metadata, bool native_types) {
-	CreateTableInfo info;
-	info.SetTableName(Identifier(metadata.name));
-
-	// Build column definitions
+static ColumnList MakeColumnList(const MSSQLTableMetadata &metadata, bool native_types) {
+	ColumnList columns;
 	for (const auto &col : metadata.columns) {
 		ColumnDefinition column_def(Identifier(col.name), native_types ? col.NativeDuckDBType() : col.duckdb_type);
-		info.columns.AddColumn(std::move(column_def));
+		columns.AddColumn(std::move(column_def));
 	}
+	return columns;
+}
 
+//! Everything the base constructor still reads out of a CreateTableInfo, which
+//! since duckdb 888cd17bee is the name and nothing else this entry sets — the
+//! columns moved to MakeColumnList / columns_, and MSSQL tables carry no
+//! DuckDB-side constraints. Deliberately does NOT fill info.columns: the base
+//! no longer looks at them, so populating the list here would build every
+//! table's columns twice and leave a copy nobody reads.
+static CreateTableInfo MakeTableInfo(const MSSQLTableMetadata &metadata) {
+	CreateTableInfo info;
+	info.SetTableName(Identifier(metadata.name));
 	return info;
 }
 
@@ -63,17 +71,24 @@ static CreateTableInfo MakeTableInfo(const MSSQLTableMetadata &metadata, bool na
 //===----------------------------------------------------------------------===//
 
 MSSQLTableEntry::MSSQLTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, const MSSQLTableMetadata &metadata)
+	// The base takes a non-const lvalue reference, so a temporary cannot bind;
+	// the thread_local is the storage that outlives the argument expression.
 	: TableCatalogEntry(catalog, schema,
 						[&]() -> CreateTableInfo & {
 							static thread_local CreateTableInfo info;
-							info = MakeTableInfo(metadata, MSSQLReportsNativeTypes(catalog));
+							info = MakeTableInfo(metadata);
 							return info;
 						}()),
+	  columns_(MakeColumnList(metadata, MSSQLReportsNativeTypes(catalog))),
 	  mssql_columns_(metadata.columns),
 	  object_type_(metadata.object_type),
 	  approx_row_count_(metadata.approx_row_count) {}
 
 MSSQLTableEntry::~MSSQLTableEntry() = default;
+
+const ColumnList &MSSQLTableEntry::GetColumns() const {
+	return columns_;
+}
 
 //===----------------------------------------------------------------------===//
 // Required Overrides

--- a/src/include/catalog/mssql_table_entry.hpp
+++ b/src/include/catalog/mssql_table_entry.hpp
@@ -53,6 +53,14 @@ public:
 	// Required Overrides
 	//===----------------------------------------------------------------------===//
 
+	// Since duckdb 888cd17bee ("moving ColumnList ownership out of
+	// TableCatalogEntry and into DuckTableEntry") the base class no longer
+	// holds the column list: it declares GetColumns() pure virtual and its
+	// constructor takes nothing but the name, constraints and flags out of the
+	// CreateTableInfo it is handed. Every catalog entry now owns its own list,
+	// so this one does too — see columns_ below.
+	const ColumnList &GetColumns() const override;
+
 	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
 
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
@@ -112,6 +120,11 @@ public:
 	const mssql::PrimaryKeyInfo &GetPrimaryKeyInfo(ClientContext &context);
 
 private:
+	// The DuckDB-visible columns. Owned here since the base stopped owning
+	// them; GetInfo() and the whole binder read the table's shape through
+	// GetColumns(), so this is what makes the entry a table at all.
+	ColumnList columns_;
+
 	vector<MSSQLColumnInfo> mssql_columns_;	 // Column metadata with collation
 	MSSQLObjectType object_type_;			 // TABLE or VIEW
 	idx_t approx_row_count_;				 // Cardinality estimate


### PR DESCRIPTION
DuckDB cut **`v2.0-cyanoptera`** on 2026-09-03 as the stabilisation branch for v2.0 — the API track this repo already targets (spec 069). The submodule follows it now instead of `main`.

That is not a cosmetic choice. The two branches have diverged: **613 commits live on cyanoptera that `main` does not have**, going back to 2026-07-21, and `main` carries 13 that cyanoptera does not. Tracking `main` means tracking the branch where 2.0 is *not* being stabilised.

Pin moves `d7a4366603` → `070ce1f695` (**1679 commits**). The old pin is a strict ancestor, so this is a fast-forward within the same lineage, not a switch.

## What broke — both real API changes, neither churn

### 1. `ColumnList` ownership moved out of `TableCatalogEntry`

duckdb [`888cd17bee`](https://github.com/duckdb/duckdb/commit/888cd17bee) — *"moving ColumnList ownership out of TableCatalogEntry and into DuckTableEntry"*. `GetColumns()` is now `= 0`, and the base constructor no longer copies `info.columns` out of the `CreateTableInfo` it is handed:

```cpp
TableCatalogEntry::TableCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info)
    : StandardEntry(...), constraints(std::move(info.constraints)) { ... }   // no columns
```

`MSSQLTableEntry` was therefore abstract and the build stopped on `error: allocating an object of abstract class type`. It owns its own `ColumnList` now.

`MakeTableInfo` also **stops filling `info.columns`** — nothing reads them there any more, so populating the list would build every table's columns twice and leave a copy nobody looks at.

### 2. cpp-httplib now takes its roots from the macOS keychain

The bundled httplib enables `CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN` by itself for Apple + clang + OpenSSL, so `azure_http.cpp` pulls in `SecTrustSettingsCopyCertificates` and the CoreFoundation accessors. The extension failed to link:

```
Undefined symbols for architecture arm64:
  "_SecTrustSettingsCopyCertificates", referenced from:
      duckdb_httplib_openssl::tls::load_system_certs(void*) in azure_http.cpp.o
```

Both frameworks are linked on `APPLE`. Taking the keychain roots is the right side of that choice rather than setting `CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES`: **vcpkg's static OpenSSL ships no CA bundle**, so disabling the feature leaves Azure AD token acquisition verifying against an empty trust store.

### Also

Two `EntryLookupInfo(CatalogType, Identifier)` call sites move to the `QualifiedName` overload — duckdb deprecated the old one in the same window, and it was the only warning the bump produced. `QualifiedName(info.GetQualifiedName().Name())` rather than the whole qualified name, so the DROP SCHEMA lookup keeps exactly today's semantics.

`CLAUDE.md` and the `ci.yml` comment that both said the submodule tracks `branch = main` are updated.

## Verified

- **Clean build, zero warnings** (`GEN=ninja make`, macOS arm64).
- **SQL suite green against SQL Server 2025**: 175 passed, 8 skipped.
  The two failures on a 12-worker run were `Transaction (Process ID N) was deadlocked on lock resources` on *metadata* queries — parallel workers against a freshly-initialised database, not this change. Both pass run on their own (`preload_catalog.test`, `partitioned_table.test`).
- `clang-format-14` clean; `yamllint` clean under the ruleset CI uses.

## One thing this does NOT fix, and it is worth knowing

The `azure-test` job installs the azure extension from `extensions.duckdb.org/<source_id>/…`, which exists only for commits DuckDB's own extension CI published. **It 404s for this pin — and it 404s for the current pin too**:

```
070ce1f695: 404
d7a4366603: 404
```

So that lane was already broken before this PR and is not a regression from it. It is manual-dispatch only, so nothing here goes red. Worth its own issue: any pin that tracks a development branch will keep hitting this, and the job's own error text already predicts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz