### PR TITLE
docs(#224): mssql_scan hands back code-page bytes, and the docs promised an error it never raised

### DIFF
--- a/website/docs/reading/types.md
+++ b/website/docs/reading/types.md
@@ -30,6 +30,30 @@ sidebar_position: 3
 | `NCHAR(n)`        | `VARCHAR`      | UTF-16LE decoded             |
 | `NVARCHAR(n)`     | `VARCHAR`      | UTF-16LE decoded             |
 
+**Non-Unicode `CHAR` / `VARCHAR` carry a code page, and only the catalog casts it away.**
+`CHAR`, `VARCHAR` and `TEXT` hold bytes in the *column's* code page —
+`Latin1_General_CI_AS` is CP1252, `Cyrillic_General_CI_AS` is CP1251 — while
+DuckDB `VARCHAR` is UTF-8 by contract. A **catalog scan** rewrites those columns
+to `CAST(col AS NVARCHAR(...))` server-side, so three-part-name queries (and the
+`COPY` / `CREATE TABLE AS` that read through them) always get UTF-8. A raw
+`mssql_scan()` has no such rewrite: the bytes arrive unchanged, and for anything
+outside ASCII the result is **not valid UTF-8** — it is not rejected, it is
+stored and then mangled by whatever touches it (`upper('naïve')` → `'NA'`).
+
+Add the cast yourself in the T-SQL:
+
+```sql
+SELECT * FROM mssql_scan('db',
+    'SELECT id, CAST(name AS NVARCHAR(MAX)) AS name FROM dbo.customers');
+```
+
+`NVARCHAR(MAX)` rather than a fixed width: SQL Server does not raise on a
+narrowing character `CAST`, so `NVARCHAR(50)` would silently truncate. Columns
+with a UTF-8 collation (`..._UTF8`, SQL Server 2019+) need nothing — they are
+already UTF-8 — but note that the default collation of a SQL Server
+installation is *not* one of those. See
+[Troubleshooting](../reference/troubleshooting.md#raw-mssql_scan-does-not-transcode-code-pages).
+
 ### Binary Types
 
 | SQL Server Type   | DuckDB Type    | Notes                        |

--- a/website/docs/reference/troubleshooting.md
+++ b/website/docs/reference/troubleshooting.md
@@ -184,11 +184,34 @@ SELECT id, name FROM db.dbo.customers;
   legacy code page unless somebody chose otherwise.
 - **ASCII-only data**, in any code page: every byte is already valid UTF-8.
 
-Tracked as [issue #224](https://github.com/hugr-lab/mssql-extension/issues/224).
-Validating every value on read was considered and rejected: the check would sit
-on the scan's hot path, and it would be paid mostly by UTF-8 columns that cannot
-be affected. An explicit `CAST` in a query you wrote yourself is the cheaper
-contract.
+### Why this is not validated for you
+
+Tracked as [issue #224](https://github.com/hugr-lab/mssql-extension/issues/224),
+and deliberately answered with documentation rather than a runtime check.
+
+The obvious fix is to validate every value as it is decoded and raise on the
+first one that is not UTF-8. It was considered and rejected, because of where
+that check would have to live.
+
+**The string codec is built to avoid exactly that call.** Its ASCII fast path
+exists for one reason, recorded next to it in `codec/string_codec.hpp`: measured
+on 12-byte values, *a simdutf call costs ~3.1 ns of pure overhead* against *~3 ns
+of actual byte work* — the call is as expensive as the transcoding it performs.
+Adding validation to the read path puts one back, per value, and as a **second
+pass over bytes the decoder has already copied**. That is a real cost on every
+scan, paid in full by the UTF-8 and `NVARCHAR` columns that cannot be affected by
+this in the first place.
+
+**And it would be paid on the wrong path.** The catalog scan — three-part names,
+and the `COPY` / `CREATE TABLE AS` built on them — is the path that carries
+volume, and it is already safe here: it casts non-Unicode string columns
+server-side, so the bytes it decodes are Unicode by construction. `mssql_scan()`
+is the escape hatch for hand-written T-SQL. Slowing the main path to guard the
+escape hatch is the wrong trade.
+
+**What the escape hatch gets instead is this page.** Someone writing raw T-SQL is
+already choosing the exact columns and can add `CAST(col AS NVARCHAR(MAX))`; what
+they were missing was any statement that they had to. That is what changed.
 
 
 ### Unicode Transcoding (simdutf)

--- a/website/docs/reference/troubleshooting.md
+++ b/website/docs/reference/troubleshooting.md
@@ -123,15 +123,72 @@ SET mssql_convert_varchar_max = false;
 
 **Notes:**
 
-1. **Catalog queries only**: This conversion applies only to catalog-based queries (three-part naming like `db.schema.table`). When using `mssql_scan()` with raw SQL, you must manually add CAST expressions:
+1. **Catalog queries only**: This conversion applies only to catalog-based queries (three-part naming like `db.schema.table`). When using `mssql_scan()` with raw SQL, you must add the CAST yourself — see [Raw `mssql_scan()` does not transcode code pages](#raw-mssql_scan-does-not-transcode-code-pages) below for what happens if you do not.
 
 ```sql
--- Without CAST: may fail with UTF-8 validation error for extended ASCII
+-- No CAST: the raw code-page bytes are returned as-is. For a non-UTF8
+-- collation that is NOT valid UTF-8, and string functions will mangle it.
 FROM mssql_scan('db', 'SELECT name FROM dbo.customers');
 
--- With CAST: properly handles extended ASCII characters
-FROM mssql_scan('db', 'SELECT CAST(name AS NVARCHAR(100)) AS name FROM dbo.customers');
+-- With CAST: SQL Server transcodes to UTF-16 and the extension decodes it.
+FROM mssql_scan('db', 'SELECT CAST(name AS NVARCHAR(MAX)) AS name FROM dbo.customers');
 ```
+
+### Raw `mssql_scan()` does not transcode code pages
+
+**Symptom.** A string read through `mssql_scan()` looks right in the output but
+behaves as if it were truncated. The classic shape is a string function
+returning less than it was given:
+
+```sql
+SELECT upper(name) FROM mssql_scan('db', 'SELECT name FROM dbo.t');
+-- 'naïve' comes back as 'NA'
+```
+
+**Cause.** SQL Server's `CHAR` / `VARCHAR` / `TEXT` carry bytes in the
+**column's own code page** — `Latin1_General_CI_AS` is CP1252, `Cyrillic_General_CI_AS`
+is CP1251, and so on. DuckDB `VARCHAR` is UTF-8 by contract. The extension does
+not transcode legacy code pages: it hands those bytes to DuckDB unchanged, and
+for anything outside ASCII the result is not valid UTF-8. It is not rejected —
+it is stored, displayed, and then mangled by whatever touches it. `ï` in CP1252
+is the single byte `0xEF`, which UTF-8 reads as the start of a three-byte
+sequence, so `upper()` consumes the two bytes after it and returns `NA`.
+
+The transcoding SQL Server *will* do for you is a `CAST` to a Unicode type, and
+that is what the fix is.
+
+**Fix — one of:**
+
+```sql
+-- 1. CAST in the query. NVARCHAR(MAX), not NVARCHAR(n): SQL Server does not
+--    raise on a narrowing character CAST, so a fixed width silently truncates.
+SELECT * FROM mssql_scan('db',
+    'SELECT id, CAST(name AS NVARCHAR(MAX)) AS name FROM dbo.customers');
+
+-- 2. Read through the attached catalog instead, which adds that CAST for you.
+SELECT id, name FROM db.dbo.customers;
+```
+
+**When this cannot happen:**
+
+- **Catalog scans** (three-part names, and therefore `COPY`/`CREATE TABLE AS`
+  reading from them) — the generated `SELECT` casts every non-Unicode string
+  column server-side. The one exception is a declared `VARCHAR(MAX)` when
+  `mssql_convert_varchar_max = false`, which opts out of that cast on purpose.
+- **`NCHAR` / `NVARCHAR` / `NTEXT` / `XML`** — always UTF-16 on the wire,
+  always decoded.
+- **UTF-8 collations** (`..._UTF8`, SQL Server 2019 and later). Those columns
+  are already UTF-8, so the bytes are correct with or without a cast. Note that
+  the *default* collation of a SQL Server installation is not one of these —
+  `SQL_Latin1_General_CP1_CI_AS` is CP1252 — so a `varchar` column is in a
+  legacy code page unless somebody chose otherwise.
+- **ASCII-only data**, in any code page: every byte is already valid UTF-8.
+
+Tracked as [issue #224](https://github.com/hugr-lab/mssql-extension/issues/224).
+Validating every value on read was considered and rejected: the check would sit
+on the scan's hot path, and it would be paid mostly by UTF-8 columns that cannot
+be affected. An explicit `CAST` in a query you wrote yourself is the cheaper
+contract.
 
 
 ### Unicode Transcoding (simdutf)
@@ -154,6 +211,7 @@ The codec validates the input first and falls back to a slower scalar implementa
 ### Known Issues
 
 - Catalog scans auto-CAST server-specific types (`SQL_VARIANT`, `hierarchyid`, CLR UDTs) to `NVARCHAR(MAX)`, so three-part-name queries succeed; raw `mssql_scan()` needs an explicit CAST for such columns
+- Raw `mssql_scan()` returns non-Unicode `CHAR`/`VARCHAR`/`TEXT` bytes in the column's code page without transcoding them, so a non-ASCII value is not valid UTF-8 and string functions mangle it silently — add `CAST(col AS NVARCHAR(MAX))`, or read through the catalog. See [Raw `mssql_scan()` does not transcode code pages](#raw-mssql_scan-does-not-transcode-code-pages)
 - XML columns in INSERT/UPDATE are limited to 4096 bytes per value — use COPY TO with BCP protocol for larger documents
 - Very large DECIMAL values may lose precision at extreme scales
 - Connection pool statistics reset when all connections close


### PR DESCRIPTION
Closes the documentation half of #224. **No behaviour change.**

## The bug in the docs

`website/docs/reference/troubleshooting.md` told readers:

```sql
-- Without CAST: may fail with UTF-8 validation error for extended ASCII
FROM mssql_scan('db', 'SELECT name FROM dbo.customers');
```

It does not fail. It returns the column's **code-page bytes** into a DuckDB `VARCHAR`, which for anything outside ASCII is not valid UTF-8 — so the value is stored, displayed, and then mangled by whatever touches it:

```sql
SELECT upper(name) FROM mssql_scan('db', 'SELECT name FROM dbo.t');
-- 'naïve' -> 'NA'
```

CP1252's `ï` is the single byte `0xEF`, which UTF-8 reads as a three-byte lead, so `upper()` eats the two bytes after it.

A documented error that is never raised is worse than no documentation at all: a reader concludes the case is handled and stops looking.

## What the entry now says

The real behaviour, the fix, and **precisely where it cannot bite** — which turns out to be most places:

- **Catalog scans** rewrite every non-Unicode string column to `CAST(col AS NVARCHAR(...))` server-side, so three-part names — and the `COPY` / `CREATE TABLE AS` that read through them — are safe. The one exception is the one the setting already documents: a declared `VARCHAR(MAX)` under `mssql_convert_varchar_max = false`.
- **`NCHAR` / `NVARCHAR` / `NTEXT` / `XML`** are UTF-16 on the wire and always decoded.
- **UTF-8 collations** (`..._UTF8`, SQL Server 2019+) are already UTF-8. Worth saying out loud that the *default* collation of a SQL Server installation is **not** one of these — `SQL_Latin1_General_CP1_CI_AS` is CP1252 — so a `varchar` column is in a legacy code page unless somebody chose otherwise.
- **ASCII-only data** is valid UTF-8 in every code page.

The recommended cast is `NVARCHAR(MAX)`, not `NVARCHAR(n)`: SQL Server does not raise on a narrowing character `CAST`, so a fixed width truncates silently — the same trap the `VARCHAR(n > 4000)` note directly above it already records.

## Why documentation rather than a check

Stated in the entry itself, so the decision does not have to be rediscovered: validating every value on read would sit on the scan's hot path and be paid mostly by UTF-8 columns that cannot be affected, while the case it protects is a query the user wrote and can fix with one `CAST`. See the discussion on #305.

## Verified

- `scripts/ci/check_docs_links.py` clean.
- Anchor `#raw-mssql_scan-does-not-transcode-code-pages` is referenced from `reading/types.md` and from the Known Issues bullet; both are relative links, which is what the checker enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz