### PR TITLE
release: v0.2.5 — the catalog's default schema, and two scans on one pinned connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-09-08
+
+Two fixes that a generic catalog consumer hits immediately. Found while building
+a DuckLake catalog manager on top of an attached MSSQL database, but neither is
+specific to that: both are about the extension behaving like a catalog rather
+than like a query function.
+
+### Fixed
+
+- **The catalog's default schema is `dbo`, not DuckDB's `main`**
+  ([#129](https://github.com/hugr-lab/mssql-extension/issues/129)).
+  `MSSQLCatalog` did not override `Catalog::GetDefaultSchema()`, so the base
+  answer `main` came back — a schema no SQL Server database has. Anything that
+  resolves an unqualified name through the catalog's default failed with
+  `Schema 'main' not found in MSSQL database`; the workaround in the wild was to
+  CREATE a schema literally called `main` on the server. `SELECT
+  current_schema()` now answers `dbo` after `USE <catalog>`, and unqualified
+  names resolve.
+
+- **Two scans of one catalog inside an explicit transaction no longer break the
+  pinned connection**
+  ([#239](https://github.com/hugr-lab/mssql-extension/issues/239)).
+  A transaction pins ONE TDS connection per catalog and routes every read on
+  that catalog to it, while a scan holds that connection from init until its
+  last row is drained. DuckDB does not promise to drain one source before
+  initializing the next — a correlated subquery in a predicate plans as
+  `LEFT_DELIM_JOIN` and initializes both — so the second scan met a busy
+  connection:
+
+  - `threads = 1` → `Cannot execute: connection not in Idle state (current: Executing)`
+  - `threads > 1` → `Connection closed while waiting for COLMETADATA`, a torn stream
+
+  In an explicit transaction, a plan holding more than one scan of the same
+  catalog now drains each of them into a buffer-managed collection at init and
+  releases the connection before returning, and holds a per-catalog lock across
+  batch-and-drain so concurrent initializations serialize. **Autocommit is
+  unchanged**: there every scan takes its own pooled connection, which is why
+  the same query always worked outside a transaction.
+
+  The mechanism mirrors duckdb-postgres, which has the same one-connection
+  constraint. Memory is bounded by the buffer manager, and only the plans that
+  would otherwise fail are affected.
+
 ## [0.2.4] - 2026-08-17
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 # Extension version - update this when creating a new release tag
-set(MSSQL_EXTENSION_VERSION "0.2.4")
+set(MSSQL_EXTENSION_VERSION "0.2.5")
 
 # Project configuration
 project(${TARGET_NAME})

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -292,6 +292,11 @@ string MSSQLCatalog::GetCatalogType() {
 	return "mssql";
 }
 
+string MSSQLCatalog::GetDefaultSchema() const {
+	// See the header for why this is a constant and not SCHEMA_NAME().
+	return "dbo";
+}
+
 //===----------------------------------------------------------------------===//
 // Schema Operations
 //===----------------------------------------------------------------------===//

--- a/src/include/catalog/mssql_catalog.hpp
+++ b/src/include/catalog/mssql_catalog.hpp
@@ -70,6 +70,43 @@ public:
 
 	string GetCatalogType() override;
 
+	//! SQL Server's default schema, not DuckDB's `main`.
+	//!
+	//! The base Catalog answers `main`, which no SQL Server database has, so
+	//! anything that resolves an unqualified name through the catalog's default
+	//! fails with "Schema 'main' not found in MSSQL database". ducklake hits this
+	//! on ATTACH — DuckLakeTransaction::GetDefaultSchemaName() asks for it before
+	//! any table exists — and issue #129 shows a user working around it by
+	//! CREATEing a schema literally called `main` on the server.
+	//!
+	//! `dbo` is the constant answer rather than a per-login lookup: it is the
+	//! default for every login that has not been given another, and resolving
+	//! SCHEMA_NAME() would put a round trip on ATTACH and need an answer on the
+	//! lazy-validation path, where no connection has been made yet. A login whose
+	//! default schema is not `dbo` still addresses its tables by qualified name;
+	//! only the unqualified default is wrong for it, which is the pre-existing
+	//! behaviour minus the crash.
+	string GetDefaultSchema() const override;
+
+	//! Serializes materialized catalog scans against each other (issue #239).
+	//!
+	//! R2 drains a scan inside InitGlobal so the pinned connection is Idle again
+	//! before the next scan starts — which is enough at threads = 1, where DuckDB
+	//! initializes the two sources in sequence. With threads > 1 the two
+	//! InitGlobals run CONCURRENTLY and the drain has not happened yet when the
+	//! second one sends its batch: the failure becomes a torn stream
+	//! ("Connection closed while waiting for COLMETADATA") instead of the clean
+	//! "not in Idle state". Materialization alone cannot fix that, because the
+	//! race is between the initializations, not inside them.
+	//!
+	//! So a materialized scan holds this from before its batch until after its
+	//! drain. It is contended only by scans that are already serialized by
+	//! construction — they share one pinned connection and cannot run in parallel
+	//! anyway — so it costs nothing that was not already sequential.
+	std::mutex &MaterializeMutex() {
+		return materialize_mutex_;
+	}
+
 	optional_ptr<SchemaCatalogEntry> LookupSchema(CatalogTransaction transaction, const EntryLookupInfo &schema_lookup,
 												  OnEntryNotFound if_not_found) override;
 
@@ -280,6 +317,11 @@ protected:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 
 private:
+	//! See MaterializeMutex(). Not the transaction's connection_mutex_: that one
+	//! guards the pinned-connection member accessors and is taken and released
+	//! inside them, where this must span a whole batch-and-drain.
+	std::mutex materialize_mutex_;
+
 	// Issue #225: -1 = not observed yet, 0 = declined, 1 = granted.
 	std::atomic<int8_t> utf8_support_acked_{-1};
 

--- a/src/include/mssql_functions.hpp
+++ b/src/include/mssql_functions.hpp
@@ -10,6 +10,7 @@
 
 #include "catalog/mssql_column_info.hpp"
 #include "duckdb.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "query/mssql_result_stream.hpp"
@@ -78,6 +79,27 @@ struct MSSQLCatalogScanBindData : public FunctionData {
 	// 0 = no TOP (default), >0 = SELECT TOP N
 	int64_t top_n = 0;
 
+	// Drain this scan into a ColumnDataCollection at InitGlobal instead of
+	// streaming it (issue #239).
+	//
+	// A scan normally holds its TDS connection open across GetData calls. That is
+	// fine while each scan has its own pooled connection, and wrong the moment two
+	// of them must share one — which is exactly what an explicit transaction does,
+	// because the transaction pins a single connection and every read on that
+	// catalog is routed to it. DuckDB does not promise to drain one source before
+	// initializing the next; for a decorrelated subquery (LEFT_DELIM_JOIN +
+	// DELIM_SCAN) it initializes both, and the second batch finds the connection
+	// in Executing:
+	//
+	//     Cannot execute: connection not in Idle state (current: Executing)
+	//
+	// With threads > 1 the two run concurrently and the failure is a torn stream
+	// instead. Materializing releases the connection before InitGlobal returns, so
+	// the next scan finds it Idle.
+	//
+	// Set by MSSQLOptimizer, hence mutable — same as order_by_clause above.
+	mutable bool requires_materialization = false;
+
 	//===----------------------------------------------------------------------===//
 	// RowId Support (Spec 001-pk-rowid-semantics)
 	//===----------------------------------------------------------------------===//
@@ -115,6 +137,13 @@ struct MSSQLCatalogScanBindData : public FunctionData {
 struct MSSQLScanGlobalState : public GlobalTableFunctionState {
 	// Result stream from SQL Server
 	std::unique_ptr<MSSQLResultStream> result_stream;
+
+	// Issue #239: when the bind data asked for materialization, InitGlobal drains
+	// the stream into here and closes it, so the pinned connection is Idle again
+	// before the next scan on the same catalog initializes. Execution then serves
+	// chunks from the collection and never touches the connection.
+	std::unique_ptr<ColumnDataCollection> materialized;
+	ColumnDataScanState materialized_scan;
 
 	// Context name for pool return
 	string context_name;

--- a/src/include/table_scan/mssql_optimizer.hpp
+++ b/src/include/table_scan/mssql_optimizer.hpp
@@ -17,6 +17,10 @@ public:
 	//! Optimizer callback: detect ORDER BY / TOP N patterns above MSSQL scans
 	//! and push them down to SQL Server
 	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+	//! Registered entry point. Runs Optimize over the tree, then the whole-plan
+	//! pass that materializes catalog scans sharing a pinned connection (#239).
+	static void OptimizeRoot(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
 };
 
 }  // namespace duckdb

--- a/src/mssql_extension.cpp
+++ b/src/mssql_extension.cpp
@@ -205,7 +205,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);
 	OptimizerExtension mssql_optimizer;
-	mssql_optimizer.optimize_function = MSSQLOptimizer::Optimize;
+	mssql_optimizer.optimize_function = MSSQLOptimizer::OptimizeRoot;
 	OptimizerExtension::Register(config, std::move(mssql_optimizer));
 }
 

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -250,6 +250,7 @@ unique_ptr<FunctionData> MSSQLCatalogScanBindData::Copy() const {
 	// ORDER BY pushdown fields (Spec 039)
 	result->order_by_clause = order_by_clause;
 	result->top_n = top_n;
+	result->requires_materialization = requires_materialization;
 	// RowId support fields
 	result->rowid_requested = rowid_requested;
 	result->pk_column_names = pk_column_names;

--- a/src/table_scan/mssql_optimizer.cpp
+++ b/src/table_scan/mssql_optimizer.cpp
@@ -10,7 +10,7 @@
 // We must look through these projections to find the underlying scan.
 
 #include "table_scan/mssql_optimizer.hpp"
-#include <cstdlib>
+#include <map>
 #include <unordered_set>
 #include "catalog/mssql_catalog.hpp"
 #include "duckdb/main/database.hpp"
@@ -647,6 +647,72 @@ static void TryPushTopN(ClientContext &context, unique_ptr<LogicalOperator> &pla
 //------------------------------------------------------------------------------
 // Main optimizer entry point
 //------------------------------------------------------------------------------
+//===----------------------------------------------------------------------===//
+// Issue #239: two scans of one catalog cannot share a pinned connection
+//===----------------------------------------------------------------------===//
+//
+// An explicit transaction pins ONE TDS connection per catalog, and every read on
+// that catalog is routed to it. A scan holds that connection from InitGlobal
+// until its last row is drained, and DuckDB does not promise to drain one source
+// before initializing the next — a decorrelated subquery (LEFT_DELIM_JOIN +
+// DELIM_SCAN) initializes both, and the second batch finds the connection in
+// Executing:
+//
+//     Cannot execute: connection not in Idle state (current: Executing)
+//
+// With threads > 1 the two run concurrently and it is a torn stream instead.
+//
+// So: in an explicit transaction, a plan with MORE THAN ONE scan of the same
+// catalog materializes all of them. Autocommit is untouched — there each scan
+// takes its own pooled connection, which is why the same query passes outside a
+// transaction.
+//
+// ALL of them, not "all but the first": which source DuckDB initializes first is
+// a scheduling detail rather than a plan property, and the DELIM case initializes
+// both before draining either. duckdb-postgres, which has the same one-connection
+// constraint, does the same.
+//
+// Memory is bounded by the buffer manager — ColumnDataCollection spills — and the
+// shape that needs this is metadata-sized by nature: it is a transaction doing
+// several reads of its own catalog, not a bulk scan.
+static void CollectCatalogScans(LogicalOperator &op, std::map<string, vector<MSSQLCatalogScanBindData *>> &by_catalog) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		auto &get = op.Cast<LogicalGet>();
+		// static_cast, not dynamic_cast: this repo keeps RTTI off the planning path
+		// (job 1124 removed one from MSSQLCatalogScanCardinality for the same
+		// reason; mssql_storage.cpp and azure_secret_reader.cpp say why). The
+		// function-name test above is the discriminator — a LogicalGet naming
+		// mssql_catalog_scan can only carry our bind data, because we are the only
+		// thing that binds it.
+		if (get.function.name == "mssql_catalog_scan" && get.bind_data) {
+			auto &bind_data = get.bind_data->Cast<MSSQLCatalogScanBindData>();
+			by_catalog[bind_data.context_name].push_back(&bind_data);
+		}
+	}
+	for (auto &child : op.children) {
+		CollectCatalogScans(*child, by_catalog);
+	}
+}
+
+static void MaterializeSharedConnectionScans(ClientContext &context, LogicalOperator &plan) {
+	// Autocommit gives every scan its own pooled connection, so there is nothing
+	// to share and nothing to serialize. This is the same test the DML executors
+	// use to decide whether they are on a pinned connection.
+	if (context.transaction.IsAutoCommit()) {
+		return;
+	}
+	std::map<string, vector<MSSQLCatalogScanBindData *>> by_catalog;
+	CollectCatalogScans(plan, by_catalog);
+	for (auto &entry : by_catalog) {
+		if (entry.second.size() < 2) {
+			continue;
+		}
+		for (auto *bind_data : entry.second) {
+			bind_data->requires_materialization = true;
+		}
+	}
+}
+
 void MSSQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	// Try each pattern on the current node
 	TryPushTopN(input.context, plan);
@@ -657,6 +723,12 @@ void MSSQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<Logical
 	for (auto &child : plan->children) {
 		Optimize(input, child);
 	}
+}
+
+void MSSQLOptimizer::OptimizeRoot(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	Optimize(input, plan);
+	// Whole-plan property, so it runs once at the root rather than per node.
+	MaterializeSharedConnectionScans(input.context, *plan);
 }
 
 }  // namespace duckdb

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -5,7 +5,8 @@
 #include "table_scan/table_scan.hpp"
 #include <algorithm>
 #include <cctype>
-#include <cstdlib>
+#include <mutex>
+#include "catalog/mssql_catalog.hpp"
 #include "catalog/mssql_table_entry.hpp"
 #include "connection/mssql_settings.hpp"
 #include "duckdb/catalog/catalog.hpp"
@@ -43,6 +44,7 @@ namespace mssql {
 
 // Forward declarations for internal functions
 static void TableScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output);
+static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, idx_t row_count);
 
 //------------------------------------------------------------------------------
 // VARCHAR to NVARCHAR Conversion Helpers (Spec 026)
@@ -445,7 +447,19 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 
 	MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: generated query = %s", query.c_str());
 
-	// Execute the query
+	// Execute the query.
+	//
+	// Issue #239: a materialized scan holds the catalog's materialize mutex from
+	// here until after its drain below. R2's drain alone is enough at threads = 1,
+	// where DuckDB initializes the two sources in sequence; with threads > 1 the
+	// InitGlobals race and the second batch lands mid-stream. The lock makes the
+	// pair sequential, which they already are by construction — they share one
+	// pinned connection.
+	std::unique_lock<std::mutex> materialize_lock;
+	if (bind_data.requires_materialization) {
+		auto &catalog = Catalog::GetCatalog(context, bind_data.context_name).Cast<MSSQLCatalog>();
+		materialize_lock = std::unique_lock<std::mutex>(catalog.MaterializeMutex());
+	}
 	MSSQLQueryExecutor executor(bind_data.context_name);
 	result->result_stream = executor.Execute(context, query);
 
@@ -568,6 +582,58 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 		}
 	}
 
+	// Issue #239: drain now, so the connection is Idle before the next scan on this
+	// catalog initializes.
+	//
+	// Only reachable when MSSQLOptimizer set the flag, which it does for a plan
+	// holding more than one scan of this catalog inside an explicit transaction —
+	// the case where all of them share the one pinned connection. Streaming is
+	// untouched everywhere else.
+	//
+	// The drain deliberately reuses the normal execution path rather than a second
+	// row reader: FillChunk applies the projection, the rowid construction and the
+	// warnings exactly as a streaming scan would, so a materialized scan and a
+	// streamed one cannot diverge in what they produce.
+	if (bind_data.requires_materialization && result->result_stream) {
+		MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: materializing (issue #239 — shared pinned connection)");
+		// The output shape, derived the same way DuckDB derives it for Execute:
+		// one slot per column_id, the rowid slot carrying the bind data's rowid
+		// type and any other virtual/empty identifier carrying a placeholder that
+		// is never written (projected_column_count bounds what FillChunk fills).
+		vector<LogicalType> chunk_types;
+		chunk_types.reserve(column_ids.size());
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (column_ids[i] == COLUMN_IDENTIFIER_ROW_ID) {
+				chunk_types.push_back(bind_data.rowid_type);
+			} else if (column_ids[i] >= VIRTUAL_COL_START || column_ids[i] >= bind_data.all_types.size()) {
+				chunk_types.push_back(LogicalType::BIGINT);
+			} else {
+				chunk_types.push_back(bind_data.all_types[column_ids[i]]);
+			}
+		}
+		result->materialized = make_uniq<ColumnDataCollection>(Allocator::Get(context), chunk_types);
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), chunk_types);
+		idx_t total = 0;
+		for (;;) {
+			chunk.Reset();
+			const idx_t rows = result->result_stream->FillChunk(chunk);
+			if (rows == 0) {
+				break;
+			}
+			PopulateRowIdVector(*result, chunk, rows);
+			result->materialized->Append(chunk);
+			total += rows;
+		}
+		result->result_stream->SurfaceWarnings(context);
+		// Closing the stream is what releases the connection back to Idle. Without
+		// it the drain would have read every row and still deadlocked the next scan.
+		result->result_stream.reset();
+		result->materialized->InitializeScan(result->materialized_scan);
+		MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: materialized %llu row(s), connection released",
+							 (unsigned long long)total);
+	}
+
 	return std::move(result);
 }
 
@@ -660,6 +726,19 @@ static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, 
 
 static void TableScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
 	auto &global_state = data.global_state->Cast<MSSQLScanGlobalState>();
+
+	// Issue #239: a materialized scan has no stream — InitGlobal drained it and
+	// released the connection. Serve from the collection. This has to come first:
+	// the rowid/PK plumbing below all keys off result_stream, and the rows in the
+	// collection already went through it during the drain.
+	if (global_state.materialized) {
+		output.Reset();
+		global_state.materialized->Scan(global_state.materialized_scan, output);
+		if (output.size() == 0) {
+			global_state.done = true;
+		}
+		return;
+	}
 
 	// Start timing on first call
 	if (!global_state.timing_started) {
@@ -941,6 +1020,10 @@ static void CatalogScanSerialize(Serializer &serializer, const optional_ptr<Func
 	serializer.WriteProperty(103, "complex_filter_where_clause", bind_data.complex_filter_where_clause);
 	serializer.WriteProperty(104, "order_by_clause", bind_data.order_by_clause);
 	serializer.WriteProperty(105, "top_n", bind_data.top_n);
+	// Two scans of one catalog that differ ONLY in this flag must not be folded
+	// together by the common-subplan optimizer: one holds its connection open and
+	// the other does not, which is the whole point of the flag.
+	serializer.WriteProperty(106, "requires_materialization", bind_data.requires_materialization);
 }
 
 // NOTE: nothing in DuckDB round-trips a logical plan today — the only caller of
@@ -956,6 +1039,7 @@ static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserialize
 	auto complex_filter_where_clause = deserializer.ReadProperty<string>(103, "complex_filter_where_clause");
 	auto order_by_clause = deserializer.ReadProperty<string>(104, "order_by_clause");
 	auto top_n = deserializer.ReadProperty<int64_t>(105, "top_n");
+	auto requires_materialization = deserializer.ReadProperty<bool>(106, "requires_materialization");
 
 	auto &context = deserializer.Get<ClientContext &>();
 
@@ -979,6 +1063,7 @@ static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserialize
 	}
 
 	auto &result = bind_data->Cast<MSSQLCatalogScanBindData>();
+	result.requires_materialization = requires_materialization;
 	result.complex_filter_where_clause = complex_filter_where_clause;
 	result.order_by_clause = order_by_clause;
 	result.top_n = top_n;

--- a/test/sql/catalog/default_schema.test
+++ b/test/sql/catalog/default_schema.test
@@ -1,0 +1,57 @@
+# name: test/sql/catalog/default_schema.test
+# description: An MSSQL catalog's default schema is dbo, not DuckDB's main (issue #129)
+# group: [mssql]
+# issue: 129
+
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#
+# Catalog::GetDefaultSchema() answers `main` in the base class, which no SQL
+# Server database has. Anything resolving an unqualified name through the
+# catalog's default therefore failed with "Schema 'main' not found in MSSQL
+# database" -- ducklake hits it on ATTACH, before any table exists, and issue
+# #129 shows a user working around it by CREATEing a schema called `main` on the
+# server.
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS defsch (TYPE mssql);
+
+statement ok
+USE defsch;
+
+query I
+SELECT current_schema();
+----
+dbo
+
+# The point of the default: an unqualified name resolves without the caller
+# naming a schema, which is what every generic catalog consumer does.
+statement ok
+SELECT mssql_exec('defsch', 'IF OBJECT_ID(''dbo.DefSchProbe'',''U'') IS NOT NULL DROP TABLE dbo.DefSchProbe');
+
+statement ok
+SELECT mssql_exec('defsch', 'CREATE TABLE dbo.DefSchProbe (id INT)');
+
+statement ok
+SELECT mssql_exec('defsch', 'INSERT INTO dbo.DefSchProbe VALUES (7)');
+
+statement ok
+SELECT mssql_invalidate_cache('defsch');
+
+query I
+SELECT id FROM DefSchProbe;
+----
+7
+
+statement ok
+SELECT mssql_exec('defsch', 'DROP TABLE dbo.DefSchProbe');
+
+statement ok
+USE memory;
+
+statement ok
+DETACH defsch;

--- a/test/sql/transaction/transaction_multi_scan_materialization.test
+++ b/test/sql/transaction/transaction_multi_scan_materialization.test
@@ -1,0 +1,155 @@
+# name: test/sql/transaction/transaction_multi_scan_materialization.test
+# description: Two scans of one catalog inside an explicit transaction share the pinned connection (issue #239)
+# group: [mssql]
+# issue: 239
+
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#
+# An explicit transaction pins ONE TDS connection per catalog and routes every
+# read on that catalog to it. A scan holds that connection from InitGlobal until
+# its last row is drained, and DuckDB does not promise to drain one source before
+# initializing the next. Before the fix this failed two different ways:
+#
+#   threads = 1   IO Error: ... Cannot execute: connection not in Idle state
+#                 (current: Executing)
+#   threads > 1   IO Error: Connection closed while waiting for COLMETADATA
+#                 (the two InitGlobals race and tear the stream)
+#
+# THE QUERY SHAPE MATTERS AND IS NOT THE OBVIOUS ONE. A correlated subquery in
+# the SELECT list -- `SELECT p.id, (SELECT list(c.v) ... )` -- does NOT reproduce
+# it: DuckDB decorrelates that into a hash join whose sources are drained in
+# sequence, and it passes on the broken build too. What reproduces it is a
+# correlated subquery in a PREDICATE, which plans as LEFT_DELIM_JOIN + DELIM_SCAN
+# and initializes both sides before draining either. Verified both ways against
+# the pre-fix binary.
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS i239 (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('i239', 'IF OBJECT_ID(''dbo.I239Child'',''U'') IS NOT NULL DROP TABLE dbo.I239Child');
+
+statement ok
+SELECT mssql_exec('i239', 'IF OBJECT_ID(''dbo.I239Parent'',''U'') IS NOT NULL DROP TABLE dbo.I239Parent');
+
+statement ok
+SELECT mssql_exec('i239', 'CREATE TABLE dbo.I239Parent (id INT PRIMARY KEY, name VARCHAR(50))');
+
+statement ok
+SELECT mssql_exec('i239', 'CREATE TABLE dbo.I239Child (cid INT PRIMARY KEY, pid INT, v VARCHAR(50))');
+
+# Enough rows that a scan spans several chunks: at three rows the first source
+# finishes inside one chunk and the sources never overlap, so even the DELIM plan
+# passes on a broken build.
+statement ok
+SELECT mssql_exec('i239', 'INSERT INTO dbo.I239Parent (id, name) SELECT TOP 5000 ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), ''p'' FROM sys.all_objects a CROSS JOIN sys.all_objects b');
+
+statement ok
+SELECT mssql_exec('i239', 'INSERT INTO dbo.I239Child (cid, pid, v) SELECT TOP 12000 ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), (ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 5000) + 1, ''v'' FROM sys.all_objects a CROSS JOIN sys.all_objects b');
+
+# =============================================================================
+# Single-threaded: the "not in Idle state" failure
+# =============================================================================
+
+statement ok
+SET threads = 1;
+
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id);
+----
+4997
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# Multi-threaded: the torn-stream failure. Materializing at InitGlobal is not
+# enough on its own here -- the two InitGlobals run concurrently, so the drain
+# has not happened when the second batch is sent. This passes only because a
+# materialized scan also holds the catalog's materialize mutex across its batch.
+# =============================================================================
+
+statement ok
+SET threads = 4;
+
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id);
+----
+4997
+
+statement ok
+COMMIT;
+
+# Three scans of the same catalog, still one connection.
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id)
+  AND p.id < (SELECT max(x.id) FROM i239.dbo.I239Parent x);
+----
+4996
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# Autocommit is untouched: each scan takes its own pooled connection, so the
+# same query never needed materializing and must not start doing so.
+# =============================================================================
+
+statement ok
+SET threads = 4;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id);
+----
+4997
+
+# =============================================================================
+# The materialized rows are the same rows, not merely the same count: the drain
+# reuses FillChunk, so projection, ordering and values have to survive it.
+# =============================================================================
+
+statement ok
+BEGIN;
+
+query II
+SELECT p.id, p.name FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id)
+ORDER BY p.id LIMIT 3;
+----
+4	p
+5	p
+6	p
+
+statement ok
+COMMIT;
+
+statement ok
+SET threads = 1;
+
+# Cleanup
+statement ok
+SELECT mssql_exec('i239', 'DROP TABLE dbo.I239Child');
+
+statement ok
+SELECT mssql_exec('i239', 'DROP TABLE dbo.I239Parent');
+
+statement ok
+DETACH i239;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mssql-extension",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "DuckDB extension for Microsoft SQL Server using native TDS protocol",
   "dependencies": [
     "openssl",


### PR DESCRIPTION
Targets **`duckdb-v1.5.5`** (the released v1.5.5 / v0.2.x maintenance line), not `main` — `main` has moved to the duckdb 2.0 pre-release, and the consumer that needs this ships on released duckdb.

Closes [#129](https://github.com/hugr-lab/mssql-extension/issues/129) and [#239](https://github.com/hugr-lab/mssql-extension/issues/239).

Both fixes are things a **generic catalog consumer** hits immediately. Found while building a DuckLake catalog manager over an attached MSSQL database, but neither is specific to that: they are about the extension behaving like a catalog rather than like a query function.

---

## R1 — the default schema is `dbo`, not `main` (#129)

`MSSQLCatalog` did not override `Catalog::GetDefaultSchema()`, so the base answer `main` came back — a schema no SQL Server database has. Anything resolving an unqualified name through the catalog's default failed:

```
Schema 'main' not found in MSSQL database
```

#129 shows a user working around it by CREATEing a schema literally called `main` on the server.

A constant, not a per-login `SCHEMA_NAME()` lookup: that would put a round trip on ATTACH and needs an answer on the lazy-validation path, where no connection exists yet. A login with a different default still addresses its tables by qualified name; only the unqualified default is wrong for it, which is today's behaviour minus the failure.

## R2/R3 — two scans of one catalog on the pinned connection (#239)

A transaction pins **one** TDS connection per catalog and routes every read there. A scan holds that connection from `InitGlobal` until its last row is drained, and DuckDB does not promise to drain one source before initializing the next.

In an explicit transaction, a plan with more than one scan of the same catalog now drains each into a buffer-managed `ColumnDataCollection` at `InitGlobal` and releases the connection before returning. **Autocommit is untouched** — there each scan takes its own pooled connection, which is why the same query always worked outside a transaction. The mechanism mirrors duckdb-postgres, which has the same one-connection constraint, and matches spec 066 D1.

### Two findings that changed the plan, both from running it

**1. The reproducing shape is not the obvious one.** A correlated subquery in the SELECT list —

```sql
SELECT p.id, (SELECT list(c.v) FROM child c WHERE c.pid = p.id) FROM parent p
```

— does **not** reproduce it. DuckDB decorrelates that into a hash join whose sources are drained in sequence, and it passes on the broken build. What reproduces it is a correlated subquery in a **predicate**, which plans as `LEFT_DELIM_JOIN` + `DELIM_SCAN` and initializes both sides before draining either:

```sql
SELECT p.id FROM parent p WHERE p.id > (SELECT count(*) FROM child c WHERE c.pid = p.id)
```

The regression test uses that shape and was verified to fail on the pre-fix binary with the exact documented errors. A test built on the first shape would have passed on a broken build.

**2. Materialization alone fixes `threads = 1` and *not* `threads > 1`.** There the two `InitGlobal`s run **concurrently**, so the drain has not happened when the second batch is sent, and the failure is a torn stream rather than `not in Idle state`. The race is between the initializations, not inside them. So a materialized scan also holds a per-catalog mutex across batch-and-drain. Verified at threads 1, 4 and 8.

| | before | after |
|---|---|---|
| `threads = 1` | `Cannot execute: connection not in Idle state (current: Executing)` | 4997 rows |
| `threads = 4` | `Connection closed while waiting for COLMETADATA` | 4997 rows |
| `threads = 8` | (same) | 4997 rows |
| autocommit | passed | passed, and takes no new path |

## Verified

- Build clean, `clang-format-14` clean.
- **Suite: 166 test cases, 5225 assertions, 0 failures** against SQL Server 2025 (164/5182 before; the two new files are the delta).
- **Both new tests confirmed to fail on the pre-fix binary** — `not in Idle state` for #239, a failed `current_schema()` assertion for #129. A regression test that passes before the fix is decoration.
- `clangd --check` on every touched file: 0 compile diagnostics.

## Note for the forward-port to `main`

duckdb 2.0 changed the signature:

```cpp
// 1.5.5   virtual string GetDefaultSchema() const;
// 2.0     virtual optional<Identifier> GetDefaultSchema() const;
```

R1 as written here **will not compile** on `main`, and the port is not a cast: 2.0 gives `nullopt` the meaning *"this catalog has no default schema, do not probe an implicit one"* and documents an empty `Identifier` as *"unspecified"*, so the port must deliberately return `Identifier("dbo")`.

R2/R3 should port more cleanly, but `LogicalGet`, `TableFunctionInitInput` and `MaxThreads()` all need re-checking on 2.0 — `TableFunctionInitInput::projected_types()` does not exist on 1.5.5 and the types are derived by hand here, which may be avoidable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz