### PR TITLE
fix(catalog): the v0.2.5 fixes on the duckdb 2.0 line, plus mssql_scan on the pinned connection (#129, #239, #316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Forward-port of the v0.2.5 fixes to the duckdb 2.0 line** (#314). The
+  released v0.2.5 sits on the `duckdb-v1.5.5` maintenance branch; these are the
+  same two fixes against duckdb `main`.
+  - **An MSSQL catalog's default schema is `dbo`** (#129). `Catalog::GetDefaultSchema()`
+    answered `main` from the base class, which no SQL Server database has, so
+    anything resolving an unqualified name through the catalog default failed
+    with `Schema 'main' not found` — ducklake hits it on ATTACH, before any
+    table exists. On the 2.0 API the signature is `optional<Identifier>`, where
+    `nullopt` means "this catalog has no default, do not try"; we return
+    `Identifier("dbo")`.
+  - **Two scans of one catalog inside a transaction** (#239). A transaction pins
+    one connection and routes every read of that catalog to it, but a scan holds
+    that connection from `InitGlobal` until its last row, and DuckDB does not
+    promise to drain one source before starting the next. Such plans are now
+    materialized into a buffer-managed collection as each scan starts, freeing
+    the connection immediately. Autocommit is untouched.
+
+- **`mssql_scan()` inside a transaction took the pinned connection and kept it**
+  (#316). The #239 gate runs on the optimized plan and sees only
+  `mssql_catalog_scan`. `mssql_scan()` is unreachable from there by construction:
+  it executes its query during **binding** — that is how it reads the result's
+  column types — so a second scan of the catalog failed inside its own Bind,
+  before any `InitGlobal` and long before the gate. Reported shapes were
+  `Connection closed unexpectedly` (catalog scan + `mssql_scan`) and
+  `Cannot execute: connection not in Idle state` (two `mssql_scan`). It now
+  drains at Bind whenever the session is not in autocommit — the trigger is "in
+  a transaction", not "more than one scan", because Bind cannot see the rest of
+  the plan. Autocommit still streams.
+
+- **The materialized scan could not spill** (#318, thanks @oluies). It was built
+  from `Allocator::Get(context)`, and that overload is duckdb's
+  `IN_MEMORY_ALLOCATOR` one: unaccounted against the buffer manager and unable to
+  spill, so a large materialized scan grew in process memory until it OOMed while
+  the docs promised the opposite. Built from the `ClientContext` overload, which
+  defaults to `BUFFER_MANAGER_ALLOCATOR`.
+
 ## [0.2.4] - 2026-08-17
 
 ### Fixed

--- a/src/catalog/mssql_catalog.cpp
+++ b/src/catalog/mssql_catalog.cpp
@@ -292,6 +292,12 @@ string MSSQLCatalog::GetCatalogType() {
 	return "mssql";
 }
 
+optional<Identifier> MSSQLCatalog::GetDefaultSchema() const {
+	// See the header: a value (not nullopt, not an empty Identifier) is what says
+	// "probe dbo for unqualified names".
+	return Identifier("dbo");
+}
+
 //===----------------------------------------------------------------------===//
 // Schema Operations
 //===----------------------------------------------------------------------===//

--- a/src/include/catalog/mssql_catalog.hpp
+++ b/src/include/catalog/mssql_catalog.hpp
@@ -70,6 +70,51 @@ public:
 
 	string GetCatalogType() override;
 
+	//! SQL Server's default schema, not DuckDB's `main`.
+	//!
+	//! The base Catalog answers `main`, which no SQL Server database has, so
+	//! anything that resolves an unqualified name through the catalog's default
+	//! fails with "Schema 'main' not found in MSSQL database". ducklake hits this
+	//! on ATTACH — DuckLakeTransaction::GetDefaultSchemaName() asks for it before
+	//! any table exists — and issue #129 shows a user working around it by
+	//! CREATEing a schema literally called `main` on the server.
+	//!
+	//! `dbo` is the constant answer rather than a per-login lookup: it is the
+	//! default for every login that has not been given another, and resolving
+	//! SCHEMA_NAME() would put a round trip on ATTACH and need an answer on the
+	//! lazy-validation path, where no connection has been made yet. A login whose
+	//! default schema is not `dbo` still addresses its tables by qualified name;
+	//! only the unqualified default is wrong for it, which is the pre-existing
+	//! behaviour minus the crash.
+	//!
+	//! On the duckdb 2.0 line the return type is optional<Identifier>, and the
+	//! three answers are distinct: a value means "probe this schema for
+	//! unqualified names", nullopt means "this catalog HAS no default, never
+	//! probe", and an empty Identifier means "unspecified" elsewhere in the
+	//! catalog. We mean the first, so this returns Identifier("dbo") and neither
+	//! of the empty forms. (The v0.2.x line on duckdb 1.5.5 returns a plain
+	//! string; that is the only difference between the two ports.)
+	optional<Identifier> GetDefaultSchema() const override;
+
+	//! Serializes materialized catalog scans against each other (issue #239).
+	//!
+	//! R2 drains a scan inside InitGlobal so the pinned connection is Idle again
+	//! before the next scan starts — which is enough at threads = 1, where DuckDB
+	//! initializes the two sources in sequence. With threads > 1 the two
+	//! InitGlobals run CONCURRENTLY and the drain has not happened yet when the
+	//! second one sends its batch: the failure becomes a torn stream
+	//! ("Connection closed while waiting for COLMETADATA") instead of the clean
+	//! "not in Idle state". Materialization alone cannot fix that, because the
+	//! race is between the initializations, not inside them.
+	//!
+	//! So a materialized scan holds this from before its batch until after its
+	//! drain. It is contended only by scans that are already serialized by
+	//! construction — they share one pinned connection and cannot run in parallel
+	//! anyway — so it costs nothing that was not already sequential.
+	std::mutex &MaterializeMutex() {
+		return materialize_mutex_;
+	}
+
 	optional_ptr<SchemaCatalogEntry> LookupSchema(CatalogTransaction transaction, const EntryLookupInfo &schema_lookup,
 												  OnEntryNotFound if_not_found) override;
 
@@ -280,6 +325,11 @@ protected:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 
 private:
+	//! See MaterializeMutex(). Not the transaction's connection_mutex_: that one
+	//! guards the pinned-connection member accessors and is taken and released
+	//! inside them, where this must span a whole batch-and-drain.
+	std::mutex materialize_mutex_;
+
 	// Issue #225: -1 = not observed yet, 0 = declined, 1 = granted.
 	std::atomic<int8_t> utf8_support_acked_{-1};
 

--- a/src/include/mssql_functions.hpp
+++ b/src/include/mssql_functions.hpp
@@ -38,6 +38,28 @@ struct MSSQLScanBindData : public FunctionData {
 	// no pre-built stream (InitGlobal then re-executes the query).
 	string result_stream_id;
 
+	// Issue #316: inside an explicit transaction, Bind drains the result here and
+	// closes the stream instead of registering it.
+	//
+	// mssql_scan executes its query at BIND time — it has to, the schema comes
+	// from the batch's own COLMETADATA — and then holds the connection open until
+	// execution drains it. In a transaction that connection is the ONE pinned
+	// connection, so a second mssql_scan fails in its own Bind, before any
+	// InitGlobal runs. The catalog scan's fix cannot reach that: materializing at
+	// InitGlobal is too late, and the optimizer gate that decides it runs later
+	// still.
+	//
+	// So the trigger here is "in a transaction", not "more than one scan": Bind
+	// cannot know what else the plan will hold. That does buffer a lone
+	// mssql_scan that would have streamed — but inside a transaction such a scan
+	// could not have coexisted with anything else on that catalog anyway, so this
+	// turns a failing case into a slower one rather than taking a working case
+	// away.
+	//
+	// shared_ptr because FunctionData::Copy has to share it rather than duplicate
+	// the rows.
+	shared_ptr<ColumnDataCollection> materialized;
+
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other) const override;
 };
@@ -144,6 +166,12 @@ struct MSSQLScanGlobalState : public GlobalTableFunctionState {
 	// before the next scan on the same catalog initializes. Execution then serves
 	// chunks from the collection and never touches the connection.
 	std::unique_ptr<ColumnDataCollection> materialized;
+
+	// Issue #316: the raw mssql_scan materializes at BIND, not here, so its
+	// collection is owned by the bind data and shared rather than moved — the
+	// same bind data can init more than one global state.
+	shared_ptr<ColumnDataCollection> materialized_shared;
+
 	ColumnDataScanState materialized_scan;
 
 	// Context name for pool return

--- a/src/include/mssql_functions.hpp
+++ b/src/include/mssql_functions.hpp
@@ -10,6 +10,7 @@
 
 #include "catalog/mssql_column_info.hpp"
 #include "duckdb.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "query/mssql_result_stream.hpp"
@@ -79,6 +80,27 @@ struct MSSQLCatalogScanBindData : public FunctionData {
 	// 0 = no TOP (default), >0 = SELECT TOP N
 	int64_t top_n = 0;
 
+	// Drain this scan into a ColumnDataCollection at InitGlobal instead of
+	// streaming it (issue #239).
+	//
+	// A scan normally holds its TDS connection open across GetData calls. That is
+	// fine while each scan has its own pooled connection, and wrong the moment two
+	// of them must share one — which is exactly what an explicit transaction does,
+	// because the transaction pins a single connection and every read on that
+	// catalog is routed to it. DuckDB does not promise to drain one source before
+	// initializing the next; for a decorrelated subquery (LEFT_DELIM_JOIN +
+	// DELIM_SCAN) it initializes both, and the second batch finds the connection
+	// in Executing:
+	//
+	//     Cannot execute: connection not in Idle state (current: Executing)
+	//
+	// With threads > 1 the two run concurrently and the failure is a torn stream
+	// instead. Materializing releases the connection before InitGlobal returns, so
+	// the next scan finds it Idle.
+	//
+	// Set by MSSQLOptimizer, hence mutable — same as order_by_clause above.
+	mutable bool requires_materialization = false;
+
 	//===----------------------------------------------------------------------===//
 	// RowId Support (Spec 001-pk-rowid-semantics)
 	//===----------------------------------------------------------------------===//
@@ -116,6 +138,13 @@ struct MSSQLCatalogScanBindData : public FunctionData {
 struct MSSQLScanGlobalState : public GlobalTableFunctionState {
 	// Result stream from SQL Server
 	std::unique_ptr<MSSQLResultStream> result_stream;
+
+	// Issue #239: when the bind data asked for materialization, InitGlobal drains
+	// the stream into here and closes it, so the pinned connection is Idle again
+	// before the next scan on the same catalog initializes. Execution then serves
+	// chunks from the collection and never touches the connection.
+	std::unique_ptr<ColumnDataCollection> materialized;
+	ColumnDataScanState materialized_scan;
 
 	// Context name for pool return
 	string context_name;

--- a/src/include/table_scan/mssql_optimizer.hpp
+++ b/src/include/table_scan/mssql_optimizer.hpp
@@ -17,6 +17,10 @@ public:
 	//! Optimizer callback: detect ORDER BY / TOP N patterns above MSSQL scans
 	//! and push them down to SQL Server
 	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+	//! Registered entry point. Runs Optimize over the tree, then the whole-plan
+	//! pass that materializes catalog scans sharing a pinned connection (#239).
+	static void OptimizeRoot(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
 };
 
 }  // namespace duckdb

--- a/src/mssql_extension.cpp
+++ b/src/mssql_extension.cpp
@@ -203,7 +203,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);
 	OptimizerExtension mssql_optimizer;
-	mssql_optimizer.optimize_function = MSSQLOptimizer::Optimize;
+	mssql_optimizer.optimize_function = MSSQLOptimizer::OptimizeRoot;
 	OptimizerExtension::Register(config, std::move(mssql_optimizer));
 }
 

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -47,6 +47,8 @@ unique_ptr<FunctionData> MSSQLScanBindData::Copy() const {
 	result->return_types = return_types;
 	result->column_names = column_names;
 	result->result_stream_id = result_stream_id;
+	// Shared, not copied: the rows are the same rows (issue #316).
+	result->materialized = materialized;
 	return std::move(result);
 }
 
@@ -127,13 +129,44 @@ unique_ptr<FunctionData> MSSQLScanBind(ClientContext &context, TableFunctionBind
 	bind_data->return_types = return_types;
 	bind_data->column_names = result_stream->GetColumnNames();
 
-	// Register the result stream for later retrieval in InitGlobal
-	// This avoids executing the query twice (which causes 30s timeout on large datasets)
-	// Spec 047 / US3: registry lives on MSSQLCatalog (previously process-wide singleton).
 	auto &catalog = Catalog::GetCatalog(context, Identifier(bind_data->context_name));
 	auto &mssql_catalog = catalog.Cast<MSSQLCatalog>();
-	bind_data->result_stream_id = mssql_catalog.RegisterStream(std::move(result_stream));
-	MSSQL_FN_DEBUG_LOG(1, "MSSQLScanBind: registered result_stream_id=%s", bind_data->result_stream_id.c_str());
+
+	if (!context.transaction.IsAutoCommit()) {
+		// Issue #316: this connection is the transaction's ONE pinned connection.
+		// Holding it open until execution makes the NEXT mssql_scan fail in its own
+		// Bind, before any InitGlobal runs — which is why the catalog scan's fix
+		// cannot reach this path. Drain here and close it. See the `materialized`
+		// comment on MSSQLScanBindData for why the trigger is the transaction and
+		// not a count of scans.
+		MSSQL_FN_DEBUG_LOG(1, "MSSQLScanBind: in a transaction — draining to release the pinned connection");
+		auto collection = make_shared_ptr<ColumnDataCollection>(context, bind_data->return_types);
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), bind_data->return_types);
+		idx_t total = 0;
+		for (;;) {
+			chunk.Reset();
+			const idx_t rows = result_stream->FillChunk(chunk);
+			if (rows == 0) {
+				break;
+			}
+			collection->Append(chunk);
+			total += rows;
+		}
+		result_stream->SurfaceWarnings(context);
+		// Closing is what returns the connection to Idle; draining alone does not.
+		result_stream.reset();
+		bind_data->materialized = std::move(collection);
+		MSSQL_FN_DEBUG_LOG(1, "MSSQLScanBind: materialized %llu row(s), pinned connection released",
+						   (unsigned long long)total);
+	} else {
+		// Autocommit: this scan holds a pooled connection of its own, so streaming
+		// costs nobody anything. Register the stream so execution reuses it instead
+		// of running the query twice (a 30 s timeout on large results).
+		// Spec 047 / US3: registry lives on MSSQLCatalog.
+		bind_data->result_stream_id = mssql_catalog.RegisterStream(std::move(result_stream));
+		MSSQL_FN_DEBUG_LOG(1, "MSSQLScanBind: registered result_stream_id=%s", bind_data->result_stream_id.c_str());
+	}
 
 	auto bind_end = std::chrono::steady_clock::now();
 	auto bind_ms = std::chrono::duration_cast<std::chrono::milliseconds>(bind_end - bind_start).count();
@@ -149,6 +182,15 @@ unique_ptr<GlobalTableFunctionState> MSSQLScanInitGlobal(ClientContext &context,
 	auto &bind_data = input.bind_data->Cast<MSSQLScanBindData>();
 	auto result = make_uniq<MSSQLScanGlobalState>();
 	result->context_name = bind_data.context_name;
+
+	// Issue #316: Bind already drained this one and released the connection.
+	if (bind_data.materialized) {
+		result->materialized_shared = bind_data.materialized;
+		result->materialized_shared->InitializeScan(result->materialized_scan);
+		MSSQL_FN_DEBUG_LOG(1, "MSSQLScanInitGlobal: serving %llu materialized row(s)",
+						   (unsigned long long)result->materialized_shared->Count());
+		return std::move(result);
+	}
 
 	// Try to retrieve pre-initialized result stream from registry
 	// This was created in Bind and avoids executing the query twice
@@ -191,6 +233,17 @@ unique_ptr<LocalTableFunctionState> MSSQLScanInitLocal(ExecutionContext &context
 
 void MSSQLScanFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
 	auto &global_state = data.global_state->Cast<MSSQLScanGlobalState>();
+
+	// Issue #316: materialized at Bind, so there is no stream to read. Must come
+	// before the `!result_stream` test below, which would report "done" at once.
+	if (global_state.materialized_shared) {
+		output.Reset();
+		global_state.materialized_shared->Scan(global_state.materialized_scan, output);
+		if (output.size() == 0) {
+			global_state.done = true;
+		}
+		return;
+	}
 
 	// Start timing on first call
 	if (!global_state.timing_started) {

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -250,6 +250,7 @@ unique_ptr<FunctionData> MSSQLCatalogScanBindData::Copy() const {
 	// ORDER BY pushdown fields (Spec 039)
 	result->order_by_clause = order_by_clause;
 	result->top_n = top_n;
+	result->requires_materialization = requires_materialization;
 	// RowId support fields
 	result->rowid_requested = rowid_requested;
 	result->pk_column_names = pk_column_names;

--- a/src/table_scan/mssql_optimizer.cpp
+++ b/src/table_scan/mssql_optimizer.cpp
@@ -10,7 +10,7 @@
 // We must look through these projections to find the underlying scan.
 
 #include "table_scan/mssql_optimizer.hpp"
-#include <cstdlib>
+#include <map>
 #include <unordered_set>
 #include "catalog/mssql_catalog.hpp"
 #include "duckdb/main/database.hpp"
@@ -645,6 +645,72 @@ static void TryPushTopN(ClientContext &context, unique_ptr<LogicalOperator> &pla
 //------------------------------------------------------------------------------
 // Main optimizer entry point
 //------------------------------------------------------------------------------
+//===----------------------------------------------------------------------===//
+// Issue #239: two scans of one catalog cannot share a pinned connection
+//===----------------------------------------------------------------------===//
+//
+// An explicit transaction pins ONE TDS connection per catalog, and every read on
+// that catalog is routed to it. A scan holds that connection from InitGlobal
+// until its last row is drained, and DuckDB does not promise to drain one source
+// before initializing the next — a decorrelated subquery (LEFT_DELIM_JOIN +
+// DELIM_SCAN) initializes both, and the second batch finds the connection in
+// Executing:
+//
+//     Cannot execute: connection not in Idle state (current: Executing)
+//
+// With threads > 1 the two run concurrently and it is a torn stream instead.
+//
+// So: in an explicit transaction, a plan with MORE THAN ONE scan of the same
+// catalog materializes all of them. Autocommit is untouched — there each scan
+// takes its own pooled connection, which is why the same query passes outside a
+// transaction.
+//
+// ALL of them, not "all but the first": which source DuckDB initializes first is
+// a scheduling detail rather than a plan property, and the DELIM case initializes
+// both before draining either. duckdb-postgres, which has the same one-connection
+// constraint, does the same.
+//
+// Memory is bounded by the buffer manager — ColumnDataCollection spills — and the
+// shape that needs this is metadata-sized by nature: it is a transaction doing
+// several reads of its own catalog, not a bulk scan.
+static void CollectCatalogScans(LogicalOperator &op, std::map<string, vector<MSSQLCatalogScanBindData *>> &by_catalog) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		auto &get = op.Cast<LogicalGet>();
+		// static_cast, not dynamic_cast: this repo keeps RTTI off the planning path
+		// (job 1124 removed one from MSSQLCatalogScanCardinality for the same
+		// reason; mssql_storage.cpp and azure_secret_reader.cpp say why). The
+		// function-name test above is the discriminator — a LogicalGet naming
+		// mssql_catalog_scan can only carry our bind data, because we are the only
+		// thing that binds it.
+		if (get.function.name == "mssql_catalog_scan" && get.bind_data) {
+			auto &bind_data = get.bind_data->Cast<MSSQLCatalogScanBindData>();
+			by_catalog[bind_data.context_name].push_back(&bind_data);
+		}
+	}
+	for (auto &child : op.children) {
+		CollectCatalogScans(*child, by_catalog);
+	}
+}
+
+static void MaterializeSharedConnectionScans(ClientContext &context, LogicalOperator &plan) {
+	// Autocommit gives every scan its own pooled connection, so there is nothing
+	// to share and nothing to serialize. This is the same test the DML executors
+	// use to decide whether they are on a pinned connection.
+	if (context.transaction.IsAutoCommit()) {
+		return;
+	}
+	std::map<string, vector<MSSQLCatalogScanBindData *>> by_catalog;
+	CollectCatalogScans(plan, by_catalog);
+	for (auto &entry : by_catalog) {
+		if (entry.second.size() < 2) {
+			continue;
+		}
+		for (auto *bind_data : entry.second) {
+			bind_data->requires_materialization = true;
+		}
+	}
+}
+
 void MSSQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	// Try each pattern on the current node
 	TryPushTopN(input.context, plan);
@@ -655,6 +721,12 @@ void MSSQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<Logical
 	for (auto &child : plan->children) {
 		Optimize(input, child);
 	}
+}
+
+void MSSQLOptimizer::OptimizeRoot(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	Optimize(input, plan);
+	// Whole-plan property, so it runs once at the root rather than per node.
+	MaterializeSharedConnectionScans(input.context, *plan);
 }
 
 }  // namespace duckdb

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -683,7 +683,14 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 				chunk_types.push_back(bind_data.all_types[column_ids[i]]);
 			}
 		}
-		result->materialized = make_uniq<ColumnDataCollection>(Allocator::Get(context), chunk_types);
+		// ClientContext, not Allocator::Get(context) (#318, found by @oluies). The
+		// Allocator overload builds an IN_MEMORY_ALLOCATOR collection — unaccounted
+		// against the buffer manager and unable to spill — so a large materialized
+		// scan grew in process memory until it OOMed, while the docs promised the
+		// opposite. The ClientContext overload defaults to BUFFER_MANAGER_ALLOCATOR.
+		// The chunk below deliberately keeps the plain Allocator: it is one DataChunk,
+		// not the accumulating collection.
+		result->materialized = make_uniq<ColumnDataCollection>(context, chunk_types);
 		DataChunk chunk;
 		chunk.Initialize(Allocator::Get(context), chunk_types);
 		idx_t total = 0;

--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <mutex>
 #include "catalog/mssql_catalog.hpp"
 #include "catalog/mssql_statistics.hpp"
 #include "catalog/mssql_table_entry.hpp"
@@ -49,6 +50,7 @@ namespace mssql {
 
 // Forward declarations for internal functions
 static void TableScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output);
+static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, idx_t row_count);
 
 // Execute the filters the encoder refused to push (see ClientTableFilter) over
 // a filled output chunk. Each filter's expression sees its column as
@@ -516,7 +518,20 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 
 	MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: generated query = %s", query.c_str());
 
-	// Execute the query
+	// Execute the query.
+	//
+	// Issue #239: a materialized scan holds the catalog's materialize mutex from
+	// here until after its drain below. R2's drain alone is enough at threads = 1,
+	// where DuckDB initializes the two sources in sequence; with threads > 1 the
+	// InitGlobals race and the second batch lands mid-stream. The lock makes the
+	// pair sequential, which they already are by construction — they share one
+	// pinned connection.
+	std::unique_lock<std::mutex> materialize_lock;
+	if (bind_data.requires_materialization) {
+		// Identifier at the DuckDB API boundary, std::string inside (CLAUDE.md).
+		auto &catalog = Catalog::GetCatalog(context, Identifier(bind_data.context_name)).Cast<MSSQLCatalog>();
+		materialize_lock = std::unique_lock<std::mutex>(catalog.MaterializeMutex());
+	}
 	MSSQLQueryExecutor executor(bind_data.context_name);
 	result->result_stream = executor.Execute(context, query);
 
@@ -639,6 +654,58 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 		}
 	}
 
+	// Issue #239: drain now, so the connection is Idle before the next scan on this
+	// catalog initializes.
+	//
+	// Only reachable when MSSQLOptimizer set the flag, which it does for a plan
+	// holding more than one scan of this catalog inside an explicit transaction —
+	// the case where all of them share the one pinned connection. Streaming is
+	// untouched everywhere else.
+	//
+	// The drain deliberately reuses the normal execution path rather than a second
+	// row reader: FillChunk applies the projection, the rowid construction and the
+	// warnings exactly as a streaming scan would, so a materialized scan and a
+	// streamed one cannot diverge in what they produce.
+	if (bind_data.requires_materialization && result->result_stream) {
+		MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: materializing (issue #239 — shared pinned connection)");
+		// The output shape, derived the same way DuckDB derives it for Execute:
+		// one slot per column_id, the rowid slot carrying the bind data's rowid
+		// type and any other virtual/empty identifier carrying a placeholder that
+		// is never written (projected_column_count bounds what FillChunk fills).
+		vector<LogicalType> chunk_types;
+		chunk_types.reserve(column_ids.size());
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (column_ids[i] == COLUMN_IDENTIFIER_ROW_ID) {
+				chunk_types.push_back(bind_data.rowid_type);
+			} else if (column_ids[i] >= VIRTUAL_COL_START || column_ids[i] >= bind_data.all_types.size()) {
+				chunk_types.push_back(LogicalType::BIGINT);
+			} else {
+				chunk_types.push_back(bind_data.all_types[column_ids[i]]);
+			}
+		}
+		result->materialized = make_uniq<ColumnDataCollection>(Allocator::Get(context), chunk_types);
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), chunk_types);
+		idx_t total = 0;
+		for (;;) {
+			chunk.Reset();
+			const idx_t rows = result->result_stream->FillChunk(chunk);
+			if (rows == 0) {
+				break;
+			}
+			PopulateRowIdVector(*result, chunk, rows);
+			result->materialized->Append(chunk);
+			total += rows;
+		}
+		result->result_stream->SurfaceWarnings(context);
+		// Closing the stream is what releases the connection back to Idle. Without
+		// it the drain would have read every row and still deadlocked the next scan.
+		result->result_stream.reset();
+		result->materialized->InitializeScan(result->materialized_scan);
+		MSSQL_SCAN_DEBUG_LOG(1, "TableScanInitGlobal: materialized %llu row(s), connection released",
+							 (unsigned long long)total);
+	}
+
 	return std::move(result);
 }
 
@@ -731,6 +798,19 @@ static void PopulateRowIdVector(MSSQLScanGlobalState &state, DataChunk &output, 
 
 static void TableScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
 	auto &global_state = data.global_state->Cast<MSSQLScanGlobalState>();
+
+	// Issue #239: a materialized scan has no stream — InitGlobal drained it and
+	// released the connection. Serve from the collection. This has to come first:
+	// the rowid/PK plumbing below all keys off result_stream, and the rows in the
+	// collection already went through it during the drain.
+	if (global_state.materialized) {
+		output.Reset();
+		global_state.materialized->Scan(global_state.materialized_scan, output);
+		if (output.size() == 0) {
+			global_state.done = true;
+		}
+		return;
+	}
 
 	// Start timing on first call
 	if (!global_state.timing_started) {
@@ -1270,6 +1350,10 @@ static void CatalogScanSerialize(Serializer &serializer, const optional_ptr<Func
 	serializer.WriteProperty(103, "complex_filter_where_clause", bind_data.complex_filter_where_clause);
 	serializer.WriteProperty(104, "order_by_clause", bind_data.order_by_clause);
 	serializer.WriteProperty(105, "top_n", bind_data.top_n);
+	// Two scans of one catalog that differ ONLY in this flag must not be folded
+	// together by the common-subplan optimizer: one holds its connection open and
+	// the other does not, which is the whole point of the flag.
+	serializer.WriteProperty(106, "requires_materialization", bind_data.requires_materialization);
 }
 
 // NOTE: nothing in DuckDB round-trips a logical plan today — the only caller of
@@ -1285,6 +1369,7 @@ static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserialize
 	auto complex_filter_where_clause = deserializer.ReadProperty<string>(103, "complex_filter_where_clause");
 	auto order_by_clause = deserializer.ReadProperty<string>(104, "order_by_clause");
 	auto top_n = deserializer.ReadProperty<int64_t>(105, "top_n");
+	auto requires_materialization = deserializer.ReadProperty<bool>(106, "requires_materialization");
 
 	auto &context = deserializer.Get<ClientContext &>();
 
@@ -1309,6 +1394,7 @@ static unique_ptr<FunctionData> CatalogScanDeserialize(Deserializer &deserialize
 	}
 
 	auto &result = bind_data->Cast<MSSQLCatalogScanBindData>();
+	result.requires_materialization = requires_materialization;
 	result.complex_filter_where_clause = complex_filter_where_clause;
 	result.order_by_clause = order_by_clause;
 	result.top_n = top_n;

--- a/test/sql/catalog/default_schema.test
+++ b/test/sql/catalog/default_schema.test
@@ -1,0 +1,57 @@
+# name: test/sql/catalog/default_schema.test
+# description: An MSSQL catalog's default schema is dbo, not DuckDB's main (issue #129)
+# group: [mssql]
+# issue: 129
+
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#
+# Catalog::GetDefaultSchema() answers `main` in the base class, which no SQL
+# Server database has. Anything resolving an unqualified name through the
+# catalog's default therefore failed with "Schema 'main' not found in MSSQL
+# database" -- ducklake hits it on ATTACH, before any table exists, and issue
+# #129 shows a user working around it by CREATEing a schema called `main` on the
+# server.
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS defsch (TYPE mssql);
+
+statement ok
+USE defsch;
+
+query I
+SELECT current_schema();
+----
+dbo
+
+# The point of the default: an unqualified name resolves without the caller
+# naming a schema, which is what every generic catalog consumer does.
+statement ok
+SELECT mssql_exec('defsch', 'IF OBJECT_ID(''dbo.DefSchProbe'',''U'') IS NOT NULL DROP TABLE dbo.DefSchProbe');
+
+statement ok
+SELECT mssql_exec('defsch', 'CREATE TABLE dbo.DefSchProbe (id INT)');
+
+statement ok
+SELECT mssql_exec('defsch', 'INSERT INTO dbo.DefSchProbe VALUES (7)');
+
+statement ok
+SELECT mssql_invalidate_cache('defsch');
+
+query I
+SELECT id FROM DefSchProbe;
+----
+7
+
+statement ok
+SELECT mssql_exec('defsch', 'DROP TABLE dbo.DefSchProbe');
+
+statement ok
+USE memory;
+
+statement ok
+DETACH defsch;

--- a/test/sql/transaction/transaction_mssql_scan_materialization.test
+++ b/test/sql/transaction/transaction_mssql_scan_materialization.test
@@ -1,0 +1,130 @@
+# name: test/sql/transaction/transaction_mssql_scan_materialization.test
+# description: mssql_scan() inside an explicit transaction releases the pinned connection (issue #316)
+# group: [mssql]
+# issue: 316
+
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#
+# Issue #239 taught catalog scans to materialize on the transaction's pinned
+# connection. mssql_scan() was left out, and it is NOT reachable by the same fix:
+# MSSQLScanBind executes the query to read COLMETADATA and hands the live stream
+# to InitGlobal. So a second scan of the catalog fails inside its own BIND, before
+# any InitGlobal runs and long before the optimizer gate that #239 added.
+#
+# The fix drains at Bind whenever the session is not in autocommit. The trigger is
+# "in a transaction", not "more than one scan": Bind cannot see the rest of the
+# plan, so by the time a count would be available the connection is already held.
+#
+# Pre-fix failures, reproduced on this build:
+#   A  IO Error: Connection closed unexpectedly
+#   B  IO Error: Failed to execute SQL batch: Cannot execute: connection not in
+#      Idle state (current: Executing)
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS i316 (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('i316', 'IF OBJECT_ID(''dbo.I316Rows'',''U'') IS NOT NULL DROP TABLE dbo.I316Rows');
+
+statement ok
+SELECT mssql_exec('i316', 'CREATE TABLE dbo.I316Rows (id INT, v VARCHAR(20))');
+
+# Enough rows to span several chunks -- at a handful the first scan finishes
+# inside one chunk and the two never overlap.
+statement ok
+SELECT mssql_exec('i316', 'INSERT INTO dbo.I316Rows SELECT TOP 5000 ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), ''x'' FROM sys.all_objects a CROSS JOIN sys.all_objects b');
+
+statement ok
+SELECT mssql_invalidate_cache('i316');
+
+statement ok
+SET threads = 4;
+
+# =============================================================================
+# A: a catalog scan and an mssql_scan of the same catalog
+# =============================================================================
+
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i316.dbo.I316Rows p
+WHERE p.id > (SELECT count(*) FROM mssql_scan('i316', 'SELECT id FROM dbo.I316Rows') c WHERE c.id = p.id);
+----
+4999
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# B: two mssql_scan calls, no catalog scan at all -- the optimizer gate never
+# sees these, so only the Bind-time drain saves them.
+# =============================================================================
+
+statement ok
+BEGIN;
+
+query I
+SELECT count(*)
+FROM mssql_scan('i316', 'SELECT id FROM dbo.I316Rows') a,
+     mssql_scan('i316', 'SELECT id FROM dbo.I316Rows') b
+WHERE a.id = b.id;
+----
+5000
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# The materialized rows are the same rows, not merely the same count.
+# =============================================================================
+
+statement ok
+BEGIN;
+
+query II
+SELECT id, v FROM mssql_scan('i316', 'SELECT id, v FROM dbo.I316Rows') ORDER BY id LIMIT 3;
+----
+1	x
+2	x
+3	x
+
+# A single scan in a transaction is materialized too, and must still see the
+# transaction's own uncommitted rows -- the drain runs on the pinned connection.
+statement ok
+SELECT mssql_exec('i316', 'INSERT INTO dbo.I316Rows VALUES (99999, ''tx'')');
+
+query I
+SELECT count(*) FROM mssql_scan('i316', 'SELECT id FROM dbo.I316Rows WHERE id = 99999');
+----
+1
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# Autocommit is untouched: each scan takes its own pooled connection and streams.
+# =============================================================================
+
+query I
+SELECT count(*)
+FROM mssql_scan('i316', 'SELECT id FROM dbo.I316Rows') a,
+     mssql_scan('i316', 'SELECT id FROM dbo.I316Rows') b
+WHERE a.id = b.id;
+----
+5001
+
+statement ok
+SET threads = 1;
+
+# Cleanup
+statement ok
+SELECT mssql_exec('i316', 'DROP TABLE dbo.I316Rows');
+
+statement ok
+DETACH i316;

--- a/test/sql/transaction/transaction_multi_scan_materialization.test
+++ b/test/sql/transaction/transaction_multi_scan_materialization.test
@@ -1,0 +1,155 @@
+# name: test/sql/transaction/transaction_multi_scan_materialization.test
+# description: Two scans of one catalog inside an explicit transaction share the pinned connection (issue #239)
+# group: [mssql]
+# issue: 239
+
+# Environment variables required:
+#   MSSQL_TESTDB_DSN - Connection string to test database
+#
+# An explicit transaction pins ONE TDS connection per catalog and routes every
+# read on that catalog to it. A scan holds that connection from InitGlobal until
+# its last row is drained, and DuckDB does not promise to drain one source before
+# initializing the next. Before the fix this failed two different ways:
+#
+#   threads = 1   IO Error: ... Cannot execute: connection not in Idle state
+#                 (current: Executing)
+#   threads > 1   IO Error: Connection closed while waiting for COLMETADATA
+#                 (the two InitGlobals race and tear the stream)
+#
+# THE QUERY SHAPE MATTERS AND IS NOT THE OBVIOUS ONE. A correlated subquery in
+# the SELECT list -- `SELECT p.id, (SELECT list(c.v) ... )` -- does NOT reproduce
+# it: DuckDB decorrelates that into a hash join whose sources are drained in
+# sequence, and it passes on the broken build too. What reproduces it is a
+# correlated subquery in a PREDICATE, which plans as LEFT_DELIM_JOIN + DELIM_SCAN
+# and initializes both sides before draining either. Verified both ways against
+# the pre-fix binary.
+
+require mssql
+
+require-env MSSQL_TESTDB_DSN
+
+statement ok
+ATTACH '${MSSQL_TESTDB_DSN}' AS i239 (TYPE mssql);
+
+statement ok
+SELECT mssql_exec('i239', 'IF OBJECT_ID(''dbo.I239Child'',''U'') IS NOT NULL DROP TABLE dbo.I239Child');
+
+statement ok
+SELECT mssql_exec('i239', 'IF OBJECT_ID(''dbo.I239Parent'',''U'') IS NOT NULL DROP TABLE dbo.I239Parent');
+
+statement ok
+SELECT mssql_exec('i239', 'CREATE TABLE dbo.I239Parent (id INT PRIMARY KEY, name VARCHAR(50))');
+
+statement ok
+SELECT mssql_exec('i239', 'CREATE TABLE dbo.I239Child (cid INT PRIMARY KEY, pid INT, v VARCHAR(50))');
+
+# Enough rows that a scan spans several chunks: at three rows the first source
+# finishes inside one chunk and the sources never overlap, so even the DELIM plan
+# passes on a broken build.
+statement ok
+SELECT mssql_exec('i239', 'INSERT INTO dbo.I239Parent (id, name) SELECT TOP 5000 ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), ''p'' FROM sys.all_objects a CROSS JOIN sys.all_objects b');
+
+statement ok
+SELECT mssql_exec('i239', 'INSERT INTO dbo.I239Child (cid, pid, v) SELECT TOP 12000 ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), (ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 5000) + 1, ''v'' FROM sys.all_objects a CROSS JOIN sys.all_objects b');
+
+# =============================================================================
+# Single-threaded: the "not in Idle state" failure
+# =============================================================================
+
+statement ok
+SET threads = 1;
+
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id);
+----
+4997
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# Multi-threaded: the torn-stream failure. Materializing at InitGlobal is not
+# enough on its own here -- the two InitGlobals run concurrently, so the drain
+# has not happened when the second batch is sent. This passes only because a
+# materialized scan also holds the catalog's materialize mutex across its batch.
+# =============================================================================
+
+statement ok
+SET threads = 4;
+
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id);
+----
+4997
+
+statement ok
+COMMIT;
+
+# Three scans of the same catalog, still one connection.
+statement ok
+BEGIN;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id)
+  AND p.id < (SELECT max(x.id) FROM i239.dbo.I239Parent x);
+----
+4996
+
+statement ok
+COMMIT;
+
+# =============================================================================
+# Autocommit is untouched: each scan takes its own pooled connection, so the
+# same query never needed materializing and must not start doing so.
+# =============================================================================
+
+statement ok
+SET threads = 4;
+
+query I
+SELECT count(*) FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id);
+----
+4997
+
+# =============================================================================
+# The materialized rows are the same rows, not merely the same count: the drain
+# reuses FillChunk, so projection, ordering and values have to survive it.
+# =============================================================================
+
+statement ok
+BEGIN;
+
+query II
+SELECT p.id, p.name FROM i239.dbo.I239Parent p
+WHERE p.id > (SELECT count(*) FROM i239.dbo.I239Child c WHERE c.pid = p.id)
+ORDER BY p.id LIMIT 3;
+----
+4	p
+5	p
+6	p
+
+statement ok
+COMMIT;
+
+statement ok
+SET threads = 1;
+
+# Cleanup
+statement ok
+SELECT mssql_exec('i239', 'DROP TABLE dbo.I239Child');
+
+statement ok
+SELECT mssql_exec('i239', 'DROP TABLE dbo.I239Parent');
+
+statement ok
+DETACH i239;

--- a/website/docs/reading/catalog.md
+++ b/website/docs/reading/catalog.md
@@ -45,6 +45,33 @@ WHERE status = 'active'
 LIMIT 100;
 ```
 
+### The default schema is `dbo`
+
+After `USE <catalog>`, unqualified names resolve against `dbo`:
+
+```sql
+USE sqlserver;
+
+SELECT current_schema();
+-- dbo
+
+-- resolves as sqlserver.dbo.customers
+SELECT id FROM customers;
+```
+
+This matters beyond convenience. DuckDB's own default is `main`, which no SQL
+Server database has, so anything that asks the catalog for its default schema —
+generic tooling, or an extension layering its own catalog on top of this one —
+used to fail with `Schema 'main' not found in MSSQL database` before it could
+read anything. The workaround in the wild was to create a schema literally named
+`main` on the server.
+
+`dbo` is a constant, not a per-login lookup: it is the default for every login
+that has not been given another, and resolving it per connection would cost a
+round trip on every `ATTACH`. If your login's default schema is something else,
+address those tables by their qualified name — `catalog.schema.table` works
+regardless, and is what the three-part naming above is for.
+
 ### Cross-Catalog Joins
 
 Join SQL Server tables with local DuckDB tables:

--- a/website/docs/writing/transactions.md
+++ b/website/docs/writing/transactions.md
@@ -32,18 +32,19 @@ All statements within a transaction execute on the same SQL Server connection. I
   DDL and loads on connections of its own, so `ROLLBACK` undoes neither. See
   [CTAS is not part of the transaction](./copy.md#ctas-is-not-part-of-the-transaction)
 
-- **Two reads of the same catalog in one transaction are buffered.** The pinned
+- **Reads of the same catalog in one transaction are buffered.** The pinned
   connection can carry one result stream at a time, and DuckDB does not promise
   to finish reading one source before it starts the next — a correlated subquery
   in a predicate plans as a delim join and opens both. So inside an explicit
-  transaction, a query holding more than one scan of the same catalog reads each
-  of them fully into memory as it starts, and frees the connection before moving
-  on. See [Two scans of one catalog](#two-scans-of-one-catalog) below.
+  transaction, a scan is read to completion as it starts and the connection is
+  freed before anything else runs. See
+  [Reading a catalog inside a transaction](#reading-a-catalog-inside-a-transaction)
+  below.
 
-### Two scans of one catalog
+### Reading a catalog inside a transaction
 
-A query that reads the same attached catalog twice behaves differently inside a
-transaction than outside it, and it is worth knowing why.
+Reading an attached catalog behaves differently inside a transaction than outside
+it, and it is worth knowing why.
 
 **Outside a transaction**, every scan takes its own connection from the pool and
 streams: rows arrive as they are needed and nothing is held in memory.
@@ -72,16 +73,48 @@ COMMIT;
 
 What this means in practice:
 
-- **Only queries that would otherwise fail are affected.** One scan per catalog
-  streams as before, in or out of a transaction. Autocommit is never affected.
 - **Memory is bounded by DuckDB's buffer manager**, not by the row count — a
-  collection too large for memory spills.
+  collection too large for memory spills to disk rather than growing in process
+  memory.
+- **The rule is wider than the failure it prevents.** At planning time DuckDB
+  does not say in which order it will drain a plan's sources, so the decision
+  cannot be "these two would have overlapped". Any plan holding two or more
+  scans of one catalog inside a transaction materializes all of them — including
+  a plain hash join between two of that catalog's tables, which would have
+  drained one side and then the other and never needed it. Guessing the other
+  way costs a hung connection, not a slow query.
 - **If you are reading something large inside a transaction and do not need
   read-your-writes, read it outside one.** Autocommit will stream it.
 
 Before this was handled, such a query failed mid-flight with
 `Cannot execute: connection not in Idle state` on a single thread, or
 `Connection closed while waiting for COLMETADATA` on several.
+
+#### `mssql_scan()` is materialized on every call in a transaction
+
+The rule above counts scans of attached tables, because the planner can see
+those. `mssql_scan()` cannot take part in it: it runs its query during **binding**
+— that is how it learns the result's column types, long before there is a plan to
+count anything in — and so it would be holding the pinned connection before any
+gate could ask how many scans there are.
+
+So inside an explicit transaction, **every** `mssql_scan()` is read to completion
+at bind time and its connection released, even when it is the only one in the
+statement. The rows are still the transaction's own: the drain runs on the pinned
+connection, so uncommitted writes are visible as usual.
+
+```sql
+BEGIN;
+INSERT INTO mssql.dbo.orders (id, total) VALUES (1, 10);
+
+-- Sees the uncommitted row: read on the same pinned connection, then buffered.
+SELECT count(*) FROM mssql_scan('mssql', 'SELECT id FROM dbo.orders');
+
+COMMIT;
+```
+
+In autocommit, `mssql_scan()` streams exactly as before — it takes a pooled
+connection of its own and nothing is buffered.
 
 ### Multi-Statement SQL Batches
 

--- a/website/docs/writing/transactions.md
+++ b/website/docs/writing/transactions.md
@@ -62,11 +62,11 @@ large, and the connection is released immediately afterwards.
 ```sql
 BEGIN;
 
--- Two scans of `mssql`: the outer table and the correlated subquery.
+-- Two scans of `sqlserver`: the outer table and the correlated subquery.
 -- Both are read fully as they start, then served from memory.
 SELECT o.id
-FROM mssql.dbo.orders o
-WHERE o.total > (SELECT avg(x.total) FROM mssql.dbo.orders x WHERE x.customer_id = o.customer_id);
+FROM sqlserver.dbo.orders o
+WHERE o.total > (SELECT avg(x.total) FROM sqlserver.dbo.orders x WHERE x.customer_id = o.customer_id);
 
 COMMIT;
 ```
@@ -105,10 +105,10 @@ connection, so uncommitted writes are visible as usual.
 
 ```sql
 BEGIN;
-INSERT INTO mssql.dbo.orders (id, total) VALUES (1, 10);
+INSERT INTO sqlserver.dbo.orders (id, total) VALUES (1, 10);
 
 -- Sees the uncommitted row: read on the same pinned connection, then buffered.
-SELECT count(*) FROM mssql_scan('mssql', 'SELECT id FROM dbo.orders');
+SELECT count(*) FROM mssql_scan('sqlserver', 'SELECT id FROM dbo.orders');
 
 COMMIT;
 ```

--- a/website/docs/writing/transactions.md
+++ b/website/docs/writing/transactions.md
@@ -32,6 +32,57 @@ All statements within a transaction execute on the same SQL Server connection. I
   DDL and loads on connections of its own, so `ROLLBACK` undoes neither. See
   [CTAS is not part of the transaction](./copy.md#ctas-is-not-part-of-the-transaction)
 
+- **Two reads of the same catalog in one transaction are buffered.** The pinned
+  connection can carry one result stream at a time, and DuckDB does not promise
+  to finish reading one source before it starts the next — a correlated subquery
+  in a predicate plans as a delim join and opens both. So inside an explicit
+  transaction, a query holding more than one scan of the same catalog reads each
+  of them fully into memory as it starts, and frees the connection before moving
+  on. See [Two scans of one catalog](#two-scans-of-one-catalog) below.
+
+### Two scans of one catalog
+
+A query that reads the same attached catalog twice behaves differently inside a
+transaction than outside it, and it is worth knowing why.
+
+**Outside a transaction**, every scan takes its own connection from the pool and
+streams: rows arrive as they are needed and nothing is held in memory.
+
+**Inside `BEGIN … COMMIT`**, all of them share the one connection the transaction
+pinned. That is what makes read-your-writes work — a second connection would sit
+outside the transaction and could not see its uncommitted rows, and under READ
+COMMITTED it would block on their locks. The cost is that one connection cannot
+stream two results at once.
+
+Rather than fail, such scans are **materialized**: each one is read to completion
+when it starts, into a buffer-managed collection that spills to disk if it is
+large, and the connection is released immediately afterwards.
+
+```sql
+BEGIN;
+
+-- Two scans of `mssql`: the outer table and the correlated subquery.
+-- Both are read fully as they start, then served from memory.
+SELECT o.id
+FROM mssql.dbo.orders o
+WHERE o.total > (SELECT avg(x.total) FROM mssql.dbo.orders x WHERE x.customer_id = o.customer_id);
+
+COMMIT;
+```
+
+What this means in practice:
+
+- **Only queries that would otherwise fail are affected.** One scan per catalog
+  streams as before, in or out of a transaction. Autocommit is never affected.
+- **Memory is bounded by DuckDB's buffer manager**, not by the row count — a
+  collection too large for memory spills.
+- **If you are reading something large inside a transaction and do not need
+  read-your-writes, read it outside one.** Autocommit will stream it.
+
+Before this was handled, such a query failed mid-flight with
+`Cannot execute: connection not in Idle state` on a single thread, or
+`Connection closed while waiting for COLMETADATA` on several.
+
 ### Multi-Statement SQL Batches
 
 `mssql_scan()` supports multi-statement batches where intermediate statements don't return result sets:


### PR DESCRIPTION
Started as the forward-port of **#313** (v0.2.5, on `duckdb-v1.5.5`) to the 2.0 line. It has since picked up a fix that exists only here, so it is no longer a pure port: no version bump, but it does carry a `[Unreleased]` CHANGELOG entry now.

Closes [#129](https://github.com/hugr-lab/mssql-extension/issues/129), [#239](https://github.com/hugr-lab/mssql-extension/issues/239) and [#316](https://github.com/hugr-lab/mssql-extension/issues/316) on `main`. Read #313 for the reasoning behind the first two; this describes what 2.0 made different, and #316 in full.

## What the port is, and what it is not

**`GetDefaultSchema` changed its signature *and its meaning*:**

```cpp
// 1.5.5   virtual string GetDefaultSchema() const;
// 2.0     virtual optional<Identifier> GetDefaultSchema() const;
```

2.0 gives the three possible answers distinct meanings, documented in `catalog.hpp`:

| answer | means |
|---|---|
| a value | probe this schema for unqualified names |
| `nullopt` | this catalog **has** no default schema — never probe an implicit one |
| empty `Identifier` | "unspecified" elsewhere in the catalog |

We mean the first, so this returns `Identifier("dbo")` and deliberately neither empty form. The header now says that, because someone reading `return Identifier("dbo")` on a 2.0 header cannot otherwise tell that `nullopt` was considered and rejected — and getting it wrong would silently stop unqualified names resolving at all, which is the very bug being fixed.

**`Catalog::GetCatalog` takes an `Identifier` on 2.0**, so the new call site wraps at the API boundary and keeps `std::string` inside — the rule CLAUDE.md states and the rest of the file already follows.

Everything else — the optimizer gate, the materialization drain, the per-catalog mutex — ports unchanged.

## #316 — `mssql_scan()` was never reachable by the #239 gate

The v0.2.5 fix counts scans on the optimized plan, and the optimizer knows one function name: `mssql_catalog_scan`. @oluies flagged that `mssql_scan()` takes the same pinned connection and is not covered. It turns out it cannot be covered there at all.

`MSSQLScanBind` **executes the query during binding** — that is where the result's column types come from, out of the batch's own COLMETADATA — and hands the live stream forward, holding the connection until execution drains it. So inside a transaction the second scan of that catalog fails in its own `Bind`, before any `InitGlobal` exists to materialize and long before the optimizer runs. Both shapes reproduced against a live server on this build:

```
catalog scan + mssql_scan   IO Error: Connection closed unexpectedly
two mssql_scan              IO Error: Cannot execute: connection not in Idle state (current: Executing)
```

Bind now drains into a collection and closes the stream whenever the session is not in autocommit. Closing is the operative half — draining alone leaves the connection `Executing`.

**The trigger is "in a transaction", not "more than one scan."** Bind cannot see the rest of the plan; by the time a count would be available the connection is already held. So a lone `mssql_scan()` in a transaction is buffered too. The defence for that is narrow and worth stating rather than glossing: inside a transaction such a scan could not have coexisted with anything else on that catalog anyway, so this turns a failing case into a slower one rather than taking a working case away.

The collection is a `shared_ptr` on the bind data, not a `unique_ptr` on the global state: `FunctionData::Copy` has to hand out the same rows, and one bind data can initialize more than one global state.

## Also carries #318

@oluies found that the materialized collection could not spill — built from `Allocator::Get(context)`, which is duckdb's `IN_MEMORY_ALLOCATOR` overload, unaccounted against the buffer manager, while the docs promised the opposite. Confirmed unchanged on the `070ce1f6` pin, so it is not a 1.5.5 artefact. Both call sites here use the `ClientContext` overload.

His three doc findings are applied too: the page no longer claims *"only queries that would otherwise fail are affected"* (the gate flags every scan of a catalog once two appear, so a plain hash join over two of its tables buffers both sides — deliberate, but not what was written), it now says what `mssql_scan()` does in a transaction, and the example alias is `sqlserver` like the rest of the page.

## Verified

- Build clean, `clang-format-14` clean.
- **Full SQL suite: 159 cases, 4925 assertions, 0 failures** against a live SQL Server on the `v2.0-cyanoptera` pin.
- The #239 regressions pass here as on 1.5.5, including the `threads = 4` case that needs the mutex rather than the drain.
- `transaction_mssql_scan_materialization.test` is new: both of the shapes above, rows-not-just-counts, read-your-writes through a drained scan, and autocommit still streaming. Verified **failing** on the pre-fix binary before it was written the other way round.

## Merge order

No longer coupled: #313 is merged and `v0.2.5` has been retagged over #318 and #319, so this branch has nothing left to wait for.

## Not in this PR

Scoping the materialize lock to `MSSQLTransaction` rather than the catalog (@oluies' third point). Agreed, but it changes locking behaviour and wants its own test for two transactions on one catalog not blocking each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz
