### PR TITLE
fix(catalog): spec 071 — what catalog metadata actually costs

### DIFF
--- a/specs/071-catalog-metadata-cost/spec.md
+++ b/specs/071-catalog-metadata-cost/spec.md
@@ -1,0 +1,268 @@
+# Spec 071 — What catalog metadata actually costs
+
+**Status**: PROPOSED.
+**Closes**: [#86](https://github.com/hugr-lab/mssql-extension/issues/86) (`SHOW ALL TABLES` unusable on a database with many schemas).
+**Relates to**: PR #308 (the 1205 deadlock-victim retry — the reset callback that
+makes losing a deadlock recoverable). This spec attacks the same queries from the
+other side: W1 removes the resource that 7 of 8 captured deadlock cycles were
+fighting over, so the retry has far less to absorb.
+
+Four defects in the metadata layer, found by measuring rather than reading. They
+are independent, they land in ascending order of size, and three of them are the
+same root cause seen from different paths: **the `sys.partitions` aggregate that
+every catalog query carries, for a column nothing reads.**
+
+---
+
+## 0. How everything below was measured
+
+Reproduce before trusting. SQL Server **2025** (17.0.4075.5) in Docker — the 2022
+image crash-loops on Apple Silicon, see `docs/TESTING.md` — with a synthetic
+catalog in `TestDB`:
+
+```sql
+-- 200,000 tables x 6 columns, one schema `big`, plus an empty schema `empty1`
+CREATE TABLE big.tN (id INT, c1 VARCHAR(50), c2 INT, c3 DECIMAL(18,4),
+                     c4 DATETIME2(3), c5 NVARCHAR(100));
+```
+
+Resulting size: **200,000 tables / 1,200,000 columns / 200,230 rows in
+`sys.partitions`**. Creation ran at ~1 ms per table and did **not** degrade with
+catalog size (0.8 ms/table at 2K, 0.97 ms/table at 97K) — the write side of the
+catalog scales fine, which is why everything below is about reads.
+
+- **Wall clock**: `sqlcmd -i q.sql -o /dev/null` with `GO N` inside one session,
+  so connection setup is paid once. A `SELECT 1` script measured the same way is
+  subtracted as the baseline (~20.7 ms/rep here — it is `docker exec` plus
+  sqlcmd's own formatting, and it is large relative to the signal, which is why
+  the per-invocation form of this measurement is useless and was discarded).
+- **Server cost**: `SET STATISTICS TIME ON` (CPU ms) and `SET STATISTICS IO ON`
+  (logical reads per base table). These are the numbers that carry the argument;
+  wall clock is only corroboration.
+- Variants were run **interleaved** and repeated, never one-after-another —
+  three passes, and any effect that did not survive all three is reported as
+  noise below rather than as a result.
+
+---
+
+## 1. The findings
+
+### F1 — `sys.partitions` cannot be seeked, in any form
+
+All three metadata queries fetch `approx_rows` / `index_type` /
+`partition_count` from one uncorrelated subquery:
+
+```sql
+LEFT JOIN (SELECT p.object_id, SUM(p.[rows]) AS [rows],
+                  MAX(ISNULL(i.type, 0)) AS index_type, COUNT(*) AS partition_count
+           FROM sys.partitions p
+           LEFT JOIN sys.indexes i ON i.object_id = p.object_id AND i.index_id = p.index_id
+           WHERE p.index_id IN (0, 1)
+           GROUP BY p.object_id) p ON p.object_id = o.object_id
+```
+
+`sys.partitions` reads `sys.sysrowsets`, which is clustered on `rowsetid`;
+`object_id` is derived and has no index. Filtering by it changes nothing:
+
+| lookup by `object_id` | base table | logical reads |
+|---|---|---|
+| `sys.partitions` | `sysrowsets` | **3200** (2 scans) |
+| `sys.dm_db_partition_stats` | `sysrowsets` | **1600** (1 scan) |
+| `sys.indexes` | `sysidxstats` | **6** (seek) |
+
+So the row count is O(catalog) however it is asked for, and the index *shape* is
+O(1). They do not belong in the same subquery.
+
+### F2 — `partition_count` has no consumer
+
+`ParseTableShape` writes `MSSQLTableMetadata::partition_count` and **nothing ever
+reads it** — it is not even copied into `MSSQLTableEntry`. Spec 049 added it
+"which the write path needs: TABLOCK helps a heap and serialises a clustered
+rowstore index"; the write path never picked it up.
+
+It is not free. `COUNT(*)` per `object_id` is what forces the `GROUP BY` over
+`sysrowsets`, i.e. F1's scan exists to populate a dead field.
+
+### F3 — on the lazy path, `approx_row_count` is loaded and then bypassed
+
+`MSSQLTableEntry::GetStorageInfo` resolves cardinality as: statistics cache →
+**acquire a connection and query the DMV** → and only on "no connection" or an
+exception does it fall back to `approx_row_count_`. Meanwhile `PreloadRowCount`
+— the only thing that puts catalog-sourced counts *into* that cache — is called
+from `mssql_preload_catalog.cpp` and nowhere else.
+
+Two consequences:
+
+1. A lazy single-table load pays F1's 3200-read scan for a number
+   `GetStorageInfo` then declines to use.
+2. `SHOW ALL TABLES` / `duckdb_tables()` **without** a prior
+   `mssql_preload_catalog()` takes a pooled connection and runs a DMV query
+   **per table**. `CLAUDE.md` describes the exemption in
+   `mssql_statistics_cache_ttl_seconds` as protecting "a catalog that had just
+   loaded every count in one query" — on the lazy path that catalog never told
+   the cache anything.
+
+### F4 — per-schema discovery is O(objects in the database), not O(schema)
+
+This is issue #86, and it is not about the reporter's table count. An **empty**
+schema, in a database holding 200K objects:
+
+| | CPU | logical reads |
+|---|---|---|
+| current query | **2708 ms** | `sysschobjs` 3025, `sysidxstats` 1520, `sysrowsets` 4800, Workfile 2584 (spill) |
+| without the F1 aggregate | **362 ms** | `sysschobjs` 2570 |
+
+362 ms to return zero rows, because `sys.objects` applies metadata-visibility
+filtering per object in the database. It is not the predicate's fault — measured
+identical (2570 reads) for `SCHEMA_NAME(o.schema_id) = 'x'`, for
+`o.schema_id = SCHEMA_ID('x')`, for `sys.tables`, and with the `type` /
+`is_ms_shipped` filters removed. There is no seek path to buy.
+
+So N schemas cost N full passes over the catalog. The reporter's 10,000 schemas
+with **zero tables** extrapolate to **~7.5 hours** at the current query, which
+matches "30 minutes and still running". `mssql_preload_catalog()` was offered as
+the workaround and is built the same way — `BulkLoadAll` loops per schema — so it
+reduced the constant, not the exponent.
+
+The alternative is one query:
+
+| approach, 200K objects | cost |
+|---|---|
+| one query for **all** schemas (200,036 rows) | **1917 ms CPU** |
+| current, per schema | 2708 ms CPU **x number of schemas** |
+
+Break-even is under 5 schemas. There is no catalog size at which the present
+design wins.
+
+---
+
+## 2. The work
+
+### W1 — Take the row count out of the shape query
+
+Replace the `sys.partitions` subquery in all three templates
+(`TABLE_DISCOVERY`, `SINGLE_TABLE_METADATA`, `BULK_METADATA_SCHEMA`) with a
+seekable shape lookup:
+
+```sql
+OUTER APPLY (SELECT MAX(i.type) AS index_type,
+                    MAX(CASE WHEN ps.data_space_id IS NULL THEN 0 ELSE 1 END) AS is_partitioned
+             FROM sys.indexes i
+             LEFT JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
+             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) ix
+```
+
+- `index_kind` keeps its meaning and its source semantics (`sys.indexes.type`:
+  0 heap, 1 clustered rowstore, 5 clustered columnstore).
+- `partition_count` is **deleted** — from the SQL, from `MSSQLTableMetadata`, and
+  from `ParseTableShape` (F2). `is_partitioned` replaces it, which is what every
+  comment in the tree claims the field is for ("`partition_count > 1` marks a
+  partitioned object"). If a future caller genuinely needs the count, it is a
+  seekable lookup at that point rather than a tax on every metadata load.
+
+Measured, single table, 200K catalog: **18.1 ms → 0.7 ms net of baseline (26x)**,
+`sysrowsets` **3200 → 0** logical reads.
+
+Deadlock benefit, from the PR #308 investigation: `sysrowsets` was one of the two
+resources in **7 of 8** captured cycles. Removing it from the joined statement is
+what took index-DDL contention from **127/141/93 to 0/0/0** deadlocks per 150
+metadata queries, and table-DDL from **63/73/46 to 32/24/24**.
+
+### W2 — The single-table path stops fetching a row count at all
+
+`SINGLE_TABLE_METADATA` returns columns plus the W1 shape, and no `approx_rows`.
+The statistics provider already owns that number, has a cache and a TTL, and
+`GetStorageInfo` already prefers it (F3). `MSSQLTableMetadata::approx_row_count`
+stays for the paths that do load it; on this path it is simply not populated.
+
+Behavioural note to state in the PR: with no connection available,
+`GetStorageInfo`'s last-resort fallback now sees 0 instead of a catalog-loaded
+count. That path already means "we could not ask the server", and reporting
+nothing is what `mssql_enable_statistics` documents as correct when the count is
+unknown — see the setting's note that a VIEW reports 0 while returning millions,
+which is the failure mode a made-up number produces.
+
+### W3 — The listing path issues one query for every schema
+
+The change that closes #86.
+
+- `MSSQLTableSet::Scan` currently calls `LoadAllTableMetadata(connection, schema)`
+  and is invoked once per schema by DuckDB. `MSSQLTableSet::GetEntry` — the plain
+  `SELECT * FROM db.sch.tbl` path — goes to `GetTableMetadata` instead and is
+  **untouched**, so laziness for ordinary queries is preserved exactly.
+- On the first `Scan` (or first `BulkLoadAll`), run **one** query covering every
+  schema the filter admits, and populate the cache for all of them. Subsequent
+  per-schema `Scan` calls are cache hits.
+- **Drop the `ORDER BY`.** The per-schema loop exists because "each query sorts
+  only within one schema, keeping the result set small enough to avoid tempdb
+  spills" — but the current query spills anyway (Workfile 2584 reads above), and
+  a global sort over 1.2M rows would be worse. Group client-side into a hash map
+  keyed by `object_id` instead of relying on ordered arrival. This also removes
+  the streaming group-by's dependence on `current_table`, which is the state PR
+  #308's reset callback has to unwind.
+- `BulkLoadAll` collapses into the same single query, so
+  `mssql_preload_catalog()` stops being O(schemas x objects) too.
+
+10,000 schemas, 200K objects: **~7.5 hours → ~2 s** plus transfer.
+
+### W4 — Catalog-loaded counts reach the statistics cache
+
+Where a path does load counts (W3's whole-catalog query), call
+`PreloadRowCount` for each table, as `mssql_preload_catalog.cpp` already does.
+Without this, `SHOW ALL TABLES` takes a pooled connection and runs a DMV query
+per table (F3), each of which is itself a 1600-read scan of `sysrowsets`.
+
+---
+
+## 3. Dead ends — checked, and not to be re-proposed
+
+Each of these looked right and measured wrong. Recorded so the next person does
+not spend the afternoon.
+
+| idea | verdict |
+|---|---|
+| `READ UNCOMMITTED` / `NOLOCK` on catalog reads to dodge the deadlock | **Catalog reads ignore the session isolation level.** Wrapping the query in `REPEATABLE READ` + `BEGIN TRAN` and inspecting `sys.dm_tran_locks` afterwards leaves only a `DATABASE` S lock — the key locks were taken and released inside the scan regardless. It would also reintroduce the duplicate-row hazard on an allocation-order scan, which is the "Column with name x already exists!" class. |
+| `sys.dm_db_partition_stats` instead of `sys.partitions` | Still a full scan of `sysrowsets` (1600 vs 3200 reads). For the deadlock it reshuffles rather than removes: plan references to `sysrowsets` fall 30 → 10 but `sysidxstats` appears (12). |
+| Correlate the aggregate to the one object (`OUTER APPLY`) for the single-table query | No change: 38.8–41.6 ms, same as the uncorrelated form. F1 explains why. |
+| Split the aggregate into a second statement | Helps only a small catalog — **−42%** on 200 tables x 20 columns, where the three aggregate columns are otherwise repeated on every one of 4000 column rows. At 200K it is a wash (3109/2856 ms vs 2861/2793). W1 subsumes it. |
+| Materialise into `#temp` server-side, then stream from tempdb, to shorten the catalog-lock window | **+89%** (74.0 ms vs 39.2 net). Writing 4000 rows to tempdb and reading them back costs far more than the window it saves. (First measurement of this variant looked like a 96% *win* — because `SELECT INTO` was failing with Msg 1038 on unnamed columns and the timing was of a query that did nothing.) |
+| `o.schema_id = SCHEMA_ID('x')` instead of `SCHEMA_NAME(o.schema_id) = 'x'` | No effect. Identical 2570 logical reads, as do `sys.tables` and the form with `type`/`is_ms_shipped` removed. The scan is metadata-visibility filtering, not a sargability problem. |
+
+Two measurements from this investigation were **retracted** after repetition and
+should not be quoted from earlier notes: an `ALTER TABLE` deadlock rate of 22/33
+per 150 (did not reproduce — leftover churn sessions from the previous DDL kind
+were contaminating the run; it is 0/0/0 with sessions killed before each pass),
+and a `TRUNCATE` comparison (4–80 per 150 on identical conditions — too noisy for
+any conclusion).
+
+---
+
+## 4. Risks
+
+- **W3 changes when work happens, not how much.** A user who touches one schema
+  of a 10,000-schema catalog and never lists anything pays nothing extra: `Scan`
+  is the listing path, `GetEntry` is the query path. But a user who lists *one*
+  schema now loads all of them. At the measured break-even (<5 schemas) this is
+  cheaper in every case that has been measured; it should still be stated
+  plainly in the PR, and `schema_filter` remains the way to bound it.
+- **W3's result set is large** — 200K rows for 200K objects, and with columns it
+  is 1.2M. The hash-map grouping must not hold two copies; the parse should build
+  entries in place as rows arrive, as the current streaming group-by does.
+- **W1 changes `DESCRIBE`-visible nothing** but does change `MSSQLTableMetadata`.
+  `partition_count` removal is a struct change; confirm no serialization depends
+  on it.
+- **W2 is a behaviour change in one corner**: cardinality when no connection can
+  be acquired. Small, and stated above.
+
+## 5. Acceptance
+
+1. Single-table metadata against a 200K-table catalog: **zero** logical reads on
+   `sysrowsets`, and net query time within noise of the columns-only query
+   (≈0.7 ms vs the current 18.1 ms).
+2. An empty schema's discovery costs no more than the fixed catalog pass
+   (≈362 ms at 200K objects, from 2708 ms).
+3. `SHOW ALL TABLES` over N schemas issues **one** metadata query, not N.
+4. `SHOW ALL TABLES` acquires no per-table connection for row counts (W4).
+5. `partition_count` appears nowhere in `src/`.
+6. The SQL suite stays green, and the 12-worker `make test` deadlock rate does
+   not regress from PR #308's baseline (four consecutive runs, 177 passed).

--- a/specs/071-catalog-metadata-cost/spec.md
+++ b/specs/071-catalog-metadata-cost/spec.md
@@ -1,16 +1,19 @@
 # Spec 071 — What catalog metadata actually costs
 
-**Status**: PROPOSED.
+**Status**: PROPOSED. Implementation in progress.
 **Closes**: [#86](https://github.com/hugr-lab/mssql-extension/issues/86) (`SHOW ALL TABLES` unusable on a database with many schemas).
-**Relates to**: PR #308 (the 1205 deadlock-victim retry — the reset callback that
-makes losing a deadlock recoverable). This spec attacks the same queries from the
-other side: W1 removes the resource that 7 of 8 captured deadlock cycles were
-fighting over, so the retry has far less to absorb.
+**Relates to**: PR #308 (the 1205 deadlock-victim retry). This spec attacks the same
+queries from the other side: W1 removes the resource that 7 of 8 captured deadlock
+cycles were fighting over, so the retry has far less to absorb.
 
-Four defects in the metadata layer, found by measuring rather than reading. They
-are independent, they land in ascending order of size, and three of them are the
-same root cause seen from different paths: **the `sys.partitions` aggregate that
-every catalog query carries, for a column nothing reads.**
+Two defects in the metadata layer, found by measuring rather than reading. They
+share a cause: **the `sys.partitions` aggregate every catalog query carries.**
+
+> **Revision note.** This spec was rewritten after measurement killed most of its
+> first draft, including two of its own proposals and a claim about the code. §5
+> keeps every dead end with its numbers, because the value of this investigation
+> is as much in what does not work as in what does. Nothing in §2 is a design
+> preference; each line is what survived a measurement.
 
 ---
 
@@ -21,57 +24,56 @@ image crash-loops on Apple Silicon, see `docs/TESTING.md` — with a synthetic
 catalog in `TestDB`:
 
 ```sql
--- 200,000 tables x 6 columns, one schema `big`, plus an empty schema `empty1`
+-- 200,000 tables x 6 columns in schema `big`, plus an empty schema `empty1`
 CREATE TABLE big.tN (id INT, c1 VARCHAR(50), c2 INT, c3 DECIMAL(18,4),
                      c4 DATETIME2(3), c5 NVARCHAR(100));
 ```
 
-Resulting size: **200,000 tables / 1,200,000 columns / 200,230 rows in
-`sys.partitions`**. Creation ran at ~1 ms per table and did **not** degrade with
-catalog size (0.8 ms/table at 2K, 0.97 ms/table at 97K) — the write side of the
-catalog scales fine, which is why everything below is about reads.
+**200,000 tables / 1,200,000 columns / 200,230 rows in `sys.partitions`.** Creation
+ran at ~1 ms per table and did **not** degrade with catalog size (0.8 ms/table at
+2K, 0.97 ms/table at 97K) — the write side scales fine, which is why everything
+below is about reads.
 
-- **Wall clock**: `sqlcmd -i q.sql -o /dev/null` with `GO N` inside one session,
-  so connection setup is paid once. A `SELECT 1` script measured the same way is
-  subtracted as the baseline (~20.7 ms/rep here — it is `docker exec` plus
-  sqlcmd's own formatting, and it is large relative to the signal, which is why
-  the per-invocation form of this measurement is useless and was discarded).
 - **Server cost**: `SET STATISTICS TIME ON` (CPU ms) and `SET STATISTICS IO ON`
-  (logical reads per base table). These are the numbers that carry the argument;
-  wall clock is only corroboration.
-- Variants were run **interleaved** and repeated, never one-after-another —
-  three passes, and any effect that did not survive all three is reported as
-  noise below rather than as a result.
+  (logical reads per base table). These carry the argument.
+- **Wall clock**: `sqlcmd -i q.sql -o /dev/null` with `GO N` **inside one
+  session**, minus a `SELECT 1` baseline measured the same way. The
+  per-invocation form is useless here: `docker exec` plus sqlcmd startup costs
+  ~330 ms and buries a 40 ms signal.
+- **End-to-end**: two statically-linked builds differing only in the change under
+  test, each run in a **fresh process**, `ATTACH` + query, interleaved.
+- Variants interleaved and repeated. Anything that did not survive repetition is
+  reported in §5 as retracted, not as a result.
 
 ---
 
 ## 1. The findings
 
-### F1 — `sys.partitions` cannot be seeked, in any form
+### F1 — `sys.partitions` cannot be seeked by `object_id`, and the row count does not need it
 
 All three metadata queries fetch `approx_rows` / `index_type` /
-`partition_count` from one uncorrelated subquery:
+`partition_count` from one uncorrelated subquery over `sys.partitions`. That view
+reads `sys.sysrowsets`, which is clustered on `rowsetid`; `object_id` is derived
+and has no index, so filtering by it buys nothing:
 
-```sql
-LEFT JOIN (SELECT p.object_id, SUM(p.[rows]) AS [rows],
-                  MAX(ISNULL(i.type, 0)) AS index_type, COUNT(*) AS partition_count
-           FROM sys.partitions p
-           LEFT JOIN sys.indexes i ON i.object_id = p.object_id AND i.index_id = p.index_id
-           WHERE p.index_id IN (0, 1)
-           GROUP BY p.object_id) p ON p.object_id = o.object_id
-```
+| row count for ONE object | base table touched | logical reads | CPU |
+|---|---|---|---|
+| `sys.partitions` | `sysrowsets` | **3200** (2 scans) | 18 ms |
+| `sys.dm_db_partition_stats` | `sysrowsets` | **1601** (1 scan) | 54 ms |
+| `sys.sysindexes` | `sysidxstats` + `sysschobjs` | 6 | 1 ms |
+| `sys.dm_db_stats_properties` | `sysidxstats` + `sysobjvalues` | ~17 | 1 ms |
+| **`OBJECTPROPERTYEX(id, 'Cardinality')`** | `sysschobjs` | **3** | **0 ms** |
 
-`sys.partitions` reads `sys.sysrowsets`, which is clustered on `rowsetid`;
-`object_id` is derived and has no index. Filtering by it changes nothing:
+`OBJECTPROPERTYEX` answers out of object metadata. Verified to agree with
+`sys.partitions` **exactly** — 5000/5000, 150000/150000, 0/0 for an empty table,
+and `NULL` for a VIEW, which maps to the same 0 the catalog already carried for a
+view. It needs no statistics to exist on the table, and it is not deprecated.
 
-| lookup by `object_id` | base table | logical reads |
-|---|---|---|
-| `sys.partitions` | `sysrowsets` | **3200** (2 scans) |
-| `sys.dm_db_partition_stats` | `sysrowsets` | **1600** (1 scan) |
-| `sys.indexes` | `sysidxstats` | **6** (seek) |
+Fetching **every** row count in the database: **84 ms**, against **2400 ms**
+through either `sys.partitions` or `sys.dm_db_partition_stats`.
 
-So the row count is O(catalog) however it is asked for, and the index *shape* is
-O(1). They do not belong in the same subquery.
+The shape half splits the same way: `sys.indexes` **seeks** (6 logical reads),
+while `sys.partitions` cannot. The two had no business sharing a subquery.
 
 ### F2 — `partition_count` has no consumer
 
@@ -80,29 +82,10 @@ reads it** — it is not even copied into `MSSQLTableEntry`. Spec 049 added it
 "which the write path needs: TABLOCK helps a heap and serialises a clustered
 rowstore index"; the write path never picked it up.
 
-It is not free. `COUNT(*)` per `object_id` is what forces the `GROUP BY` over
-`sysrowsets`, i.e. F1's scan exists to populate a dead field.
+It is not free: `COUNT(*)` per `object_id` is what forces the `GROUP BY` over
+`sysrowsets`. The scan exists to populate a dead field.
 
-### F3 — on the lazy path, `approx_row_count` is loaded and then bypassed
-
-`MSSQLTableEntry::GetStorageInfo` resolves cardinality as: statistics cache →
-**acquire a connection and query the DMV** → and only on "no connection" or an
-exception does it fall back to `approx_row_count_`. Meanwhile `PreloadRowCount`
-— the only thing that puts catalog-sourced counts *into* that cache — is called
-from `mssql_preload_catalog.cpp` and nowhere else.
-
-Two consequences:
-
-1. A lazy single-table load pays F1's 3200-read scan for a number
-   `GetStorageInfo` then declines to use.
-2. `SHOW ALL TABLES` / `duckdb_tables()` **without** a prior
-   `mssql_preload_catalog()` takes a pooled connection and runs a DMV query
-   **per table**. `CLAUDE.md` describes the exemption in
-   `mssql_statistics_cache_ttl_seconds` as protecting "a catalog that had just
-   loaded every count in one query" — on the lazy path that catalog never told
-   the cache anything.
-
-### F4 — per-schema discovery is O(objects in the database), not O(schema)
+### F3 — per-schema discovery is O(objects in the database), not O(schema)
 
 This is issue #86, and it is not about the reporter's table count. An **empty**
 schema, in a database holding 200K objects:
@@ -110,84 +93,81 @@ schema, in a database holding 200K objects:
 | | CPU | logical reads |
 |---|---|---|
 | current query | **2708 ms** | `sysschobjs` 3025, `sysidxstats` 1520, `sysrowsets` 4800, Workfile 2584 (spill) |
-| without the F1 aggregate | **362 ms** | `sysschobjs` 2570 |
+| with F1 applied — count and shape both seekable | **484 ms** | no `sysrowsets` |
+| for reference, with no count at all | 362 ms | `sysschobjs` 2570 |
 
-362 ms to return zero rows, because `sys.objects` applies metadata-visibility
-filtering per object in the database. It is not the predicate's fault — measured
+484 ms to return zero rows, because `sys.objects` applies metadata-visibility
+filtering per object in the database. Not the predicate's fault: measured
 identical (2570 reads) for `SCHEMA_NAME(o.schema_id) = 'x'`, for
 `o.schema_id = SCHEMA_ID('x')`, for `sys.tables`, and with the `type` /
-`is_ms_shipped` filters removed. There is no seek path to buy.
+`is_ms_shipped` filters removed. There is no seek to buy.
 
-So N schemas cost N full passes over the catalog. The reporter's 10,000 schemas
-with **zero tables** extrapolate to **~7.5 hours** at the current query, which
-matches "30 minutes and still running". `mssql_preload_catalog()` was offered as
-the workaround and is built the same way — `BulkLoadAll` loops per schema — so it
-reduced the constant, not the exponent.
+So N schemas cost N passes over the catalog. The reporter's 10,000 schemas with
+**zero tables** extrapolate to **~7.5 hours** at the current query, which matches
+"30 minutes and still running"; at 484 ms they come to ~80 minutes, and the
+remaining fix is to stop issuing one query per schema (W2).
 
-The alternative is one query:
+Note the last row: dropping the count entirely would save a further 122 ms per
+schema. It is **not** worth it — see §3.
 
-| approach, 200K objects | cost |
-|---|---|
-| one query for **all** schemas (200,036 rows) | **1917 ms CPU** |
-| current, per schema | 2708 ms CPU **x number of schemas** |
-
-Break-even is under 5 schemas. There is no catalog size at which the present
-design wins.
+**And there is no per-schema seek to buy.** `sysschobjs` carries a nonclustered
+index on `(nsid, name)`, so the obvious hope is to make the schema predicate
+select it. Measured: it never does. `sys.objects`, `sys.tables` and
+`INFORMATION_SCHEMA.TABLES` all plan as a **Clustered Index Scan on
+`sysschobjs.clst`**, with a literal `nsid = 1` as much as with `SCHEMA_ID()` or
+`SCHEMA_NAME()` — the predicate is pushed into the scan, not turned into a seek,
+because the query needs `type` / `nsclass` / `pclass`, which that index does not
+cover. So the fixed catalog pass is a floor per statement, and the only lever left
+is to issue **one statement instead of N**. That is W2, and it is the whole
+remedy for the per-schema half of #86.
 
 ---
 
 ## 2. The work
 
-### W1 — Take the row count out of the shape query
+### W1 — Seekable sources for both halves of the shape query
 
-Replace the `sys.partitions` subquery in all three templates
-(`TABLE_DISCOVERY`, `SINGLE_TABLE_METADATA`, `BULK_METADATA_SCHEMA`) with a
-seekable shape lookup:
+In all three templates (`TABLE_DISCOVERY`, `SINGLE_TABLE_METADATA`,
+`BULK_METADATA_SCHEMA`), replace the `sys.partitions` aggregate with:
 
 ```sql
+    CAST(ISNULL(OBJECTPROPERTYEX(o.object_id, 'Cardinality'), 0) AS BIGINT) AS approx_rows,
+    ...
 OUTER APPLY (SELECT MAX(i.type) AS index_type,
                     MAX(CASE WHEN ps.data_space_id IS NULL THEN 0 ELSE 1 END) AS is_partitioned
              FROM sys.indexes i
              LEFT JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
-             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) ix
+             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) shape
 ```
 
+- `approx_rows` keeps its meaning and its exact values; only its source changes.
 - `index_kind` keeps its meaning and its source semantics (`sys.indexes.type`:
   0 heap, 1 clustered rowstore, 5 clustered columnstore).
 - `partition_count` is **deleted** — from the SQL, from `MSSQLTableMetadata`, and
   from `ParseTableShape` (F2). `is_partitioned` replaces it, which is what every
-  comment in the tree claims the field is for ("`partition_count > 1` marks a
-  partitioned object"). If a future caller genuinely needs the count, it is a
-  seekable lookup at that point rather than a tax on every metadata load.
+  comment in the tree already claimed the field meant ("`> 1` marks a partitioned
+  object"). A caller that genuinely needs the count can seek it at that point
+  instead of taxing every metadata load.
 
-Measured, single table, 200K catalog: **18.1 ms → 0.7 ms net of baseline (26x)**,
-`sysrowsets` **3200 → 0** logical reads.
+Measured at 200K tables: single-table metadata **18.1 ms → ~1 ms**;
+empty-schema discovery **2708 ms → 484 ms**; all row counts in the database
+**2400 ms → 84 ms**. `sysrowsets` logical reads on the single-table path:
+**3200 → 0**.
 
-Deadlock benefit, from the PR #308 investigation: `sysrowsets` was one of the two
-resources in **7 of 8** captured cycles. Removing it from the joined statement is
-what took index-DDL contention from **127/141/93 to 0/0/0** deadlocks per 150
-metadata queries, and table-DDL from **63/73/46 to 32/24/24**.
+Deadlock benefit, from PR #308's investigation: `sysrowsets` was one of the two
+resources in **7 of 8** captured cycles. Removing it from the joined statement
+took index-DDL contention from **127/141/93 to 0/0/0** deadlocks per 150 metadata
+queries (3 reps), and table-DDL from **63/73/46 to 32/24/24**.
 
-### W2 — The single-table path stops fetching a row count at all
+**Nothing is lost.** Counts stay, the planner's cardinality stays, behaviour is
+unchanged. Only the dead field and the scan go.
 
-`SINGLE_TABLE_METADATA` returns columns plus the W1 shape, and no `approx_rows`.
-The statistics provider already owns that number, has a cache and a TTL, and
-`GetStorageInfo` already prefers it (F3). `MSSQLTableMetadata::approx_row_count`
-stays for the paths that do load it; on this path it is simply not populated.
+### W2 — The listing path issues one query for every schema
 
-Behavioural note to state in the PR: with no connection available,
-`GetStorageInfo`'s last-resort fallback now sees 0 instead of a catalog-loaded
-count. That path already means "we could not ask the server", and reporting
-nothing is what `mssql_enable_statistics` documents as correct when the count is
-unknown — see the setting's note that a VIEW reports 0 while returning millions,
-which is the failure mode a made-up number produces.
+The remaining half of #86, and the larger change.
 
-### W3 — The listing path issues one query for every schema
-
-The change that closes #86.
-
-- `MSSQLTableSet::Scan` currently calls `LoadAllTableMetadata(connection, schema)`
-  and is invoked once per schema by DuckDB. `MSSQLTableSet::GetEntry` — the plain
+- `MSSQLTableSet::Scan` calls `LoadAllTableMetadata(connection, schema)` and is
+  invoked once per schema by DuckDB. `MSSQLTableSet::GetEntry` — the plain
   `SELECT * FROM db.sch.tbl` path — goes to `GetTableMetadata` instead and is
   **untouched**, so laziness for ordinary queries is preserved exactly.
 - On the first `Scan` (or first `BulkLoadAll`), run **one** query covering every
@@ -197,72 +177,90 @@ The change that closes #86.
   only within one schema, keeping the result set small enough to avoid tempdb
   spills" — but the current query spills anyway (Workfile 2584 reads above), and
   a global sort over 1.2M rows would be worse. Group client-side into a hash map
-  keyed by `object_id` instead of relying on ordered arrival. This also removes
-  the streaming group-by's dependence on `current_table`, which is the state PR
-  #308's reset callback has to unwind.
+  keyed by `object_id` instead of relying on ordered arrival. This also retires
+  the streaming group-by's `current_table` cursor, which is the fiddliest state
+  PR #308's reset callback has to unwind.
 - `BulkLoadAll` collapses into the same single query, so
-  `mssql_preload_catalog()` stops being O(schemas x objects) too.
+  `mssql_preload_catalog()` stops being O(schemas x objects) too — which is why
+  recommending it as the workaround on #86 lowered the constant, not the exponent.
 
-10,000 schemas, 200K objects: **~7.5 hours → ~2 s** plus transfer.
-
-### W4 — Catalog-loaded counts reach the statistics cache
-
-Where a path does load counts (W3's whole-catalog query), call
-`PreloadRowCount` for each table, as `mssql_preload_catalog.cpp` already does.
-Without this, `SHOW ALL TABLES` takes a pooled connection and runs a DMV query
-per table (F3), each of which is itself a 1600-read scan of `sysrowsets`.
+One query for all schemas measured **1917 ms** against 200K objects, versus
+484 ms **per schema** after W1. Break-even is under five schemas; there is no
+catalog size at which one-query-per-schema wins.
 
 ---
 
-## 3. Dead ends — checked, and not to be re-proposed
+## 3. What this spec no longer proposes
 
-Each of these looked right and measured wrong. Recorded so the next person does
-not spend the afternoon.
+The first draft had two further workstreams. Both are withdrawn, and the reasons
+are worth keeping.
 
-| idea | verdict |
-|---|---|
-| `READ UNCOMMITTED` / `NOLOCK` on catalog reads to dodge the deadlock | **Catalog reads ignore the session isolation level.** Wrapping the query in `REPEATABLE READ` + `BEGIN TRAN` and inspecting `sys.dm_tran_locks` afterwards leaves only a `DATABASE` S lock — the key locks were taken and released inside the scan regardless. It would also reintroduce the duplicate-row hazard on an allocation-order scan, which is the "Column with name x already exists!" class. |
-| `sys.dm_db_partition_stats` instead of `sys.partitions` | Still a full scan of `sysrowsets` (1600 vs 3200 reads). For the deadlock it reshuffles rather than removes: plan references to `sysrowsets` fall 30 → 10 but `sysidxstats` appears (12). |
-| Correlate the aggregate to the one object (`OUTER APPLY`) for the single-table query | No change: 38.8–41.6 ms, same as the uncorrelated form. F1 explains why. |
-| Split the aggregate into a second statement | Helps only a small catalog — **−42%** on 200 tables x 20 columns, where the three aggregate columns are otherwise repeated on every one of 4000 column rows. At 200K it is a wash (3109/2856 ms vs 2861/2793). W1 subsumes it. |
-| Materialise into `#temp` server-side, then stream from tempdb, to shorten the catalog-lock window | **+89%** (74.0 ms vs 39.2 net). Writing 4000 rows to tempdb and reading them back costs far more than the window it saves. (First measurement of this variant looked like a 96% *win* — because `SELECT INTO` was failing with Msg 1038 on unnamed columns and the timing was of a query that did nothing.) |
-| `o.schema_id = SCHEMA_ID('x')` instead of `SCHEMA_NAME(o.schema_id) = 'x'` | No effect. Identical 2570 logical reads, as do `sys.tables` and the form with `type`/`is_ms_shipped` removed. The scan is metadata-visibility filtering, not a sargability problem. |
-
-Two measurements from this investigation were **retracted** after repetition and
-should not be quoted from earlier notes: an `ALTER TABLE` deadlock rate of 22/33
-per 150 (did not reproduce — leftover churn sessions from the previous DDL kind
-were contaminating the run; it is 0/0/0 with sessions killed before each pass),
-and a `TRUNCATE` comparison (4–80 per 150 on identical conditions — too noisy for
-any conclusion).
+- **"The single-table path stops fetching a row count."** Withdrawn: it is what
+  gives the planner its cardinality — `MSSQLCatalogScanCardinality` reads the
+  catalog's copy *first* — and `test/sql/catalog/scan_cardinality.test` catches
+  the loss (`~1 row` instead of `~200000`). W1 makes the count cheap instead,
+  which was the better answer all along.
+- **"Feed catalog-loaded counts to `PreloadRowCount`."** Withdrawn as **already
+  implemented**: `MSSQLTableSet::Scan` calls it for every table
+  (`mssql_table_set.cpp:179`). The first draft asserted the only caller was
+  `mssql_preload_catalog.cpp`; that was a truncated `grep`, and the conclusion
+  drawn from it — that `SHOW ALL TABLES` runs a DMV query per table — was wrong.
 
 ---
 
 ## 4. Risks
 
-- **W3 changes when work happens, not how much.** A user who touches one schema
+- **`OBJECTPROPERTYEX` availability.** Standard T-SQL metadata function, present
+  on SQL Server and Azure SQL Database. **Microsoft Fabric Warehouse is not
+  verified here** and is a supported target — worth a check before merge. The
+  fallback is mechanical (`ISNULL(..., 0)` already yields "unknown", which the
+  cardinality callback handles as "no estimate").
+- **W2 changes when work happens, not how much.** A user who touches one schema
   of a 10,000-schema catalog and never lists anything pays nothing extra: `Scan`
-  is the listing path, `GetEntry` is the query path. But a user who lists *one*
-  schema now loads all of them. At the measured break-even (<5 schemas) this is
-  cheaper in every case that has been measured; it should still be stated
+  is the listing path, `GetEntry` is the query path. A user who lists *one* schema
+  now loads all of them — cheaper in every measured case, but it should be stated
   plainly in the PR, and `schema_filter` remains the way to bound it.
-- **W3's result set is large** — 200K rows for 200K objects, and with columns it
-  is 1.2M. The hash-map grouping must not hold two copies; the parse should build
-  entries in place as rows arrive, as the current streaming group-by does.
-- **W1 changes `DESCRIBE`-visible nothing** but does change `MSSQLTableMetadata`.
-  `partition_count` removal is a struct change; confirm no serialization depends
-  on it.
-- **W2 is a behaviour change in one corner**: cardinality when no connection can
-  be acquired. Small, and stated above.
+- **W2's result set is large** — 1.2M rows for 200K objects with columns. The
+  hash-map grouping must build entries in place as rows arrive, as the current
+  streaming group-by does, and must not hold two copies.
+- **`partition_count` removal is a struct change.** Confirm no serialization
+  depends on it.
 
-## 5. Acceptance
+## 5. Dead ends — measured, and not to be re-proposed
+
+Each looked right. Recorded so the next person does not spend the afternoon.
+
+| idea | verdict |
+|---|---|
+| `READ UNCOMMITTED` / `NOLOCK` on catalog reads, to dodge the deadlock | **Catalog reads ignore the session isolation level.** Wrapping the query in `REPEATABLE READ` + `BEGIN TRAN` and inspecting `sys.dm_tran_locks` afterwards leaves only a `DATABASE` S lock — the key locks were taken and released inside the scan regardless. It would also reintroduce the duplicate-row hazard on an allocation-order scan, which is the "Column with name x already exists!" class. |
+| `sys.dm_db_partition_stats` instead of `sys.partitions` | **Still a full scan** of `sysrowsets` (1601 reads / 54 ms vs 3200 / 18 ms — fewer reads, *more* CPU). For the deadlock it reshuffles rather than removes: plan references to `sysrowsets` fall 30 → 10 but `sysidxstats` appears (12). |
+| Correlate the aggregate to the one object (`OUTER APPLY`) | No change: 38.8–41.6 ms, same as the uncorrelated form. F1 explains why. |
+| Split the aggregate into a second statement | Helps only a small catalog — **−42%** at 200 tables x 20 columns, where the three aggregate columns are otherwise repeated on every one of 4000 column rows. At 200K it is a wash (3109/2856 ms vs 2861/2793). W1 subsumes it. |
+| Materialise into `#temp` server-side, then stream from tempdb, to shorten the catalog-lock window | **+89%** (74.0 ms vs 39.2 net). Writing 4000 rows to tempdb and reading them back costs far more than the window it saves. Its *first* measurement showed a 96% **win** — because `SELECT INTO` was failing with Msg 1038 on unnamed columns and the timing was of a query that did nothing. |
+| `o.schema_id = SCHEMA_ID('x')` instead of `SCHEMA_NAME(o.schema_id) = 'x'` | No effect. Identical 2570 logical reads, as do `sys.tables` and the form with `type`/`is_ms_shipped` removed. The scan is metadata-visibility filtering, not a sargability problem. |
+| Load **all** row counts once into the statistics cache, so metadata queries need none | **2400 ms** at 200K, and restricting it to one small schema barely helps (2105 ms) — the DMV enumerates the catalog either way, and the cost is the *scan*, not the transfer (rows discarded server-side: 2361 ms). Break-even against a per-table count is ~120 tables. W1 makes the per-table count 3 reads, which ends the question. |
+| `sys.sysindexes` for the row count | Genuinely cheap (6 reads / 1 ms per table, 82 ms for all 200K) and exact. **Rejected as deprecated** — it is documented for removal and its availability on Azure SQL / Fabric is not something to build on. |
+| `sys.dm_db_stats_properties` for the row count | Cheap (~17 reads / 1 ms) and supported, but **returns NULL for a table with no statistics** — verified on a 5000-row heap with zero statistics objects, which is exactly a table this extension has just created by CTAS or COPY. |
+
+**Retracted measurements** from this investigation, which did not survive
+repetition and should not be quoted from earlier notes: an `ALTER TABLE` deadlock
+rate of 22/33 per 150 (churn sessions from the previous DDL kind were still
+running; it is 0/0/0 with sessions killed *before* each pass), and a `TRUNCATE`
+comparison (4–80 per 150 on identical conditions).
+
+**End-to-end note.** At cold start the W1 saving is invisible for a single table
+— `ATTACH` dominates at ~650 ms, and 18 ms hides inside it. Across 20 tables in
+one session it is plain: 692/722 ms against 1092/1126 ms. The saving is per
+distinct table touched, and #86's cost is per schema, not per query.
+
+## 6. Acceptance
 
 1. Single-table metadata against a 200K-table catalog: **zero** logical reads on
-   `sysrowsets`, and net query time within noise of the columns-only query
-   (≈0.7 ms vs the current 18.1 ms).
+   `sysrowsets`, and net query time within noise of the columns-only query.
 2. An empty schema's discovery costs no more than the fixed catalog pass
-   (≈362 ms at 200K objects, from 2708 ms).
-3. `SHOW ALL TABLES` over N schemas issues **one** metadata query, not N.
-4. `SHOW ALL TABLES` acquires no per-table connection for row counts (W4).
+   (≈484 ms at 200K objects, from 2708 ms).
+3. `scan_cardinality.test` still passes — the planner still sees the row count.
+4. `SHOW ALL TABLES` over N schemas issues **one** metadata query, not N (W2).
 5. `partition_count` appears nowhere in `src/`.
 6. The SQL suite stays green, and the 12-worker `make test` deadlock rate does
    not regress from PR #308's baseline (four consecutive runs, 177 passed).

--- a/specs/071-catalog-metadata-cost/spec.md
+++ b/specs/071-catalog-metadata-cost/spec.md
@@ -210,11 +210,32 @@ are worth keeping.
 
 ## 4. Risks
 
-- **`OBJECTPROPERTYEX` availability.** Standard T-SQL metadata function, present
-  on SQL Server and Azure SQL Database. **Microsoft Fabric Warehouse is not
-  verified here** and is a supported target — worth a check before merge. The
-  fallback is mechanical (`ISNULL(..., 0)` already yields "unknown", which the
-  cardinality callback handles as "no estimate").
+- **`OBJECTPROPERTYEX` availability — checked against the documentation, and it
+  covers every target.** Its *Applies to* list is SQL Server, Azure SQL Database,
+  Azure SQL Managed Instance, **Azure Synapse Analytics**, Analytics Platform
+  System (PDW), **SQL analytics endpoint in Microsoft Fabric**, **Warehouse in
+  Microsoft Fabric** and **SQL database in Microsoft Fabric** — the page's own
+  monikers include `fabric`, `fabric-sqldb` (the preview surface),
+  `azure-sqldw-latest` and `aps-pdw-2016`. The `Cardinality` property is marked
+  "SQL Server 2012 (11.x) and later", an engine-version bound rather than a
+  platform one. Fabric's *T-SQL surface area* page, which enumerates what is
+  **not** supported, does not list `OBJECTPROPERTYEX`, `OBJECTPROPERTY`,
+  `sys.partitions`, `sys.indexes` or `sys.partition_schemes`.
+
+  Not verified by execution on Fabric or Synapse — no access — so what matters is
+  that the failure mode is benign: `ISNULL(..., 0)` yields 0, which
+  `MSSQLCatalogScanCardinality` already treats as "unknown" and answers with no
+  estimate. That is the same path a VIEW takes today. The documentation adds a
+  second, more likely route to it: `OBJECTPROPERTYEX` returns `NULL` when the
+  caller lacks permission to view the object's metadata, so a low-privilege user
+  degrades to "no estimate" rather than to an error.
+
+  **`mssql_enable_statistics` is not the kill switch for this**, despite the name.
+  It is `SetScope::GLOBAL`, and it is read only by `MSSQLCatalogScanCardinality` —
+  it gates whether an estimate reaches the planner, not whether the metadata query
+  asks for one. If a per-catalog escape ever proves necessary, the seam that
+  already exists is `MSSQLCatalog::IsFabricEndpoint()`
+  (`src/catalog/mssql_catalog.cpp:927`), the same one that disables BCP.
 - **W2 changes when work happens, not how much.** A user who touches one schema
   of a 10,000-schema catalog and never lists anything pays nothing extra: `Scan`
   is the listing path, `GetEntry` is the query path. A user who lists *one* schema

--- a/src/catalog/mssql_metadata_cache.cpp
+++ b/src/catalog/mssql_metadata_cache.cpp
@@ -1,4 +1,5 @@
 #include "catalog/mssql_metadata_cache.hpp"
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -165,6 +166,61 @@ WHERE s.schema_id NOT IN (3, 4)
   AND o.type IN ('U', 'V')
   AND o.is_ms_shipped = 0
   AND s.name = '%s')";
+
+// Whole-catalog metadata: every schema, every table, every column, in ONE query.
+//
+// Spec 071 W2. What made this impossible before was the ORDER BY, not the size:
+// BulkLoadAll iterated schema by schema precisely because sorting millions of
+// rows by (schema, object, column_id) overran the memory grant and spilled to
+// tempdb. But the sort was only ever there to let a STREAMING group-by parse
+// detect table boundaries. Group on object_id in a hash map instead and the sort
+// is not needed, so neither is the loop.
+//
+// That loop is the whole of issue #86. Listing one schema costs a pass over the
+// catalog whatever the predicate says -- sys.objects filters metadata visibility
+// per object in the DATABASE, so an EMPTY schema measured 484 ms of server CPU at
+// 200K objects, and no form of the schema predicate turns that scan into a seek
+// (sys.objects, sys.tables and INFORMATION_SCHEMA.TABLES all plan as a Clustered
+// Index Scan on sysschobjs.clst, with a literal nsid as much as with SCHEMA_ID()).
+// N schemas therefore cost N passes: 10,000 empty schemas extrapolate to ~80
+// minutes. One query for all of them measured 1917 ms. Break-even is under five
+// schemas, so there is no catalog size at which the per-schema loop wins.
+//
+// object_id leads the SELECT list because it is the grouping key: two schemas may
+// hold tables of the same name, so the name alone cannot identify the group.
+static const char *BULK_METADATA_ALL_SQL = R"(
+SELECT
+    o.object_id,
+    s.name AS schema_name,
+    o.name AS object_name,
+    o.type AS object_type,
+    CAST(ISNULL(OBJECTPROPERTYEX(o.object_id, 'Cardinality'), 0) AS BIGINT) AS approx_rows,
+    c.name AS column_name,
+    c.column_id,
+    ISNULL(t.name, TYPE_NAME(c.user_type_id)) AS type_name,
+    c.max_length,
+    c.precision,
+    c.scale,
+    c.is_nullable,
+    ISNULL(c.collation_name, '') AS collation_name,
+    ISNULL(shape.index_type, 0) AS index_type,
+    ISNULL(shape.is_partitioned, 0) AS is_partitioned
+FROM sys.schemas s
+INNER JOIN sys.objects o ON o.schema_id = s.schema_id
+INNER JOIN sys.columns c ON c.object_id = o.object_id
+LEFT JOIN sys.types t ON c.system_type_id = t.user_type_id AND t.system_type_id = t.user_type_id
+OUTER APPLY (SELECT MAX(i.type) AS index_type,
+                    MAX(CASE WHEN ps.data_space_id IS NULL THEN 0 ELSE 1 END) AS is_partitioned
+             FROM sys.indexes i
+             LEFT JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
+             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) shape
+WHERE s.schema_id NOT IN (3, 4)
+  AND s.principal_id != 0
+  AND s.name NOT IN ('guest', 'INFORMATION_SCHEMA', 'sys', 'db_owner', 'db_accessadmin',
+                     'db_securityadmin', 'db_ddladmin', 'db_backupoperator', 'db_datareader',
+                     'db_datawriter', 'db_denydatareader', 'db_denydatawriter')
+  AND o.type IN ('U', 'V')
+  AND o.is_ms_shipped = 0)";
 
 // Query to discover columns in a table/view
 // Note: ISNULL is used for collation_name to avoid NBCROW parsing issues with NULL values
@@ -569,9 +625,23 @@ void MSSQLMetadataCache::LoadAllTableMetadata(tds::TdsConnection &connection, co
 		}
 	}
 
-	// Bulk load all tables + columns for this schema in one query
-	CACHE_DEBUG(1, "LoadAllTableMetadata('%s') — bulk loading from SQL Server", schema_name.c_str());
+	// Not cached: load the WHOLE catalog, not just this schema (spec 071 W2).
+	//
+	// Counter-intuitive only until the cost is measured. Listing one schema costs
+	// a full pass over sys.objects whatever the predicate says, because metadata
+	// visibility is filtered per object in the DATABASE — an EMPTY schema measured
+	// 484 ms of server CPU at 200K objects. DuckDB drives this once per schema, so
+	// the per-schema shape is O(schemas x objects); one query for all of them
+	// measured 1917 ms total. Break-even is under five schemas.
+	//
+	// The plain `SELECT * FROM db.sch.tbl` path does NOT come here — it goes to
+	// GetTableMetadata, one table, one seek — so ordinary queries stay lazy.
+	CACHE_DEBUG(1, "LoadAllTableMetadata('%s') — loading every schema in one query", schema_name.c_str());
+	idx_t all_schemas = 0, all_tables = 0, all_columns = 0;
+	LoadAllSchemasMetadata(connection, all_schemas, all_tables, all_columns);
+}
 
+void MSSQLMetadataCache::LoadAllTableMetadataForSchema(tds::TdsConnection &connection, const string &schema_name) {
 	string sql = StringUtil::Format(BULK_METADATA_SCHEMA_SQL_TEMPLATE, schema_name);
 
 	// Push table filter to SQL Server if convertible to LIKE
@@ -710,17 +780,187 @@ void MSSQLMetadataCache::LoadAllTableMetadata(tds::TdsConnection &connection, co
 // Bulk Catalog Preload (Spec 033: US5)
 //===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
+// Whole-catalog metadata load (spec 071 W2)
+//===----------------------------------------------------------------------===//
+
+void MSSQLMetadataCache::LoadAllSchemasMetadata(tds::TdsConnection &connection, idx_t &schema_count, idx_t &table_count,
+												idx_t &column_count) {
+	schema_count = 0;
+	table_count = 0;
+	column_count = 0;
+
+	string sql = BULK_METADATA_ALL_SQL;
+	// Both filters push to the server where they convert to LIKE. The schema one
+	// matters most here: it is the only thing that can make this query smaller
+	// than the whole catalog, which is what a user with 10,000 schemas reaches for.
+	if (filter_ && filter_->HasSchemaFilter()) {
+		string like_clause = MSSQLCatalogFilter::TryRegexToSQLLike(filter_->GetSchemaPattern(), "s.name");
+		if (!like_clause.empty()) {
+			sql += " AND " + like_clause;
+		}
+	}
+	if (filter_ && filter_->HasTableFilter()) {
+		string like_clause = MSSQLCatalogFilter::TryRegexToSQLLike(filter_->GetTablePattern(), "o.name");
+		if (!like_clause.empty()) {
+			sql += " AND " + like_clause;
+		}
+	}
+
+	std::lock_guard<std::mutex> lock(mutex_);
+
+	// object_id -> the entry it owns. Pointers into schemas_[x].tables stay valid
+	// across insertion because both containers are node-based unordered_maps.
+	unordered_map<string, MSSQLTableMetadata *> by_object_id;
+	// Which schemas this pass actually created or refilled, so the publication
+	// below marks exactly those and leaves any others alone.
+	unordered_map<string, MSSQLSchemaMetadata *> touched;
+
+	ExecuteMetadataQuery(
+		connection, sql,
+		[&](const vector<string> &values) {
+			// 15 columns: object_id, schema, object, type, approx_rows, the eight
+			// per-column fields, then index_type and is_partitioned. Guard the LAST
+			// index read.
+			if (values.size() < 15) {
+				return;
+			}
+			const string &object_id = values[0];
+			auto found = by_object_id.find(object_id);
+			MSSQLTableMetadata *table_meta;
+			if (found == by_object_id.end()) {
+				const string &schema_name = values[1];
+				if (filter_ && !filter_->MatchesSchema(schema_name)) {
+					return;
+				}
+				const string &table_name = values[2];
+				if (filter_ && !filter_->MatchesTable(table_name)) {
+					return;
+				}
+				auto schema_it = schemas_.find(schema_name);
+				if (schema_it == schemas_.end()) {
+					schema_it = schemas_.emplace(schema_name, MSSQLSchemaMetadata(schema_name)).first;
+					schema_count++;
+				}
+				auto &schema = schema_it->second;
+				if (touched.emplace(schema_name, &schema).second) {
+					// First row for this schema in this pass: drop whatever an
+					// earlier partial load left, so the query's answer is the whole
+					// answer rather than a merge with a stale one.
+					schema.tables.clear();
+				}
+				auto &slot = schema.tables[table_name];
+				slot = MSSQLTableMetadata();
+				slot.name = table_name;
+				if (!values[3].empty() && values[3][0] == 'V') {
+					slot.object_type = MSSQLObjectType::VIEW;
+				} else {
+					slot.object_type = MSSQLObjectType::TABLE;
+				}
+				try {
+					slot.approx_row_count = static_cast<idx_t>(std::stoll(values[4]));
+				} catch (...) {
+					slot.approx_row_count = 0;
+				}
+				ParseTableShape(values, 13, 14, slot);
+				table_meta = &slot;
+				by_object_id.emplace(object_id, table_meta);
+				table_count++;
+			} else {
+				table_meta = found->second;
+			}
+
+			int32_t col_id = 0;
+			try {
+				col_id = static_cast<int32_t>(std::stoi(values[6]));
+			} catch (...) {
+			}
+			int16_t max_len = 0;
+			try {
+				max_len = static_cast<int16_t>(std::stoi(values[8]));
+			} catch (...) {
+			}
+			uint8_t prec = 0;
+			try {
+				prec = static_cast<uint8_t>(std::stoi(values[9]));
+			} catch (...) {
+			}
+			uint8_t scl = 0;
+			try {
+				scl = static_cast<uint8_t>(std::stoi(values[10]));
+			} catch (...) {
+			}
+			const bool nullable = (values[11] == "1" || values[11] == "true" || values[11] == "True");
+			table_meta->columns.push_back(MSSQLColumnInfo(values[5], col_id, values[7], max_len, prec, scl, nullable,
+														  values[12], database_collation_));
+			column_count++;
+		},
+		[&]() {
+			// Restartable (PR #308): a deadlock victim reruns from the top, so the
+			// grouping state and everything it published have to go back. Only the
+			// schemas this pass touched are cleared — one it never reached still
+			// holds whatever it legitimately had.
+			for (auto &pair : touched) {
+				pair.second->tables.clear();
+			}
+			by_object_id.clear();
+			touched.clear();
+			schema_count = 0;
+			table_count = 0;
+			column_count = 0;
+		});
+
+	// Columns arrive in no particular order, so put each table's list back into
+	// column_id order before publishing: every consumer indexes by position.
+	const auto now = std::chrono::steady_clock::now();
+	for (auto &pair : by_object_id) {
+		auto &columns = pair.second->columns;
+		std::sort(columns.begin(), columns.end(),
+				  [](const MSSQLColumnInfo &a, const MSSQLColumnInfo &b) { return a.column_id < b.column_id; });
+		pair.second->columns_load_state = CacheLoadState::LOADED;
+		pair.second->columns_last_refresh = now;
+	}
+	for (auto &pair : touched) {
+		pair.second->tables_load_state = CacheLoadState::LOADED;
+		pair.second->tables_last_refresh = now;
+	}
+	// A schema the query returned NO rows for is still loaded — it is empty, and
+	// saying so is what stops the next Scan from asking again.
+	for (auto &pair : schemas_) {
+		if (filter_ && !filter_->MatchesSchema(pair.first)) {
+			continue;
+		}
+		if (touched.find(pair.first) == touched.end()) {
+			pair.second.tables.clear();
+			pair.second.tables_load_state = CacheLoadState::LOADED;
+			pair.second.tables_last_refresh = now;
+		}
+	}
+
+	CACHE_DEBUG(1, "LoadAllSchemasMetadata — %llu schema(s), %llu table(s), %llu column(s) in ONE query",
+				(unsigned long long)touched.size(), (unsigned long long)table_count, (unsigned long long)column_count);
+}
+
 void MSSQLMetadataCache::BulkLoadAll(tds::TdsConnection &connection, const string &schema_name, idx_t &schema_count,
 									 idx_t &table_count, idx_t &column_count) {
 	schema_count = 0;
 	table_count = 0;
 	column_count = 0;
 
-	// Determine which schemas to load.
-	// When schema_name is empty, we iterate per-schema instead of one massive cross-schema
-	// query. This avoids SQL Server tempdb sort spills on large catalogs (200K+ tables)
-	// where the ORDER BY s.name, o.name, c.column_id on millions of rows exceeds the
-	// memory grant and causes non-linear performance degradation.
+	// With no schema named, ONE query covers the catalog (spec 071 W2).
+	//
+	// This used to iterate per schema, and the reason recorded here was the sort:
+	// "ORDER BY s.name, o.name, c.column_id on millions of rows exceeds the memory
+	// grant and causes non-linear performance degradation". True, and the sort was
+	// only ever there so a STREAMING parse could see table boundaries. Grouping on
+	// object_id in a hash map removes the sort, and with it the reason to loop —
+	// which was also the reason mssql_preload_catalog() was O(schemas x objects)
+	// and could not rescue issue #86 however often it was recommended.
+	if (schema_name.empty()) {
+		LoadAllSchemasMetadata(connection, schema_count, table_count, column_count);
+		return;
+	}
+
 	vector<string> schemas_to_load;
 	if (!schema_name.empty()) {
 		schemas_to_load.push_back(schema_name);

--- a/src/catalog/mssql_metadata_cache.cpp
+++ b/src/catalog/mssql_metadata_cache.cpp
@@ -27,13 +27,48 @@ namespace duckdb {
 // SQL Queries for Metadata Discovery
 //===----------------------------------------------------------------------===//
 
-// Row counts come from a pre-aggregated sys.partitions subquery, never a direct
-// join: sys.partitions holds one row PER PARTITION, so joining it raw multiplies
-// every object (and every column) by the partition count. On a partitioned table
-// that surfaced as "Column with name <x> already exists!" (issue #85) and, silently,
-// as an approx_rows taken from one arbitrary partition instead of the whole table.
-// index_id IN (0, 1) selects the heap (0) or the clustered index (1) — a table has
-// exactly one of the two, so SUM() does not double-count.
+// PHYSICAL SHAPE COMES FROM sys.indexes, NOT sys.partitions (spec 071 W1).
+//
+// Every query below used to carry one pre-aggregated sys.partitions subquery that
+// produced approx_rows, index_type and partition_count together. It was there for
+// a real reason — sys.partitions holds one row PER PARTITION, so joining it raw
+// multiplied every object and every column by the partition count, which is issue
+// #85 ("Column with name <x> already exists!") — but the aggregate it was replaced
+// with turned out to be the single most expensive thing in the catalog layer.
+//
+// sys.partitions reads sys.sysrowsets, which is clustered on rowsetid; object_id
+// is derived and has no index. Measured on a 200,000-table catalog, a lookup BY
+// object_id costs:
+//
+//     sys.partitions              sysrowsets   3200 logical reads (2 scans)
+//     sys.dm_db_partition_stats   sysrowsets   1600 logical reads (1 scan)
+//     sys.indexes                 sysidxstats     6 logical reads (SEEK)
+//
+// So the row count is O(catalog) however it is asked for and the index shape is
+// O(1); they had no business sharing a subquery. Worse, what forced the GROUP BY
+// was COUNT(*) AS partition_count — a value nothing in the tree ever read.
+//
+// The shape now comes from a correlated OUTER APPLY over sys.indexes (seekable),
+// with "is this partitioned" answered by sys.partition_schemes rather than by
+// counting partitions. index_id IN (0, 1) still selects the heap (0) or the
+// clustered index (1); a table has exactly one of the two.
+//
+// Row counts come from OBJECTPROPERTYEX(object_id, 'Cardinality'), which answers
+// out of object metadata — 3 logical reads on sysschobjs, 0 ms CPU — and needs
+// neither sys.partitions nor statistics to exist on the table. Measured against
+// sys.partitions on the same objects it agrees exactly, including 0 for an empty
+// table and NULL (-> 0) for a VIEW, which is the value the catalog already
+// carried for a view. Fetching every row count in the database costs 84 ms this
+// way against 2400 ms through sys.partitions or sys.dm_db_partition_stats.
+//
+// Dropping the count instead was tried and rejected: it is what gives the
+// planner its cardinality (MSSQLCatalogScanCardinality reads the catalog's copy
+// first), and scan_cardinality.test catches its loss. sys.sysindexes is equally
+// cheap and was rejected as deprecated; sys.dm_db_stats_properties is cheap but
+// returns nothing for a table with no statistics — which is exactly a table this
+// extension has just created by CTAS or COPY.
+//
+// See specs/071-catalog-metadata-cost/spec.md.
 
 // Query to discover all user schemas (including empty ones)
 // Excludes system schemas: INFORMATION_SCHEMA (3), sys (4), and other built-in schemas
@@ -54,16 +89,15 @@ static const char *TABLE_DISCOVERY_SQL_TEMPLATE = R"(
 SELECT
     o.name AS object_name,
     o.type AS object_type,
-    ISNULL(p.rows, 0) AS approx_rows,
-    ISNULL(p.index_type, 0) AS index_type,
-    ISNULL(p.partition_count, 0) AS partition_count
+    CAST(ISNULL(OBJECTPROPERTYEX(o.object_id, 'Cardinality'), 0) AS BIGINT) AS approx_rows,
+    ISNULL(shape.index_type, 0) AS index_type,
+    ISNULL(shape.is_partitioned, 0) AS is_partitioned
 FROM sys.objects o
-LEFT JOIN (SELECT p.object_id, SUM(p.[rows]) AS [rows],
-                  MAX(ISNULL(i.type, 0)) AS index_type, COUNT(*) AS partition_count
-           FROM sys.partitions p
-           LEFT JOIN sys.indexes i ON i.object_id = p.object_id AND i.index_id = p.index_id
-           WHERE p.index_id IN (0, 1)
-           GROUP BY p.object_id) p ON p.object_id = o.object_id
+OUTER APPLY (SELECT MAX(i.type) AS index_type,
+                    MAX(CASE WHEN ps.data_space_id IS NULL THEN 0 ELSE 1 END) AS is_partitioned
+             FROM sys.indexes i
+             LEFT JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
+             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) shape
 WHERE o.type IN ('U', 'V')
   AND o.is_ms_shipped = 0
   AND SCHEMA_NAME(o.schema_id) = '%s')";
@@ -73,7 +107,7 @@ WHERE o.type IN ('U', 'V')
 static const char *SINGLE_TABLE_METADATA_SQL_TEMPLATE = R"(
 SELECT
     o.type AS object_type,
-    ISNULL(p.rows, 0) AS approx_rows,
+    CAST(ISNULL(OBJECTPROPERTYEX(o.object_id, 'Cardinality'), 0) AS BIGINT) AS approx_rows,
     c.name AS column_name,
     c.column_id,
     ISNULL(t.name, TYPE_NAME(c.user_type_id)) AS type_name,
@@ -82,17 +116,16 @@ SELECT
     c.scale,
     c.is_nullable,
     ISNULL(c.collation_name, '') AS collation_name,
-    ISNULL(p.index_type, 0) AS index_type,
-    ISNULL(p.partition_count, 0) AS partition_count
+    ISNULL(shape.index_type, 0) AS index_type,
+    ISNULL(shape.is_partitioned, 0) AS is_partitioned
 FROM sys.objects o
 INNER JOIN sys.columns c ON c.object_id = o.object_id
 LEFT JOIN sys.types t ON c.system_type_id = t.user_type_id AND t.system_type_id = t.user_type_id
-LEFT JOIN (SELECT p.object_id, SUM(p.[rows]) AS [rows],
-                  MAX(ISNULL(i.type, 0)) AS index_type, COUNT(*) AS partition_count
-           FROM sys.partitions p
-           LEFT JOIN sys.indexes i ON i.object_id = p.object_id AND i.index_id = p.index_id
-           WHERE p.index_id IN (0, 1)
-           GROUP BY p.object_id) p ON p.object_id = o.object_id
+OUTER APPLY (SELECT MAX(i.type) AS index_type,
+                    MAX(CASE WHEN ps.data_space_id IS NULL THEN 0 ELSE 1 END) AS is_partitioned
+             FROM sys.indexes i
+             LEFT JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
+             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) shape
 WHERE o.object_id = OBJECT_ID('%s')
 ORDER BY c.column_id
 )";
@@ -104,7 +137,7 @@ SELECT
     s.name AS schema_name,
     o.name AS object_name,
     o.type AS object_type,
-    ISNULL(p.rows, 0) AS approx_rows,
+    CAST(ISNULL(OBJECTPROPERTYEX(o.object_id, 'Cardinality'), 0) AS BIGINT) AS approx_rows,
     c.name AS column_name,
     c.column_id,
     ISNULL(t.name, TYPE_NAME(c.user_type_id)) AS type_name,
@@ -113,18 +146,17 @@ SELECT
     c.scale,
     c.is_nullable,
     ISNULL(c.collation_name, '') AS collation_name,
-    ISNULL(p.index_type, 0) AS index_type,
-    ISNULL(p.partition_count, 0) AS partition_count
+    ISNULL(shape.index_type, 0) AS index_type,
+    ISNULL(shape.is_partitioned, 0) AS is_partitioned
 FROM sys.schemas s
 INNER JOIN sys.objects o ON o.schema_id = s.schema_id
 INNER JOIN sys.columns c ON c.object_id = o.object_id
 LEFT JOIN sys.types t ON c.system_type_id = t.user_type_id AND t.system_type_id = t.user_type_id
-LEFT JOIN (SELECT p.object_id, SUM(p.[rows]) AS [rows],
-                  MAX(ISNULL(i.type, 0)) AS index_type, COUNT(*) AS partition_count
-           FROM sys.partitions p
-           LEFT JOIN sys.indexes i ON i.object_id = p.object_id AND i.index_id = p.index_id
-           WHERE p.index_id IN (0, 1)
-           GROUP BY p.object_id) p ON p.object_id = o.object_id
+OUTER APPLY (SELECT MAX(i.type) AS index_type,
+                    MAX(CASE WHEN ps.data_space_id IS NULL THEN 0 ELSE 1 END) AS is_partitioned
+             FROM sys.indexes i
+             LEFT JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
+             WHERE i.object_id = o.object_id AND i.index_id IN (0, 1)) shape
 WHERE s.schema_id NOT IN (3, 4)
   AND s.principal_id != 0
   AND s.name NOT IN ('guest', 'INFORMATION_SCHEMA', 'sys', 'db_owner', 'db_accessadmin',
@@ -153,25 +185,23 @@ ORDER BY c.column_id
 )";
 
 //===----------------------------------------------------------------------===//
-// Physical shape of the object, parsed out of the aggregated sys.partitions
-// subquery. index_type and partition_count always sit last in the SELECT list,
-// so each caller passes their own indices.
+// Physical shape of the object, parsed out of the correlated sys.indexes lookup.
+// index_type and is_partitioned always sit last in the SELECT list, so each
+// caller passes their own indices.
 //
 // The two values are parsed into locals and published together: a malformed
-// partition_count must not discard an index_type that parsed fine.
+// is_partitioned must not discard an index_type that parsed fine.
 //===----------------------------------------------------------------------===//
 
-static void ParseTableShape(const vector<string> &values, idx_t index_type_idx, idx_t partition_count_idx,
+static void ParseTableShape(const vector<string> &values, idx_t index_type_idx, idx_t is_partitioned_idx,
 							MSSQLTableMetadata &table_meta) {
 	const MSSQLIndexKind kind = MSSQLIndexKindFromSysIndexesType(values[index_type_idx]);
-	idx_t partitions = 0;
-	try {
-		partitions = static_cast<idx_t>(std::stoll(values[partition_count_idx]));
-	} catch (...) {
-		partitions = 0;
-	}
+	// The server sends the CASE result, so anything but "1" is "not partitioned"
+	// — including a value that is missing or unparseable, which is the honest
+	// answer when the shape lookup produced nothing.
+	const bool partitioned = values[is_partitioned_idx] == "1";
 	table_meta.index_kind = kind;
-	table_meta.partition_count = partitions;
+	table_meta.is_partitioned = partitioned;
 }
 
 //===----------------------------------------------------------------------===//
@@ -379,13 +409,19 @@ bool MSSQLMetadataCache::GetTableMetadata(tds::TdsConnection &connection, const 
 	ExecuteMetadataQuery(
 		connection, query,
 		[this, &table_meta, &first_row](const vector<string> &values) {
-			// 12 columns: object_type, approx_rows, the eight per-column fields, then
-			// index_id and partition_count. The guard has to cover the LAST index read.
+			// 11 columns: object_type, the eight per-column fields, then index_type
+			// and is_partitioned. The guard has to cover the LAST index read.
+			//
+			// approx_rows is still here, but it no longer costs a scan of
+			// sys.sysrowsets: 3200 logical reads for these six rows became 3 (see the
+			// header). It has to stay — MSSQLCatalogScanCardinality reads the
+			// catalog's copy before anything else, so removing it plans every direct
+			// query at ~1 row.
 			if (values.size() < 12) {
 				return;
 			}
 
-			// First row: extract object type and row count
+			// First row: extract object type and physical shape
 			if (first_row) {
 				first_row = false;
 				if (!values[0].empty() && values[0][0] == 'V') {
@@ -393,20 +429,18 @@ bool MSSQLMetadataCache::GetTableMetadata(tds::TdsConnection &connection, const 
 				} else {
 					table_meta.object_type = MSSQLObjectType::TABLE;
 				}
+				// values[9] is sys.indexes.type — 1 clustered rowstore, 5 clustered
+				// COLUMNSTORE, 0 heap — and values[10] says whether the object sits on
+				// a partition scheme. Both drive the write path's TABLOCK and sort
+				// decisions. Per object, so it belongs in the first-row branch.
 				try {
 					table_meta.approx_row_count = static_cast<idx_t>(std::stoll(values[1]));
 				} catch (...) {
 					table_meta.approx_row_count = 0;
 				}
-				// Physical shape from the same aggregated subquery (see the header):
-				// values[10] is sys.indexes.type — 1 clustered rowstore, 5 clustered
-				// COLUMNSTORE, 0 heap — and partition_count > 1 marks a partitioned
-				// object. Both drive the write path's TABLOCK and sort decisions.
-				// Per object, so it belongs in the first-row branch.
 				ParseTableShape(values, 10, 11, table_meta);
-				CACHE_DEBUG(2, "table shape: %s kind=%d partitions=%llu rows=%llu", table_meta.name.c_str(),
-							(int)table_meta.index_kind, (unsigned long long)table_meta.partition_count,
-							(unsigned long long)table_meta.approx_row_count);
+				CACHE_DEBUG(2, "table shape: %s kind=%d partitioned=%d", table_meta.name.c_str(),
+							(int)table_meta.index_kind, (int)table_meta.is_partitioned);
 			}
 
 			// Parse column info
@@ -571,7 +605,7 @@ void MSSQLMetadataCache::LoadAllTableMetadata(tds::TdsConnection &connection, co
 		connection, sql,
 		[&](const vector<string> &values) {
 			// 14 columns: schema, object, type, approx_rows, the eight per-column
-			// fields, then index_id and partition_count. Guard the LAST index read.
+			// fields, then index_type and is_partitioned. Guard the LAST index read.
 			if (values.size() < 14) {
 				return;
 			}
@@ -609,10 +643,10 @@ void MSSQLMetadataCache::LoadAllTableMetadata(tds::TdsConnection &connection, co
 				} catch (...) {
 					table_meta.approx_row_count = 0;
 				}
-				// Physical shape from the same aggregated subquery (see the header):
+				// Physical shape from the correlated sys.indexes lookup (see the header):
 				// values[12] is sys.indexes.type — 1 clustered rowstore, 5 clustered
-				// COLUMNSTORE, 0 heap — and partition_count > 1 marks a partitioned
-				// object. Both drive the write path's TABLOCK and sort decisions.
+				// COLUMNSTORE, 0 heap — and values[13] says whether the object sits on a
+				// partition scheme. Both drive the write path's TABLOCK and sort decisions.
 				ParseTableShape(values, 12, 13, table_meta);
 				schema.tables.emplace(current_table, std::move(table_meta));
 				auto table_it = schema.tables.find(current_table);
@@ -749,7 +783,7 @@ void MSSQLMetadataCache::BulkLoadAll(tds::TdsConnection &connection, const strin
 			connection, sql,
 			[&](const vector<string> &values) {
 				// 14 columns: schema, object, type, approx_rows, the eight per-column
-				// fields, then index_id and partition_count. Guard the LAST index read.
+				// fields, then index_type and is_partitioned. Guard the LAST index read.
 				if (values.size() < 14) {
 					return;
 				}
@@ -794,11 +828,11 @@ void MSSQLMetadataCache::BulkLoadAll(tds::TdsConnection &connection, const strin
 						} catch (...) {
 							table_meta.approx_row_count = 0;
 						}
-						// Physical shape from the same aggregated subquery (see the header):
-						// values[12] is sys.indexes.type — 1 clustered rowstore, 5
-						// clustered COLUMNSTORE, 0 heap — and partition_count > 1 marks
-						// a partitioned object. Both drive the write path's TABLOCK and
-						// sort decisions.
+						// Physical shape from the correlated sys.indexes lookup (see the
+						// header): values[12] is sys.indexes.type — 1 clustered rowstore,
+						// 5 clustered COLUMNSTORE, 0 heap — and values[13] says whether the
+						// object sits on a partition scheme. Both drive the write path's
+						// TABLOCK and sort decisions.
 						ParseTableShape(values, 12, 13, table_meta);
 
 						tables.emplace(current_table, std::move(table_meta));
@@ -1136,8 +1170,8 @@ void MSSQLMetadataCache::EnsureTablesLoaded(tds::TdsConnection &connection, cons
 		ExecuteMetadataQuery(
 			connection, query,
 			[&schema](const vector<string> &values) {
-				// 5 columns: object_name, object_type, approx_rows, index_id,
-				// partition_count. Guard the LAST index read, not the first.
+				// 5 columns: object_name, object_type, approx_rows, index_type,
+				// is_partitioned. Guard the LAST index read, not the first.
 				if (values.size() >= 5) {
 					MSSQLTableMetadata table_meta;
 					table_meta.name = values[0];
@@ -1151,16 +1185,17 @@ void MSSQLMetadataCache::EnsureTablesLoaded(tds::TdsConnection &connection, cons
 						table_meta.object_type = MSSQLObjectType::TABLE;
 					}
 
-					// Parse row count
+					// Row count from OBJECTPROPERTYEX, not sys.partitions: it answers from
+					// object metadata (3 logical reads on sysschobjs) where a lookup through
+					// sys.partitions scans sysrowsets, which cannot be seeked by object_id.
 					try {
 						table_meta.approx_row_count = static_cast<idx_t>(std::stoll(values[2]));
 					} catch (...) {
 						table_meta.approx_row_count = 0;
 					}
-					// Physical shape from the same aggregated subquery (see the header):
 					// values[3] is sys.indexes.type — 1 clustered rowstore, 5 clustered
-					// COLUMNSTORE, 0 heap — and partition_count > 1 marks a partitioned
-					// object. Both drive the write path's TABLOCK and sort decisions.
+					// COLUMNSTORE, 0 heap — and values[4] says whether the object sits on a
+					// partition scheme. Both drive the write path's TABLOCK and sort decisions.
 					ParseTableShape(values, 3, 4, table_meta);
 
 					// Note: columns NOT loaded (columns_load_state = NOT_LOADED by default)
@@ -1320,8 +1355,8 @@ void MSSQLMetadataCache::LoadTables(tds::TdsConnection &connection, const string
 	ExecuteMetadataQuery(
 		connection, query,
 		[&schema_meta](const vector<string> &values) {
-			// 5 columns: object_name, object_type, approx_rows, index_id,
-			// partition_count. Guard the LAST index read, not the first.
+			// 5 columns: object_name, object_type, approx_rows, index_type,
+			// is_partitioned. Guard the LAST index read, not the first.
 			if (values.size() >= 5) {
 				MSSQLTableMetadata table_meta;
 				table_meta.name = values[0];
@@ -1336,16 +1371,17 @@ void MSSQLMetadataCache::LoadTables(tds::TdsConnection &connection, const string
 					table_meta.object_type = MSSQLObjectType::TABLE;
 				}
 
-				// Parse row count
+				// Row count from OBJECTPROPERTYEX, not sys.partitions: it answers from
+				// object metadata (3 logical reads on sysschobjs) where a lookup through
+				// sys.partitions scans sysrowsets, which cannot be seeked by object_id.
 				try {
 					table_meta.approx_row_count = static_cast<idx_t>(std::stoll(values[2]));
 				} catch (...) {
 					table_meta.approx_row_count = 0;
 				}
-				// Physical shape from the same aggregated subquery (see the header):
 				// values[3] is sys.indexes.type — 1 clustered rowstore, 5 clustered
-				// COLUMNSTORE, 0 heap — and partition_count > 1 marks a partitioned
-				// object. Both drive the write path's TABLOCK and sort decisions.
+				// COLUMNSTORE, 0 heap — and values[4] says whether the object sits on a
+				// partition scheme. Both drive the write path's TABLOCK and sort decisions.
 				ParseTableShape(values, 3, 4, table_meta);
 
 				schema_meta.tables[table_meta.name] = std::move(table_meta);

--- a/src/include/catalog/mssql_metadata_cache.hpp
+++ b/src/include/catalog/mssql_metadata_cache.hpp
@@ -162,6 +162,26 @@ public:
 	// Otherwise loads everything with BULK_METADATA_SCHEMA_SQL_TEMPLATE (one round trip).
 	void LoadAllTableMetadata(tds::TdsConnection &connection, const string &schema_name);
 
+	//! The single-schema bulk load. Kept because mssql_preload_catalog('schema')
+	//! names one deliberately; the listing path goes through
+	//! LoadAllSchemasMetadata instead. Caller must hold mutex_ via the public entry.
+	void LoadAllTableMetadataForSchema(tds::TdsConnection &connection, const string &schema_name);
+
+	//! Load EVERY schema's tables and columns in one query (spec 071 W2).
+	//!
+	//! Both the listing path and mssql_preload_catalog() go through here. It costs
+	//! one pass over the catalog; asking per schema costs one pass EACH, because
+	//! sys.objects filters metadata visibility per object in the database and no
+	//! predicate turns that scan into a seek. Break-even is under five schemas.
+	//!
+	//! Rows arrive UNORDERED and are grouped on object_id in a hash map — dropping
+	//! the ORDER BY is what makes the single query possible at all, since sorting
+	//! millions of rows is what forced the per-schema loop this replaces.
+	//!
+	//! Caller must NOT hold mutex_; this takes it.
+	void LoadAllSchemasMetadata(tds::TdsConnection &connection, idx_t &schema_count, idx_t &table_count,
+								idx_t &column_count);
+
 	// Check if schema exists (reads cached state only, no lazy loading)
 	bool HasSchema(const string &schema_name);
 

--- a/src/include/catalog/mssql_metadata_cache.hpp
+++ b/src/include/catalog/mssql_metadata_cache.hpp
@@ -64,7 +64,20 @@ struct MSSQLTableMetadata {
 	// accurate by its name and misleading to its only consumer. The kind comes
 	// from sys.indexes.type, which separates them.
 	MSSQLIndexKind index_kind = MSSQLIndexKind::HEAP;
-	idx_t partition_count = 0;
+
+	// Is the object partitioned? Spec 071 W1: this replaces a `partition_count`
+	// that nothing ever read — it was written here and not even copied into
+	// MSSQLTableEntry, while the COUNT(*) producing it is what forced the
+	// GROUP BY over sys.partitions that made every metadata query scan
+	// sys.sysrowsets. Every comment that referred to the count phrased its
+	// meaning as "> 1 marks a partitioned object", which is what this is.
+	//
+	// Source is sys.indexes.data_space_id against sys.partition_schemes, which
+	// seeks (6 logical reads) where sys.partitions cannot seek at all —
+	// sysrowsets is clustered on rowsetid and object_id is derived, so a lookup
+	// by object_id costs a full scan (3200 reads at 200K tables) whatever form
+	// it takes. See specs/071-catalog-metadata-cost/spec.md.
+	bool is_partitioned = false;
 
 	// Incremental cache state for columns.
 	// Issue #178 (D6): all fields — including these states — are guarded by the

--- a/src/include/mssql_storage.hpp
+++ b/src/include/mssql_storage.hpp
@@ -147,7 +147,12 @@ struct MSSQLConnectionInfo {
 	//===----------------------------------------------------------------------===//
 	// Endpoint Type Flags (T040-T041: cached at ATTACH time for performance)
 	//===----------------------------------------------------------------------===//
-	bool is_fabric_endpoint = false;  // True if targeting Microsoft Fabric (no BCP/INSERT BULK support)
+	// True if targeting Microsoft Fabric. Read ONLY by
+	// MSSQLCatalog::RequiresSingleByteText(): Fabric has no `nvarchar`, so CTAS,
+	// COPY and the collation choice pick single-byte text there. It does not gate
+	// the bulk-load path — `bcp`, whose INSERT BULK protocol this extension
+	// speaks, is supported on Fabric as a preview feature.
+	bool is_fabric_endpoint = false;
 
 	// Issue #225: did the server grant the LOGIN7 UTF8SUPPORT feature? Observed by
 	// the ATTACH-time validation login, which happens on every non-lazy attach, so

--- a/src/mssql_storage.cpp
+++ b/src/mssql_storage.cpp
@@ -1612,11 +1612,25 @@ unique_ptr<Catalog> MSSQLAttach(optional_ptr<StorageExtensionInfo> storage_info,
 	// both of which read the (now resolved) host/port.
 	connection_info->ResolveNamedInstance(context);
 
-	// T040 (Bug 0.7): Cache endpoint type at ATTACH time for performance
-	// Fabric endpoints don't support BCP/INSERT BULK, need fallback to INSERT
+	// Cache the endpoint type at ATTACH time: the test is a host-name match and
+	// several paths ask repeatedly.
+	//
+	// This does NOT disable BCP, whatever this comment used to say. The flag's
+	// only consumer is MSSQLCatalog::RequiresSingleByteText(), which exists
+	// because Fabric Warehouse has no `nvarchar` type at all; through it the flag
+	// reaches the CTAS planner, COPY's target types and the collation choice, and
+	// nothing else. Grep src/copy/ for it and there is no hit — the bulk-load path
+	// has never tested it, so the "fallback to INSERT" it described did not exist.
+	//
+	// The claim was wrong about Fabric too, not merely unimplemented: `bcp` is
+	// supported there as a preview feature (Microsoft's "T-SQL surface area in
+	// Fabric Data Warehouse" lists BULK LOAD as unsupported and exempts `bcp`),
+	// and INSERT BULK is the protocol `bcp` itself speaks. Our own docs already
+	// implied the load runs: the Fabric known-issue says a `#temp` table cannot be
+	// a BCP TARGET there, which is a limit only a working load can reach.
 	connection_info->is_fabric_endpoint = connection_info->IsFabricEndpoint();
 	if (connection_info->is_fabric_endpoint) {
-		MSSQL_STORAGE_DEBUG_LOG(1, "Fabric endpoint detected: %s (BCP disabled, using INSERT fallback)",
+		MSSQL_STORAGE_DEBUG_LOG(1, "Fabric endpoint detected: %s (no nvarchar — single-byte text types)",
 								connection_info->host.c_str());
 	}
 


### PR DESCRIPTION
Replaces **#310**, which GitHub auto-closed when #308 merged and its branch — #310's base — was deleted. Same branch, same three commits, now based on `main`. Nothing was lost: #308 landed as a merge commit, so its work is on `main` and this branch's diff against `main` is exactly the three commits below.

Implements **spec 071** (#309) in full — W1 and W2 — plus the comment correction folded in from #311. Closes [#86](https://github.com/hugr-lab/mssql-extension/issues/86).

---

## W1 — the row count never needed `sys.partitions`

Every metadata query fetched `approx_rows`, `index_type` and `partition_count` from one aggregate over `sys.partitions`. That view reads `sysrowsets`, clustered on `rowsetid` — `object_id` is derived and unindexed, so a lookup by it is a full scan in **any** form. For **one** object's row count, on a 200,000-table catalog:

| source | base table | logical reads | CPU |
|---|---|---|---|
| `sys.partitions` (today) | `sysrowsets` | **3200** | 18 ms |
| `sys.dm_db_partition_stats` | `sysrowsets` | 1601 | 54 ms |
| **`OBJECTPROPERTYEX(id, 'Cardinality')`** | `sysschobjs` | **3** | **0 ms** |

`OBJECTPROPERTYEX` agrees with `sys.partitions` **exactly** — 5000/5000, 150000/150000, 0 for empty, NULL for a VIEW, which maps to the same 0 the catalog already carried. It needs no statistics (unlike `sys.dm_db_stats_properties`, which returns NULL for a 5000-row heap with none — exactly a table CTAS or COPY has just made) and is not deprecated (unlike `sys.sysindexes`). Every row count in the database: **84 ms** against **2400 ms**.

What forced the two halves to share a subquery was `COUNT(*) AS partition_count` — a field `ParseTableShape` wrote and **nothing read**. Deleted; `is_partitioned` replaces it, which is what every comment already claimed it meant.

**Nothing is given up.** Counts stay, the planner's cardinality stays. Dropping the count was tried first and reverted — `scan_cardinality.test` catches it.

## W2 — one query for every schema

Listing **one** schema costs a full pass over `sys.objects` whatever the predicate says: metadata visibility is filtered per object in the *database*. An **empty** schema measured **484 ms** of server CPU at 200K objects. And there is no seek to buy — `sys.objects`, `sys.tables` and `INFORMATION_SCHEMA.TABLES` all plan as a **Clustered Index Scan on `sysschobjs.clst`**, with a literal `nsid` as much as with `SCHEMA_ID()`, because the nonclustered `(nsid, name)` index does not cover `type`/`nsclass`/`pclass`.

DuckDB drives that **once per schema**, so the shape was O(schemas × objects) — the reporter's 10,000 *empty* schemas extrapolate to hours. One query for all of them: **1917 ms**. Break-even is under five schemas.

What stood in the way was not size but the `ORDER BY`, and `BulkLoadAll` said so itself:

> *"ORDER BY … on millions of rows exceeds the memory grant and causes non-linear performance degradation"*

The sort existed only so a **streaming** parse could see table boundaries. Group on `object_id` in a hash map and the sort goes, and with it the loop. `object_id` rather than the name, because two schemas may hold tables of the same name.

Both callers move: the listing path and `mssql_preload_catalog()` with no schema named — preload was built the same per-schema way, which is why recommending it on #86 lowered the constant and never the exponent.

**Ordinary queries stay lazy.** `SELECT * FROM db.sch.tbl` goes to `GetTableMetadata` — one table, one seek — and never comes here.

## Folded in from #311 — the Fabric flag never disabled BCP

Comment and log only. The source said *"Fabric endpoints don't support BCP/INSERT BULK, need fallback to INSERT"*. `is_fabric_endpoint` has exactly one consumer — `RequiresSingleByteText()`, because Fabric has no `nvarchar` — and `src/copy/` never tests it, so the fallback did not exist. The premise is also out of date: `bcp` is supported on Fabric as a preview feature, and `INSERT BULK` is what `bcp` speaks.

## Results at 200K tables / 1.2M columns

| | before | after |
|---|---|---|
| single-table metadata | 18.1 ms, `sysrowsets` 3200 reads | **~1 ms, 0 reads** |
| an **empty** schema's discovery | 2708 ms CPU | **484 ms** |
| every row count in the DB | 2400 ms | **84 ms** |
| 10,000 empty schemas (#86) | ~7.5 h | **~2 s** |

Also relevant to #308: `sysrowsets` was one of the two resources in **7 of 8** captured deadlock cycles. Removing it took index-DDL contention from 127/141/93 to **0/0/0** per 150 metadata queries.

## Verified

- Build clean, `clang-format-14` clean.
- **SQL suite: 177 passed, 8 skipped** against SQL Server 2025 — including `scan_cardinality.test`.
- Every rewritten template executed against a live server before building, to check the SQL independently of the C++.
- Row counts compared per object against `sys.partitions` on tables with rows, an empty table and a view.
- `OBJECTPROPERTYEX` platform support confirmed from the documentation for Azure Synapse and all three Fabric surfaces, and against Fabric's own unsupported list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz