### PR TITLE
docs+comment: say what v0.2.5 actually covers, and why widening it is not a one-liner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,16 @@ than like a query function.
   current_schema()` now answers `dbo` after `USE <catalog>`, and unqualified
   names resolve.
 
-- **Two scans of one catalog inside an explicit transaction no longer break the
-  pinned connection**
+- **Two *catalog* scans of one catalog inside an explicit transaction no longer
+  break the pinned connection**
   ([#239](https://github.com/hugr-lab/mssql-extension/issues/239)).
+
+  Read the emphasis: this covers scans of attached tables — three-part names,
+  and the correlated subqueries and joins over them. It does **not** yet cover
+  `mssql_scan()`, which is a different table function taking the same pinned
+  connection, so a transaction mixing the two, or holding two raw scans, still
+  fails the same way. Tracked separately; the general case needs those scans
+  materialized too, not merely counted.
   A transaction pins ONE TDS connection per catalog and routes every read on
   that catalog to it, while a scan holds that connection from init until its
   last row is drained. DuckDB does not promise to drain one source before

--- a/src/table_scan/mssql_optimizer.cpp
+++ b/src/table_scan/mssql_optimizer.cpp
@@ -695,9 +695,28 @@ static void CollectCatalogScans(LogicalOperator &op, std::map<string, vector<MSS
 }
 
 static void MaterializeSharedConnectionScans(ClientContext &context, LogicalOperator &plan) {
+	// KNOWN GAP: this sees only `mssql_catalog_scan`. `mssql_scan()` is a separate
+	// table function that takes the SAME pinned connection through
+	// ConnectionProvider::GetConnection, so a transaction mixing the two — or
+	// holding two raw scans — still fails with "not in Idle state". Both shapes
+	// reproduce. The set this ought to count is "consumers of the pinned
+	// connection", which is larger than "scans the optimizer recognises".
+	//
+	// Closing it is NOT just widening this test. A lock only helps a holder that
+	// releases the connection inside InitGlobal, which is what materializing
+	// does; a raw scan that took the lock and then streamed lazily would hold it
+	// until drained, and the second scan would block in InitGlobal so the
+	// pipeline could never drain the first — a hang instead of an error. So
+	// mssql_scan() has to gain the same drain before it can be counted here.
+	//
 	// Autocommit gives every scan its own pooled connection, so there is nothing
 	// to share and nothing to serialize. This is the same test the DML executors
 	// use to decide whether they are on a pinned connection.
+	//
+	// Read at optimize time and used at execute time, which is only sound if the
+	// plan cannot outlive the transaction state it was built under. Verified that
+	// it cannot: PREPARE in autocommit then EXECUTE inside BEGIN re-plans, so the
+	// flag is never stale.
 	if (context.transaction.IsAutoCommit()) {
 		return;
 	}


### PR DESCRIPTION
Follow-up to #313, before the v0.2.5 tag. CHANGELOG wording and a code comment — **no behaviour change**, suite unchanged at 166 cases / 5225 assertions.

## The gap is real

@oluies' review of #313 pointed out that the optimizer gate sees only `mssql_catalog_scan`, while `mssql_scan()` is a separate table function taking the **same** pinned connection through `ConnectionProvider::GetConnection`. I reproduced both shapes he named, on the merged code:

```
catalog scan + mssql_scan   →  IO Error: ... connection not in Idle state (current: Executing)
two mssql_scan              →  IO Error: ... connection not in Idle state (current: Executing)
```

The `< 2` test counts scans the optimizer *recognises*; the set that matters is *consumers of the pinned connection*, and those differ.

So the CHANGELOG line overpromised. "Two scans of one catalog" reads as the general claim; what shipped covers catalog scans. That is the whole of what the DuckLake manager exercises and the reason this release exists — but the entry has to say so rather than let someone find out.

## Why the comment is longer than the gap

Because the obvious fix is wrong in a way that is worse than the bug. A lock only helps a holder that **releases the connection inside `InitGlobal`**, which is exactly what materializing does. A raw scan that took a lock and then streamed lazily would hold it until drained — and the second scan would block in `InitGlobal`, so the pipeline could never drain the first. **A hang, not an error message.**

`mssql_scan()` therefore needs the same drain before it can be counted in the gate. That ordering constraint is now written next to the gate, so nobody implements half of it.

## One review question that was a non-issue

Also recorded, with its answer, so it is not re-derived: the gate reads `IsAutoCommit()` at optimize time while the flag is used at execute time, which is only sound if a plan cannot outlive the transaction state it was built under. Verified it cannot —

```sql
PREPARE p AS SELECT ... ;   -- planned in autocommit
BEGIN; EXECUTE p; EXECUTE p; COMMIT;   -- both correct
```

duckdb re-plans, so the flag is never stale.

## Then

Tag `v0.2.5` on the merge of this, and file the three-part follow-up (`mssql_scan()` in the gate, its own materialization, lock scoped to `MSSQLTransaction` rather than the catalog) for both lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz