### PR TITLE
fix: the materialized scan never spilled — it was an in-memory collection all along

### DIFF
--- a/src/table_scan/table_scan.cpp
+++ b/src/table_scan/table_scan.cpp
@@ -611,7 +611,13 @@ static unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &c
 				chunk_types.push_back(bind_data.all_types[column_ids[i]]);
 			}
 		}
-		result->materialized = make_uniq<ColumnDataCollection>(Allocator::Get(context), chunk_types);
+		// ClientContext, not Allocator::Get(context). The Allocator overload builds
+		// an IN_MEMORY_ALLOCATOR collection -- unaccounted against the buffer manager
+		// and unable to spill -- so a large materialized scan grew in process memory
+		// until it OOMed, while the docs and the release notes promised the opposite.
+		// The ClientContext overload defaults to BUFFER_MANAGER_ALLOCATOR, which is
+		// what 'bounded by the buffer manager' requires.
+		result->materialized = make_uniq<ColumnDataCollection>(context, chunk_types);
 		DataChunk chunk;
 		chunk.Initialize(Allocator::Get(context), chunk_types);
 		idx_t total = 0;


### PR DESCRIPTION
One argument. v0.2.5's #239 fix does not have the memory behaviour it documents.

Found by roborev job 1475 while reviewing the forward-port in #314, which carries the identical line.

## The claim and the code

#313's description and `website/docs/writing/transactions.md` both state the materialized scan is bounded by DuckDB's buffer manager and spills when large. It was constructed from an `Allocator`:

```cpp
make_uniq<ColumnDataCollection>(Allocator::Get(context), chunk_types)
```

and in **the duckdb commit this branch pins** (`d8cdaa33`), that overload is explicitly the in-memory one:

```cpp
// src/common/types/column/column_data_allocator.cpp:13
ColumnDataAllocator::ColumnDataAllocator(Allocator &allocator)
    : type(ColumnDataAllocatorType::IN_MEMORY_ALLOCATOR) {
```

It allocates straight from the allocator — not accounted against the buffer manager, and **it cannot spill**. A large multi-scan inside an explicit transaction grows in process memory until it OOMs, having told the user in the release notes that it will not.

The `ClientContext` overload is the buffer-managed one and *defaults* to it, in that same pinned duckdb:

```cpp
// column_data_collection.hpp:38
ColumnDataCollection(ClientContext &context, vector<LogicalType> types,
                     ColumnDataAllocatorType type = ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR,
                     ColumnDataCollectionLifetime lifetime = ColumnDataCollectionLifetime::REGULAR);
```

so the fix is the argument, not a rewrite.

`chunk.Initialize(Allocator::Get(context), ...)` on the following line is deliberately unchanged — that one wants a plain `Allocator` and is a single `DataChunk`, not the accumulating collection.

## Bigger than the pathological case

The optimizer gate materializes **every** scan whenever a plan holds two or more of one catalog in an explicit transaction, making no attempt to decide whether they would have overlapped. So an ordinary hash join over two tables of the same catalog inside `BEGIN…COMMIT` — a query that worked before and never needed materializing — now buffers **both sides**. That is the shape most likely to be large, and it is the one that had no ceiling.

## Not built, and this branch cannot build it

Stating plainly rather than implying otherwise:

- This worktree's duckdb submodule is on `v2.0-cyanoptera` (#306), so I could not compile against 1.5.5 locally.
- **`duckdb-v1.5.5`'s `ci.yml` still carries `pull_request: branches: [main]`**, so a PR into this branch triggers no CI at all — the #285 fix that removed that filter landed on `main` only. Nothing here will go green or red; there is nothing to run it.

What I did instead was verify against the pinned duckdb commit itself rather than against a different version's headers — both the defect and the replacement signature are quoted above from `d8cdaa33`. `clang-format-14` clean.

**Someone on the 1.5.5 toolchain should compile this before the tag moves.** It is a one-argument change to a call whose overloads differ only in allocator type, so the risk is low, but "low" is not "verified".

## Related

- #314 carries the identical line and should pick this up on forward-port.
- The docs half — `transactions.md` still promising spilling, and describing a scope wider than the gate — is noted in my comment on #314 and not touched here, since this branch's copy may differ.