### PR TITLE
docs: the v0.2.5 entry claimed a memory bound it did not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,20 @@ than like a query function.
   the same query always worked outside a transaction.
 
   The mechanism mirrors duckdb-postgres, which has the same one-connection
-  constraint. Memory is bounded by the buffer manager, and only the plans that
-  would otherwise fail are affected.
+  constraint. Memory is bounded by the buffer manager and spills rather than
+  growing in process memory — but only since
+  [#318](https://github.com/hugr-lab/mssql-extension/pull/318), which is in this
+  release: the collection was first built from `Allocator::Get(context)`, and
+  that overload is duckdb's `IN_MEMORY_ALLOCATOR` one, unaccounted and unable to
+  spill.
+
+  The gate is **wider than the failure it prevents**, which is worth stating
+  plainly. At planning time DuckDB does not say in which order it will drain a
+  plan's sources, so the decision cannot be "these two would have overlapped":
+  any plan holding two or more scans of one catalog in a transaction
+  materializes all of them, including a plain hash join between two of that
+  catalog's tables that would have drained one side and then the other. Guessing
+  the other way costs a hung connection, not a slow query.
 
 ## [0.2.4] - 2026-08-17
 


### PR DESCRIPTION
Release-notes half of #318, so v0.2.5 does not ship describing behaviour it does not have. Prose only — no code, no tests, nothing to compile.

Two sentences in the `[0.2.5]` entry:

**"Memory is bounded by the buffer manager"** was written before it was. #318 (merged, in this release) is what makes it true; the entry now says so rather than letting the claim stand as if it always held.

**"only the plans that would otherwise fail are affected"** overstates the gate's precision — @oluies' LOW finding on #314, and it applies verbatim here. `MaterializeSharedConnectionScans` flags every scan of a catalog once two appear in the plan:

```cpp
for (auto &entry : by_catalog) {
    if (entry.second.size() < 2) { continue; }
    for (auto *bind_data : entry.second) { bind_data->requires_materialization = true; }
}
```

No attempt is made to tell "would have overlapped" from "would have drained in sequence", so a plain hash join over two tables of one catalog inside `BEGIN…COMMIT` buffers both sides — a query that worked before and never needed it. The breadth is the right call (the plan does not carry a drain order, and guessing wrong costs a hung connection rather than a slow query), but the entry should say what the code does.

## Why now rather than in 0.2.6

The `v0.2.5` tag is pushed but **nothing is published** — the community-extensions PR has not been opened. So the tag moves over this and #318 together, and the release run rebuilds on all six platforms with the 1.5.5 toolchain plus the linux_amd64 integration job. That also answers the open question on #318: nobody had compiled it against 1.5.5, and the retagged run is that compile.

## Note on this branch's CI

@oluies is right that `duckdb-v1.5.5`'s `ci.yml` still carries `pull_request: branches: [main]`, so no build check will run on this PR — only the prose/secret/yaml workflows, which have their own triggers. Worth fixing on this branch separately; it needs a token that can write `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz