### PR TITLE
docs(fabric): the flag never disabled BCP, and Fabric supports bcp anyway

### DIFF
--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -147,7 +147,12 @@ struct MSSQLConnectionInfo {
 	//===----------------------------------------------------------------------===//
 	// Endpoint Type Flags (T040-T041: cached at ATTACH time for performance)
 	//===----------------------------------------------------------------------===//
-	bool is_fabric_endpoint = false;  // True if targeting Microsoft Fabric (no BCP/INSERT BULK support)
+	// True if targeting Microsoft Fabric. Read ONLY by
+	// MSSQLCatalog::RequiresSingleByteText(): Fabric has no `nvarchar`, so CTAS,
+	// COPY and the collation choice pick single-byte text there. It does not gate
+	// the bulk-load path — `bcp`, whose INSERT BULK protocol this extension
+	// speaks, is supported on Fabric as a preview feature.
+	bool is_fabric_endpoint = false;
 
 	// Issue #225: did the server grant the LOGIN7 UTF8SUPPORT feature? Observed by
 	// the ATTACH-time validation login, which happens on every non-lazy attach, so

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1612,11 +1612,25 @@ unique_ptr<Catalog> MSSQLAttach(optional_ptr<StorageExtensionInfo> storage_info,
 	// both of which read the (now resolved) host/port.
 	connection_info->ResolveNamedInstance(context);
 
-	// T040 (Bug 0.7): Cache endpoint type at ATTACH time for performance
-	// Fabric endpoints don't support BCP/INSERT BULK, need fallback to INSERT
+	// Cache the endpoint type at ATTACH time: the test is a host-name match and
+	// several paths ask repeatedly.
+	//
+	// This does NOT disable BCP, whatever this comment used to say. The flag's
+	// only consumer is MSSQLCatalog::RequiresSingleByteText(), which exists
+	// because Fabric Warehouse has no `nvarchar` type at all; through it the flag
+	// reaches the CTAS planner, COPY's target types and the collation choice, and
+	// nothing else. Grep src/copy/ for it and there is no hit — the bulk-load path
+	// has never tested it, so the "fallback to INSERT" it described did not exist.
+	//
+	// The claim was wrong about Fabric too, not merely unimplemented: `bcp` is
+	// supported there as a preview feature (Microsoft's "T-SQL surface area in
+	// Fabric Data Warehouse" lists BULK LOAD as unsupported and exempts `bcp`),
+	// and INSERT BULK is the protocol `bcp` itself speaks. Our own docs already
+	// implied the load runs: the Fabric known-issue says a `#temp` table cannot be
+	// a BCP TARGET there, which is a limit only a working load can reach.
 	connection_info->is_fabric_endpoint = connection_info->IsFabricEndpoint();
 	if (connection_info->is_fabric_endpoint) {
-		MSSQL_STORAGE_DEBUG_LOG(1, "Fabric endpoint detected: %s (BCP disabled, using INSERT fallback)",
+		MSSQL_STORAGE_DEBUG_LOG(1, "Fabric endpoint detected: %s (no nvarchar — single-byte text types)",
 								connection_info->host.c_str());
 	}
 


### PR DESCRIPTION
**Comment and log-message only. No behaviour change** — the behaviour was already right, which is the point.

## What the source claimed

`src/mssql_storage.cpp`, at the ATTACH-time endpoint check:

```cpp
// Fabric endpoints don't support BCP/INSERT BULK, need fallback to INSERT
connection_info->is_fabric_endpoint = connection_info->IsFabricEndpoint();
if (connection_info->is_fabric_endpoint) {
    MSSQL_STORAGE_DEBUG_LOG(1, "Fabric endpoint detected: %s (BCP disabled, using INSERT fallback)", ...);
}
```

and the header field: `// True if targeting Microsoft Fabric (no BCP/INSERT BULK support)`.

## None of it is true

`is_fabric_endpoint` has **exactly one consumer** — `MSSQLCatalog::RequiresSingleByteText()`, which exists because Fabric Warehouse has no `nvarchar`. Through it the flag reaches the CTAS planner (`mssql_ctas_planner.cpp:54`), COPY's target types (`copy_function.cpp:269`) and the collation choice (`mssql_catalog.cpp:945,989`). That is the whole list.

Grep `src/copy/` for it and **there is no hit**. The bulk-load path has never tested it, so the "fallback to INSERT" the comment advertised does not exist and never did.

## And the premise is out of date

`bcp` **is** supported on Fabric, as a preview feature. From Microsoft's [T-SQL surface area in Fabric Data Warehouse](https://learn.microsoft.com/en-us/fabric/data-warehouse/tsql-surface-area), under Limitations:

> `BULK LOAD`, though `bcp` is supported as a preview feature.

`INSERT BULK` is the protocol `bcp` itself speaks — it is what this extension implements. And our own troubleshooting page already implied the load runs there: it records that a `#temp` table cannot be a BCP **target** on Fabric, which is a limit only a working load can reach.

## Why it is worth a commit

Same defect class as the `#224` documentation fix (#307): a documented behaviour that does not exist, wrong in the direction that costs most. A reader deciding whether to trust `COPY ... TO` against Fabric would have concluded from the source that it silently degrades to row-by-row INSERT, and either avoided it or gone looking for a switch that is not there.

Found while checking `OBJECTPROPERTYEX`'s platform support for spec 071 (#309).

## Verified

- Build clean, `clang-format-14` clean.
- SQL suite **177 passed, 8 skipped** — unchanged, as expected for a comment change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz