### PR TITLE
chore: a .clangd for the standalone C++ tests, which are outside every compile database

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,37 @@
+# clangd (the vscode-clangd extension reads this; cpptools reads
+# .vscode/settings.json) has no compile command for the standalone C++ tests
+# in test/cpp/: they are compiled by the Makefile (STANDALONE_TEST_SOURCES,
+# `make test-cpp`), not by CMake, so they are absent from
+# build/*/compile_commands.json and clangd falls back to flags that know
+# nothing about the vcpkg tree -- every <openssl/*.h> shows as "file not
+# found". This is the standalone lane's include set from the Makefile.
+#
+# clangd passes these flags verbatim to a fallback command whose working
+# directory is the FILE's directory (not this file's), so the paths are
+# written relative to test/cpp/ and to test/cpp/codec/. Triplets that do not
+# exist on a given machine are harmless.
+If:
+  PathMatch: test/cpp/[^/]+\.cpp
+CompileFlags:
+  Add:
+    - -std=c++17
+    - -I../../src/include
+    - -I../../duckdb/src/include
+    - -I../../duckdb/third_party/fmt/include
+    - -I../../build/release/vcpkg_installed/arm64-osx/include
+    - -I../../build/release/vcpkg_installed/x64-osx/include
+    - -I../../build/release/vcpkg_installed/x64-linux/include
+    - -I../../build/release/vcpkg_installed/x64-windows-static-release/include
+---
+If:
+  PathMatch: test/cpp/codec/.*\.cpp
+CompileFlags:
+  Add:
+    - -std=c++17
+    - -I../../../src/include
+    - -I../../../duckdb/src/include
+    - -I../../../duckdb/third_party/fmt/include
+    - -I../../../build/release/vcpkg_installed/arm64-osx/include
+    - -I../../../build/release/vcpkg_installed/x64-osx/include
+    - -I../../../build/release/vcpkg_installed/x64-linux/include
+    - -I../../../build/release/vcpkg_installed/x64-windows-static-release/include


### PR DESCRIPTION
`test/cpp/*.cpp` are compiled by the Makefile (`STANDALONE_TEST_SOURCES`), not by CMake, so `build/*/compile_commands.json` never lists them and clangd falls back to flags that know nothing about the vcpkg tree — every `<openssl/*.h>` in `test_tls_verification.cpp` shows as `file not found` in the IDE.

The `.clangd` gives those files the standalone lane's include set (`src/include`, DuckDB's headers, the vcpkg include dir for whichever triplet exists). The paths are relative to the **file's** directory, not the config's: clangd passes `CompileFlags.Add` verbatim to a fallback command whose cwd is the file's directory, hence one block for `test/cpp/` and one for `test/cpp/codec/`. Verified with `clangd --check` on a top-level test, the pool test and a codec test: 0 errors each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQxebCbiLHnWUz3H4ETiDz
