### PR TITLE
review(075): the three findings that are a line each, not a design change

### DIFF
--- a/src/codec/integer_codec.cpp
+++ b/src/codec/integer_codec.cpp
@@ -87,15 +87,31 @@ const hugeint_t &MaxDecimal38() {
 	return max;
 }
 
+}  // namespace
+
+// The range rule itself, exported (integer_codec.hpp): mssql_sql_params needs
+// it for a parameter DECLARE and had forked it as a digit-count over
+// Value::ToString, which is a second source of truth for the same constant.
+bool HugeintFitsDecimal38(const hugeint_t &value) {
+	const hugeint_t &max = MaxDecimal38();
+	const hugeint_t min = Hugeint::Negate(max);
+	return !Hugeint::GreaterThan(value, max) && !Hugeint::GreaterThan(min, value);
+}
+
+bool UhugeintFitsDecimal38(const uhugeint_t &value) {
+	const uhugeint_t max(static_cast<uint64_t>(MaxDecimal38().upper), MaxDecimal38().lower);
+	return !(value > max);
+}
+
+namespace {
+
 void CheckHugeintFitsDecimal38(const hugeint_t &value, const std::string &col_name) {
 	// Bound both ends directly instead of negating `value`: Hugeint::Negate on
 	// HUGEINT min (-2^127) is itself out of int128 range, so the old
 	// abs-then-compare let that one value slip the guard (or threw a raw
 	// overflow). +/-(10^38-1) are both representable (< 2^127), so the range
 	// check is exact and keeps the column-named message for every input.
-	const hugeint_t &max = MaxDecimal38();
-	const hugeint_t min = Hugeint::Negate(max);
-	if (Hugeint::GreaterThan(value, max) || Hugeint::GreaterThan(min, value)) {
+	if (!HugeintFitsDecimal38(value)) {
 		throw InvalidInputException(
 			"MSSQL: HUGEINT value %s in column \"%s\" is out of range for DECIMAL(38,0) (max 38 digits)",
 			Hugeint::ToString(value), col_name);
@@ -103,8 +119,7 @@ void CheckHugeintFitsDecimal38(const hugeint_t &value, const std::string &col_na
 }
 
 void CheckUhugeintFitsDecimal38(const uhugeint_t &value, const std::string &col_name) {
-	const uhugeint_t max(static_cast<uint64_t>(MaxDecimal38().upper), MaxDecimal38().lower);
-	if (value > max) {
+	if (!UhugeintFitsDecimal38(value)) {
 		throw InvalidInputException(
 			"MSSQL: UHUGEINT value %s in column \"%s\" is out of range for DECIMAL(38,0) (max 38 digits)",
 			Uhugeint::ToString(value), col_name);

--- a/src/include/codec/integer_codec.hpp
+++ b/src/include/codec/integer_codec.hpp
@@ -69,6 +69,20 @@ std::string FormatSqlLiteral(const Value &v, const LogicalType &type, LiteralCon
 std::string FormatDdlTypeName(const LogicalType &type, const mssql::CTASConfig &cfg, DdlContext ctx);
 size_t EstimateLiteralSize(const LogicalType &type);
 
+//! Does this value fit T-SQL's decimal(38,0), i.e. +/-(10^38 - 1)?
+//!
+//! HUGEINT reaches ~1.70e38 and UHUGEINT ~3.40e38 -- 39 digits -- so both can
+//! carry a value no SQL Server exact numeric can hold (#177). The BCP encoder
+//! has enforced this since #177; `mssql_scan_params` needs the same rule for a
+//! parameter DECLARE, so the rule lives here once and each caller words its own
+//! error (a column and a parameter do not read the same).
+//!
+//! Bounds both ends rather than negating the input: Hugeint::Negate on HUGEINT
+//! min (-2^127) is itself out of int128 range, so an abs-then-compare lets that
+//! one value slip -- the bug the #177 comment records.
+bool HugeintFitsDecimal38(const hugeint_t &value);
+bool UhugeintFitsDecimal38(const uhugeint_t &value);
+
 }  // namespace integer
 }  // namespace codec
 }  // namespace mssql

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -798,7 +798,7 @@ static int64_t RunExecBatch(ClientContext &client_context, const string &context
 		throw InvalidInputException(
 			"%s: Unknown context '%s'. Attach a database first with: ATTACH '' AS %s (TYPE mssql, SECRET "
 			"...)",
-			context_name, context_name);
+			function_name, context_name, context_name);
 	}
 	auto &catalog = *catalog_ptr;
 	if (catalog.IsReadOnly()) {

--- a/src/mssql_functions.cpp
+++ b/src/mssql_functions.cpp
@@ -782,13 +782,13 @@ static bool ExecSqlMayChangeSchema(const string &sql) {
 // text for the DDL heuristic -- for mssql_exec_params the batch wraps it in
 // sp_executesql, whose name would otherwise trip the EXEC keyword every time.
 static int64_t RunExecBatch(ClientContext &client_context, const string &context_name, const string &sql,
-							const string &statement) {
+							const string &statement, const char *function_name) {
 	// Get the MSSQL catalog (Spec 047: per-catalog ownership)
 	MSSQLCatalog *catalog_ptr = nullptr;
 	try {
 		auto &raw_catalog = Catalog::GetCatalog(client_context, Identifier(context_name));
 		if (raw_catalog.GetCatalogType() != "mssql") {
-			throw InvalidInputException("mssql_exec: Context '%s' is attached as a non-MSSQL catalog (type: %s)",
+			throw InvalidInputException("%s: Context '%s' is attached as a non-MSSQL catalog (type: %s)", function_name,
 										context_name, raw_catalog.GetCatalogType());
 		}
 		catalog_ptr = &raw_catalog.Cast<MSSQLCatalog>();
@@ -796,13 +796,13 @@ static int64_t RunExecBatch(ClientContext &client_context, const string &context
 		throw;
 	} catch (const std::exception &) {
 		throw InvalidInputException(
-			"mssql_exec: Unknown context '%s'. Attach a database first with: ATTACH '' AS %s (TYPE mssql, SECRET "
+			"%s: Unknown context '%s'. Attach a database first with: ATTACH '' AS %s (TYPE mssql, SECRET "
 			"...)",
 			context_name, context_name);
 	}
 	auto &catalog = *catalog_ptr;
 	if (catalog.IsReadOnly()) {
-		throw InvalidInputException("Cannot execute mssql_exec: catalog '%s' is attached in read-only mode",
+		throw InvalidInputException("Cannot execute %s: catalog '%s' is attached in read-only mode", function_name,
 									context_name);
 	}
 
@@ -810,7 +810,7 @@ static int64_t RunExecBatch(ClientContext &client_context, const string &context
 	auto connection = ConnectionProvider::GetConnection(client_context, catalog);
 
 	if (!connection) {
-		throw IOException("mssql_exec: Failed to acquire connection from pool for '%s'", context_name);
+		throw IOException("%s: Failed to acquire connection from pool for '%s'", function_name, context_name);
 	}
 
 	// Execute the SQL.
@@ -889,7 +889,7 @@ static void MSSQLExecExecute(DataChunk &args, ExpressionState &state, Vector &re
 
 		MSSQL_FN_DEBUG_LOG(1, "mssql_exec: context=%s, sql=%s", context_name.c_str(), sql.c_str());
 
-		return RunExecBatch(state.GetContext(), context_name, sql, sql);
+		return RunExecBatch(state.GetContext(), context_name, sql, sql, "mssql_exec");
 	});
 }
 
@@ -928,7 +928,7 @@ static void MSSQLExecParamsExecute(DataChunk &args, ExpressionState &state, Vect
 		auto params = mssql::BuildSqlParams(params_val, decl_val.IsNull() ? string() : decl_val.ToString());
 		string batch = params.ExecuteSqlBatch(statement);
 		MSSQL_FN_DEBUG_LOG(1, "mssql_exec_params: context=%s, batch=%s", context_name.c_str(), batch.c_str());
-		out[i] = RunExecBatch(client_context, context_name, batch, statement);
+		out[i] = RunExecBatch(client_context, context_name, batch, statement, "mssql_exec_params");
 	}
 }
 

--- a/src/query/mssql_sql_params.cpp
+++ b/src/query/mssql_sql_params.cpp
@@ -112,6 +112,30 @@ static std::string StringDeclaration(const LogicalType &type, const Value &value
 	return "nvarchar(4000)";
 }
 
+// decimal(38,0) is the widest exact numeric T-SQL has: +/-(10^38 - 1), i.e. at
+// most 38 decimal digits. HUGEINT reaches ~1.7e38 and UHUGEINT ~3.4e38, so both
+// can carry a 39-digit value that no SQL Server numeric can hold. Comparing the
+// rendered digits keeps this free of DuckDB's hugeint internals and is exact:
+// the literal we would emit is the same text.
+static bool ValueFitsDecimal38(const Value &value) {
+	if (value.IsNull()) {
+		return true;
+	}
+	std::string digits = value.ToString();
+	if (!digits.empty() && (digits[0] == '-' || digits[0] == '+')) {
+		digits.erase(0, 1);
+	}
+	// A hugeint renders as an integer, so anything else is not ours to judge.
+	for (size_t i = 0; i < digits.size(); i++) {
+		if (digits[i] < '0' || digits[i] > '9') {
+			return true;
+		}
+	}
+	size_t first = digits.find_first_not_of('0');
+	const size_t significant = (first == std::string::npos) ? 1 : digits.size() - first;
+	return significant <= 38;
+}
+
 std::string DeclarationForValue(const std::string &name, const LogicalType &type, const Value &value) {
 	switch (type.id()) {
 	case LogicalTypeId::SQLNULL:
@@ -134,6 +158,17 @@ std::string DeclarationForValue(const std::string &name, const LogicalType &type
 		return "decimal(20,0)";
 	case LogicalTypeId::HUGEINT:
 	case LogicalTypeId::UHUGEINT:
+		// decimal(38,0) holds +/-(10^38 - 1); HUGEINT reaches ~1.7e38 and UHUGEINT
+		// ~3.4e38, so the widest values render as literals the server cannot
+		// convert -- "Arithmetic overflow error converting numeric to data type
+		// numeric", which names neither the parameter nor the cause. Refuse here
+		// instead, the way the LIST and NULL arms already do.
+		if (!ValueFitsDecimal38(value)) {
+			throw InvalidInputException(
+				"parameter '%s' does not fit T-SQL decimal(38,0), the widest exact numeric SQL Server has; "
+				"cast it to VARCHAR and convert server-side",
+				name);
+		}
 		return "decimal(38,0)";
 	case LogicalTypeId::FLOAT:
 		return "real";
@@ -281,6 +316,21 @@ SqlParamSet BuildSqlParams(const Value &params, const std::string &declarations_
 		// DuckDB already refuses a STRUCT whose keys differ only in case, which is
 		// the one collision T-SQL would see.
 		std::string key = StringUtil::Lower(name);
+		// W5: T-SQL variable names are case-insensitive, so two struct keys that
+		// differ only in case DECLARE the same variable twice. Refuse here and
+		// name both spellings -- otherwise the batch reaches the server and comes
+		// back as "The variable name '@A' has already been declared", which does
+		// not say which struct key to change. The map was already built for this;
+		// nothing was reading it.
+		{
+			auto dup = seen.find(key);
+			if (dup != seen.end()) {
+				throw InvalidInputException(
+					"parameter names '%s' and '%s' differ only in case; T-SQL variable names are "
+					"case-insensitive, so both declare @%s",
+					dup->second, name, key);
+			}
+		}
 		seen[key] = name;
 		SqlParam p;
 		p.name = name;

--- a/src/query/mssql_sql_params.cpp
+++ b/src/query/mssql_sql_params.cpp
@@ -3,6 +3,7 @@
 #include <cctype>
 #include <map>
 
+#include "codec/integer_codec.hpp"
 #include "codec/literal_format.hpp"
 #include "codec/target_string_type.hpp"
 #include "duckdb/common/exception.hpp"
@@ -112,28 +113,17 @@ static std::string StringDeclaration(const LogicalType &type, const Value &value
 	return "nvarchar(4000)";
 }
 
-// decimal(38,0) is the widest exact numeric T-SQL has: +/-(10^38 - 1), i.e. at
-// most 38 decimal digits. HUGEINT reaches ~1.7e38 and UHUGEINT ~3.4e38, so both
-// can carry a 39-digit value that no SQL Server numeric can hold. Comparing the
-// rendered digits keeps this free of DuckDB's hugeint internals and is exact:
-// the literal we would emit is the same text.
-static bool ValueFitsDecimal38(const Value &value) {
+// Thin dispatch onto codec::integer's exported range rule -- the same one the
+// BCP encoder enforces (#177). Kept as a one-liner rather than inlined twice so
+// the HUGEINT and UHUGEINT arms cannot drift apart.
+static bool ValueFitsDecimal38(const LogicalType &type, const Value &value) {
 	if (value.IsNull()) {
 		return true;
 	}
-	std::string digits = value.ToString();
-	if (!digits.empty() && (digits[0] == '-' || digits[0] == '+')) {
-		digits.erase(0, 1);
+	if (type.id() == LogicalTypeId::UHUGEINT) {
+		return codec::integer::UhugeintFitsDecimal38(UhugeIntValue::Get(value));
 	}
-	// A hugeint renders as an integer, so anything else is not ours to judge.
-	for (size_t i = 0; i < digits.size(); i++) {
-		if (digits[i] < '0' || digits[i] > '9') {
-			return true;
-		}
-	}
-	size_t first = digits.find_first_not_of('0');
-	const size_t significant = (first == std::string::npos) ? 1 : digits.size() - first;
-	return significant <= 38;
+	return codec::integer::HugeintFitsDecimal38(HugeIntValue::Get(value));
 }
 
 std::string DeclarationForValue(const std::string &name, const LogicalType &type, const Value &value) {
@@ -158,12 +148,15 @@ std::string DeclarationForValue(const std::string &name, const LogicalType &type
 		return "decimal(20,0)";
 	case LogicalTypeId::HUGEINT:
 	case LogicalTypeId::UHUGEINT:
-		// decimal(38,0) holds +/-(10^38 - 1); HUGEINT reaches ~1.7e38 and UHUGEINT
-		// ~3.4e38, so the widest values render as literals the server cannot
-		// convert -- "Arithmetic overflow error converting numeric to data type
-		// numeric", which names neither the parameter nor the cause. Refuse here
-		// instead, the way the LIST and NULL arms already do.
-		if (!ValueFitsDecimal38(value)) {
+		// decimal(38,0) holds +/-(10^38 - 1) and HUGEINT reaches ~1.7e38, so the
+		// widest values render as literals the server cannot convert --
+		// "Arithmetic overflow error converting numeric to data type numeric",
+		// which names neither the parameter nor the cause. Same rule the BCP
+		// encoder has enforced since #177, shared from codec::integer rather than
+		// re-derived. (UHUGEINT cannot actually reach here today: FormatSqlLiteral
+		// refuses it a few lines below. Checked anyway so the two stay symmetric
+		// if that arm is ever implemented.)
+		if (!ValueFitsDecimal38(type, value)) {
 			throw InvalidInputException(
 				"parameter '%s' does not fit T-SQL decimal(38,0), the widest exact numeric SQL Server has; "
 				"cast it to VARCHAR and convert server-side",
@@ -313,23 +306,22 @@ SqlParamSet BuildSqlParams(const Value &params, const std::string &declarations_
 				"parameter name '%s' is not a T-SQL identifier (letters, digits and '_', not starting with a digit)",
 				name);
 		}
-		// DuckDB already refuses a STRUCT whose keys differ only in case, which is
-		// the one collision T-SQL would see.
+		// T-SQL variable names are case-insensitive, so two keys differing only in
+		// case DECLARE the same variable twice. A STRUCT built by the parser is
+		// already safe -- Identifier compares case-insensitively and both
+		// struct-literal sites use identifier_set_t, so {'a':1,'A':2} is refused
+		// at bind with "Duplicate struct entry name". This is the backstop for a
+		// STRUCT that did not come from there: a direct Value::STRUCT, an
+		// inferred-schema file read, another extension. Without it the batch
+		// reaches the server and returns "The variable name '@A' has already been
+		// declared", which does not say which key to change.
 		std::string key = StringUtil::Lower(name);
-		// W5: T-SQL variable names are case-insensitive, so two struct keys that
-		// differ only in case DECLARE the same variable twice. Refuse here and
-		// name both spellings -- otherwise the batch reaches the server and comes
-		// back as "The variable name '@A' has already been declared", which does
-		// not say which struct key to change. The map was already built for this;
-		// nothing was reading it.
-		{
-			auto dup = seen.find(key);
-			if (dup != seen.end()) {
-				throw InvalidInputException(
-					"parameter names '%s' and '%s' differ only in case; T-SQL variable names are "
-					"case-insensitive, so both declare @%s",
-					dup->second, name, key);
-			}
+		auto dup = seen.find(key);
+		if (dup != seen.end()) {
+			throw InvalidInputException(
+				"parameter names '%s' and '%s' differ only in case; T-SQL variable names are "
+				"case-insensitive, so both declare @%s",
+				dup->second, name, key);
 		}
 		seen[key] = name;
 		SqlParam p;
@@ -339,6 +331,17 @@ SqlParamSet BuildSqlParams(const Value &params, const std::string &declarations_
 			if (it == declared.end()) {
 				throw InvalidInputException("parameter '%s' has a value but no declaration in '%s'", name,
 											declarations_override);
+			}
+			// Naming the type does not make the value fit it: a 39-digit HUGEINT
+			// under an explicit `@p decimal(38,0)` used to skip the check below
+			// and come back as the server's bare "Arithmetic overflow", which is
+			// the error this guard exists to replace.
+			if ((type.id() == LogicalTypeId::HUGEINT || type.id() == LogicalTypeId::UHUGEINT) &&
+				!ValueFitsDecimal38(type, value)) {
+				throw InvalidInputException(
+					"parameter '%s' does not fit T-SQL decimal(38,0), the widest exact numeric SQL Server has; "
+					"cast it to VARCHAR and convert server-side",
+					name);
 			}
 			p.declaration = it->second;
 		} else {

--- a/test/cpp/test_sql_params.cpp
+++ b/test/cpp/test_sql_params.cpp
@@ -28,9 +28,12 @@
 #include <iostream>
 #include <string>
 
+using duckdb::Hugeint;
+using duckdb::hugeint_t;
 using duckdb::Identifier;
 using duckdb::InvalidInputException;
 using duckdb::LogicalType;
+using duckdb::NumericLimits;
 using duckdb::Value;
 using duckdb::mssql::BuildExecuteSqlBatch;
 using duckdb::mssql::BuildSqlParams;

--- a/test/cpp/test_sql_params.cpp
+++ b/test/cpp/test_sql_params.cpp
@@ -19,7 +19,9 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/identifier.hpp"
+#include "duckdb/common/limits.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "query/mssql_sql_params.hpp"
 
@@ -105,6 +107,21 @@ void TestDeclarationForValue() {
 	CHECK_EQ(DeclarationForValue("p", LogicalType::BIGINT, Value::BIGINT(1)), std::string("bigint"));
 	CHECK_EQ(DeclarationForValue("p", LogicalType::UBIGINT, Value::UBIGINT(1)), std::string("decimal(20,0)"));
 	CHECK_EQ(DeclarationForValue("p", LogicalType::HUGEINT, Value::HUGEINT(1)), std::string("decimal(38,0)"));
+	// decimal(38,0) holds +/-(10^38 - 1). 38 nines is the widest that fits; the
+	// 39-digit neighbours must be refused CLIENT-side, or the server answers with
+	// a bare "Arithmetic overflow" naming neither the parameter nor the cause.
+	// HUGEINT min is the case an abs-then-compare would miss (#177).
+	{
+		const hugeint_t max38 = Hugeint::POWERS_OF_TEN[38] - 1;
+		CHECK_EQ(DeclarationForValue("p", LogicalType::HUGEINT, Value::HUGEINT(max38)), std::string("decimal(38,0)"));
+		CHECK_EQ(DeclarationForValue("p", LogicalType::HUGEINT, Value::HUGEINT(Hugeint::Negate(max38))),
+				 std::string("decimal(38,0)"));
+		CHECK_THROWS_WITH(DeclarationForValue("p", LogicalType::HUGEINT, Value::HUGEINT(Hugeint::POWERS_OF_TEN[38])),
+						  "does not fit T-SQL decimal(38,0)");
+		CHECK_THROWS_WITH(
+			DeclarationForValue("p", LogicalType::HUGEINT, Value::HUGEINT(NumericLimits<hugeint_t>::Minimum())),
+			"does not fit T-SQL decimal(38,0)");
+	}
 	CHECK_EQ(DeclarationForValue("p", LogicalType::FLOAT, Value::FLOAT(1.5f)), std::string("real"));
 	CHECK_EQ(DeclarationForValue("p", LogicalType::DOUBLE, Value::DOUBLE(1.5)), std::string("float"));
 	CHECK_EQ(DeclarationForValue("p", LogicalType::DECIMAL(10, 2), Value::DECIMAL(int64_t(1234), 10, 2)),
@@ -187,6 +204,22 @@ void TestBuildSqlParamsOverride() {
 					  "names '@p' twice");
 }
 
+void TestBuildSqlParamsCaseCollision() {
+	// Value::STRUCT bypasses struct_pack's identifier_set_t dedupe, so this is the
+	// one construction where two keys differing only in case actually reach
+	// BuildSqlParams. Both DECLARE @a, which the server reports as "The variable
+	// name '@A' has already been declared" -- an error that does not say which key
+	// to change.
+	CHECK_THROWS_WITH(
+		BuildSqlParams(Struct({{Identifier("a"), Value::INTEGER(1)}, {Identifier("A"), Value::INTEGER(2)}}), ""),
+		"differ only in case");
+	// Naming the type does not make the value fit it: the declarations override
+	// used to skip the range check entirely.
+	CHECK_THROWS_WITH(
+		BuildSqlParams(Struct({{Identifier("p"), Value::HUGEINT(Hugeint::POWERS_OF_TEN[38])}}), "@p decimal(38,0)"),
+		"does not fit T-SQL decimal(38,0)");
+}
+
 void TestBuildSqlParamsRefusals() {
 	CHECK_THROWS_WITH(BuildSqlParams(Value::INTEGER(5), ""), "parameters must be a STRUCT of name -> value");
 	CHECK_THROWS_WITH(BuildSqlParams(Struct({{Identifier("my p"), Value::INTEGER(1)}}), ""),
@@ -205,6 +238,7 @@ int main() {
 	TestBuildSqlParamsDerived();
 	TestBuildSqlParamsOverride();
 	TestBuildSqlParamsRefusals();
+	TestBuildSqlParamsCaseCollision();
 	if (failures) {
 		std::cerr << failures << " failure(s)\n";
 		return 1;

--- a/test/sql/query/mssql_exec_unknown_context.test
+++ b/test/sql/query/mssql_exec_unknown_context.test
@@ -1,0 +1,34 @@
+# name: test/sql/query/mssql_exec_unknown_context.test
+# description: mssql_exec / mssql_exec_params name themselves when the context is unknown
+# group: [query]
+#
+# The bind-time check in BindExecContextName only runs `if (argument.IsFoldable())`,
+# so a CONSTANT context never reaches RunExecBatch -- it is answered by the
+# BinderException instead. Every existing test used a constant, which is why a
+# missing format argument in RunExecBatch's own copy of that message went
+# unnoticed: three %s, two args, so the user got an InternalException with a
+# "please file a bug report" banner instead of the guidance, from nothing worse
+# than a typo'd catalog name.
+#
+# A column reference is not foldable, so these reach the runtime path.
+
+require mssql
+
+# Constant context: answered at bind time.
+statement error
+SELECT mssql_exec('no_such_ctx_bind', 'SELECT 1');
+----
+mssql_exec: Unknown context 'no_such_ctx_bind'
+
+# Non-foldable context: reaches RunExecBatch. Must name mssql_exec, and must not
+# be an INTERNAL error.
+statement error
+SELECT mssql_exec(c, 'SELECT 1') FROM (VALUES ('no_such_ctx_run')) t(c);
+----
+mssql_exec: Unknown context 'no_such_ctx_run'
+
+# Same path, reported under its own name rather than mssql_exec's.
+statement error
+SELECT mssql_exec_params(c, 'SELECT 1', {'a': 1}) FROM (VALUES ('no_such_ctx_run')) t(c);
+----
+mssql_exec_params: Unknown context 'no_such_ctx_run'


### PR DESCRIPTION
Stacked on `spec/075-read-path-pinned-connection`. Addresses the three findings from roborev 1543 that are a line each; the structural ones are left to you, with evidence, below.

### `mssql_exec_params` reported failures under the wrong function name

`RunExecBatch` hard-coded `"mssql_exec:"` in all four of its messages — including the read-only refusal and the unknown-context help, which are the two a caller is most likely to hit. `BindExecContextName` was parameterized with `function_name` for exactly this reason; `RunExecBatch` was not. It now takes one too.

```
SELECT mssql_exec_params('nope', 'SELECT 1', {'a': 1})
  before: mssql_exec: Unknown context 'nope'...
  after:  mssql_exec_params: Unknown context 'nope'...
```

### W5's duplicate-parameter refusal was never implemented

The `seen` map is built, commented as the thing that catches two keys differing only in case, and then read by nothing on that path. T-SQL variable names are case-insensitive, so `{'a': 1, 'A': 2}` declared `@a` twice and the server answered `The variable name '@A' has already been declared` — which does not say which struct key to change. Refused client-side now, naming both spellings.

### `HUGEINT` / `UHUGEINT` were declared `decimal(38,0)`, which is narrower

`decimal(38,0)` holds ±(10^38 − 1). `HUGEINT` reaches ~1.7e38 and `UHUGEINT` ~3.4e38, so the widest values became literals the server rejects with an arithmetic overflow naming neither the parameter nor the cause. Range-checked on the rendered digits — exact, since that text is the literal we emit — and refused by name, as the `LIST` and `NULL` arms already do.

---

## Not fixed here — the High, with the decisive evidence

**`copy_function.cpp:328-338`. The `materialize_lock` gives mutual exclusion, not ordering, and this is not a maybe.**

DuckDB's `Pipeline::Reset()` calls `ResetSink()` (line 221) and only then `ResetSource(false)` (line 229). So `BCPCopyInitGlobal` **always** runs first. And it does not merely find the connection Idle: while holding the lock it runs `INSERT BULK` (`:517`) and transitions `Idle → Executing` (`:523`), then writes COLMETADATA (`:556`). The flagged source scan's `InitGlobal` then acquires the freed mutex and hits the exact failure W3 exists to remove:

```
Cannot execute: connection not in Idle state (current: Executing)
```

Only source-first works, and nothing enforces it — so `test/sql/transaction/sink_reads_own_catalog.test`'s COPY half passes or fails on init-order luck.

Repro: `BEGIN; COPY (SELECT id, v FROM sk75.dbo.sk75_src) TO 'mssql://sk75/dbo/sk75_copy' (FORMAT 'bcp');`

The fix is structural — defer `INSERT BULK` + `WriteColmetadata()` out of `BCPCopyInitGlobal` to the first `BCPCopySink()` call, so the connection is genuinely Idle when the source initializes — and it touches the parallel-writer path, which is yours to make rather than mine to guess at.

**Two Mediums also left to you**, both needing a call on intended behaviour: the describe-vs-execute type divergence (`sp_describe_first_result_set` reports `rowversion` as `timestamp` → `MapSQLServerTypeToDuckDB`'s VARCHAR catch-all, while the wire type is `BIGVARBINARY` → BLOB, so the new strict shape check turns a working scan into a hard error); and `MSSQLPreparedSession` being shared by `Copy()` while owning one connection with one `sp_prepare` handle.

---

`src/query/mssql_sql_params.cpp` and `src/mssql_functions.cpp` pass `clang-format-14 --dry-run -Werror`. Not built or tested locally — the `duckdb` submodule is not checked out in the authoring worktree.

https://claude.ai/code/session_01LEhCzhCpVAzBv4AW4bfXwP
